### PR TITLE
Fix assets and debts 'other' expanding in tandem

### DIFF
--- a/libs/client/features/src/account/AccountsSidebar.tsx
+++ b/libs/client/features/src/account/AccountsSidebar.tsx
@@ -187,7 +187,9 @@ export default function AccountsSidebar() {
                                 label={title}
                                 balances={balances.data}
                                 inverted={classification === 'liability'}
-                                onToggle={(isExpanded) => updateToggleState(title, isExpanded)}
+                                onToggle={(isExpanded) =>
+                                    updateToggleState(`${title}-${classification}`, isExpanded)
+                                }
                                 expanded={toggleState[title] !== false}
                                 level={1}
                                 syncing={items.some((a) => a.syncing)}


### PR DESCRIPTION
/fix #75 

This PR fixes the `Other` category expanding for both Assets and Debts simultaneously.

https://github.com/maybe-finance/maybe/assets/42482170/77346a01-173d-441d-a9ad-35e84d2f9acc

