### PR TITLE
fix: don't render chart without width or height

### DIFF
--- a/libs/client/shared/src/components/charts/time-series/Chart.tsx
+++ b/libs/client/shared/src/components/charts/time-series/Chart.tsx
@@ -49,6 +49,7 @@ export function Chart<TDatum extends Datum>({
         // Prevent chart errors from crashing entire UI
         <ParentSize>
             {({ width, height }) => {
+                if (!width || !height || width <= 0 || height <= 0) return null
                 return (
                     // Set to relative for error boundary overlay
                     <div className="relative w-full h-full">


### PR DESCRIPTION
This fixes a small error on the client that shows when initial page loads and width/height are set to `0`.

Error: `Error: <stop> attribute offset: Expected number or percentage, "-Infinity".`

### Error
![Screenshot 2024-01-14 130854](https://github.com/maybe-finance/maybe/assets/12456288/c4f0ccf4-fcf7-4392-82ce-9d7fcbcfd092)

### After Fix
![Screenshot 2024-01-14 130939](https://github.com/maybe-finance/maybe/assets/12456288/dee59b0a-2cfd-443f-b652-2b13d10bd567)
