### PR TITLE
fix repeated data-testid

### DIFF
--- a/libs/design-system/src/lib/DatePicker/DatePickerCalendar.tsx
+++ b/libs/design-system/src/lib/DatePicker/DatePickerCalendar.tsx
@@ -73,7 +73,7 @@ export function DatePickerCalendar({
                         </button>
                         <button
                             className="text-white hover:bg-gray-500 flex grow justify-center items-center rounded"
-                            data-testid="datepicker-range-month-button"
+                            data-testid="datepicker-range-year-button"
                             onClick={() => setView('year')}
                         >
                             {calendars[0].year}

--- a/libs/design-system/src/lib/DatePicker/DatePickerRange/DatePickerRangeCalendar.tsx
+++ b/libs/design-system/src/lib/DatePicker/DatePickerRange/DatePickerRangeCalendar.tsx
@@ -103,7 +103,7 @@ export function DatePickerRangeCalendar({
                         </button>
                         <button
                             className="text-white hover:bg-gray-500 flex grow justify-center items-center rounded"
-                            data-testid="datepicker-range-month-button"
+                            data-testid="datepicker-range-year-button"
                             onClick={() => setView('year')}
                         >
                             {calendars[0].year}


### PR DESCRIPTION
It seems that the `data-testid` for the year selector was incorrectly copied from the month selector.

This fixes that.