### PR TITLE
Set package manager to yarn 1.22.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ exceptions.log
 error.log
 combined.log
 /tools/output
+.yarn
 
 # System Files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -258,5 +258,6 @@
             "yarn nx format:write --uncommitted",
             "yarn eslint --fix"
         ]
-    }
+    },
+    "packageManager": "yarn@1.22.21"
 }


### PR DESCRIPTION
See #87 for context. I had some issues with `yarn install` on Yarn Berry adding extra files due to its different behavior compared to Yarn 1.x, so this PR should pin Yarn's version to 1.x until the repo is migrated to use the latest yarn version.