### PR TITLE
Fix #92: Noop postmark sends if API key is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ Then run the following yarn commands:
 
 ```
 yarn install
-yarn run dev:services
+yarn run dev:services:all
 yarn prisma:migrate:dev
 yarn prisma:seed
 yarn dev
 ```
 
 ## Contributing
+
 To contribute, please see our [contribution guide](https://github.com/maybe-finance/maybe/blob/main/CONTRIBUTING.md).
 
 ## High-priority issues
@@ -91,9 +92,9 @@ To pull market data in (for investments), you'll need a Polygon.io API key. You 
 -   [Handling money](https://github.com/maybe-finance/maybe/wiki/Handling-Money)
 -   [REST API](https://github.com/maybe-finance/maybe/wiki/REST-API)
 
-
 ## Repo Activity
-![Repo Activity](https://repobeats.axiom.co/api/embed/7866c9790deba0baf63ca1688b209130b306ea4e.svg "Repobeats analytics image")
+
+![Repo Activity](https://repobeats.axiom.co/api/embed/7866c9790deba0baf63ca1688b209130b306ea4e.svg 'Repobeats analytics image')
 
 ## Credits
 

--- a/apps/server/src/app/lib/postmark.ts
+++ b/apps/server/src/app/lib/postmark.ts
@@ -1,6 +1,6 @@
 import { ServerClient } from 'postmark'
 import env from '../../env'
 
-const postmark = new ServerClient(env.NX_POSTMARK_API_TOKEN)
+const postmark = env.NX_POSTMARK_API_TOKEN ? new ServerClient(env.NX_POSTMARK_API_TOKEN) : undefined
 
 export default postmark

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -74,7 +74,7 @@ const envSchema = z.object({
 
     NX_POSTMARK_FROM_ADDRESS: z.string().default('account@maybe.co'),
     NX_POSTMARK_REPLY_TO_ADDRESS: z.string().default('support@maybe.co'),
-    NX_POSTMARK_API_TOKEN: z.string().default('REPLACE_THIS'),
+    NX_POSTMARK_API_TOKEN: z.string().optional(),
 })
 
 const env = envSchema.parse(process.env)

--- a/apps/workers/src/app/lib/postmark.ts
+++ b/apps/workers/src/app/lib/postmark.ts
@@ -1,6 +1,6 @@
 import { ServerClient } from 'postmark'
 import env from '../../env'
 
-const postmark = new ServerClient(env.NX_POSTMARK_API_TOKEN)
+const postmark = env.NX_POSTMARK_API_TOKEN ? new ServerClient(env.NX_POSTMARK_API_TOKEN) : undefined
 
 export default postmark

--- a/apps/workers/src/env.ts
+++ b/apps/workers/src/env.ts
@@ -29,7 +29,7 @@ const envSchema = z.object({
 
     NX_POSTMARK_FROM_ADDRESS: z.string().default('account@maybe.co'),
     NX_POSTMARK_REPLY_TO_ADDRESS: z.string().default('support@maybe.co'),
-    NX_POSTMARK_API_TOKEN: z.string().default('REPLACE_THIS'),
+    NX_POSTMARK_API_TOKEN: z.string().optional(),
     NX_STRIPE_SECRET_KEY: z.string().default('sk_test_REPLACE_THIS'),
 
     NX_CDN_PRIVATE_BUCKET: z.string().default('REPLACE_THIS'),

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "dev": "nx run-many --target serve --projects=client,server,workers --parallel --host 0.0.0.0 --nx-bail=true --maxParallel=100",
         "dev:services": "COMPOSE_PROFILES=services docker-compose up -d",
-        "dev:services:all": "COMPOSE_PROFILES=services,ngrok docker-compose up",
+        "dev:services:all": "COMPOSE_PROFILES=services,ngrok docker-compose up -d",
         "dev:workers:test": "nx test workers --skip-nx-cache --runInBand",
         "dev:server:test": "nx test server --skip-nx-cache --runInBand",
         "dev:test:unit": "yarn dev:ci:test --testPathPattern='^(?!.*integration).*$' --verbose --skip-nx-cache",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "scripts": {
         "dev": "nx run-many --target serve --projects=client,server,workers --parallel --host 0.0.0.0 --nx-bail=true --maxParallel=100",
         "dev:services": "COMPOSE_PROFILES=services docker-compose up -d",
-        "dev:services:all": "COMPOSE_PROFILES=services,ngrok,stripe docker-compose up",
+        "dev:services:all": "COMPOSE_PROFILES=services,ngrok docker-compose up",
         "dev:workers:test": "nx test workers --skip-nx-cache --runInBand",
         "dev:server:test": "nx test server --skip-nx-cache --runInBand",
         "dev:test:unit": "yarn dev:ci:test --testPathPattern='^(?!.*integration).*$' --verbose --skip-nx-cache",


### PR DESCRIPTION
Addresses #92 and updates yarn run dev:services:all to get rid of stripe for now and update README to use that command so that ngrok is started at the same time as postgres and redis