### PR TITLE
Fix #95: Override default MIN_SUPPORTED_DATE on birthday date picker

### DIFF
--- a/libs/client/features/src/onboarding/steps/Profile.tsx
+++ b/libs/client/features/src/onboarding/steps/Profile.tsx
@@ -144,6 +144,7 @@ function ProfileForm({ title, onSubmit, defaultValues }: ProfileViewProps) {
                             <DatePicker
                                 popperPlacement="bottom"
                                 className="mt-2"
+                                minCalendarDate={DateTime.now().minus({ years: 100 }).toISODate()}
                                 error={error?.message}
                                 {...field}
                             />


### PR DESCRIPTION
Addresses #95 

There's a default MIN_SUPPORTED_DATE in date utils to limit transaction history to last 30 years, this overrides this for the birthday picker and makes it 100 years which matches the existing validation.

Fixed:
![CleanShot 2024-01-15 at 19 10 26](https://github.com/maybe-finance/maybe/assets/1218724/8bf05e26-91db-4ac7-b178-d6d04a69e593)
