### PR TITLE
fix: remove z-index on DevTools to prevent overlap

### DIFF
--- a/libs/client/features/src/accounts-list/AccountDevTools.tsx
+++ b/libs/client/features/src/accounts-list/AccountDevTools.tsx
@@ -17,7 +17,7 @@ export function AccountDevTools() {
     const deduplicateInstitutions = useDeduplicateInstitutions()
 
     return process.env.NODE_ENV === 'development' ? (
-        <div className="relative mb-12 mx-2 sm:mx-0 p-4 bg-gray-700 rounded-md z-50">
+        <div className="relative mb-12 mx-2 sm:mx-0 p-4 bg-gray-700 rounded-md">
             <h6 className="flex text-red">
                 Dev Tools <i className="ri-tools-fill ml-1.5" />
             </h6>


### PR DESCRIPTION
The z-index on "Dev Tools" card inside `/accounts` was overlapping the **"Edit Account"** modal when open.

To fix this, I simply removed the **z-50** styling on the Dev Tools component. Not sure if this was needed for any other scenario?

### Overlap Issue
![Screenshot 2024-01-14 132246](https://github.com/maybe-finance/maybe/assets/12456288/e1a1b057-0995-4216-a046-526c6c81e58b)

### After Fix
![Screenshot 2024-01-14 132330](https://github.com/maybe-finance/maybe/assets/12456288/803d5c49-a720-454f-8273-3538cbd1751f)

