### PR TITLE
fix date-picker tests

### DIFF
--- a/libs/design-system/src/lib/DatePicker/DatePicker.spec.tsx
+++ b/libs/design-system/src/lib/DatePicker/DatePicker.spec.tsx
@@ -3,9 +3,6 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { DatePicker } from './'
 import { DateTime } from 'luxon'
 
-// Set date to Oct 29, 2021 to keep snapshots consistent
-beforeAll(() => jest.useFakeTimers().setSystemTime(new Date('2021-10-29 12:00:00')))
-
 // DatePicker configuration
 const minDate = DateTime.now().minus({ years: 2 })
 const maxDate = DateTime.now()
@@ -73,6 +70,8 @@ describe('<DatePicker />', () => {
 
             const currentMonth = DateTime.now()
             const priorMonth = DateTime.now().minus({ months: 1 })
+
+            console.log(DateTime.now(), 'date')
 
             // Open the modal
             fireEvent.click(screen.getByTestId('datepicker-toggle-icon'))

--- a/libs/design-system/src/lib/DatePicker/DatePicker.spec.tsx
+++ b/libs/design-system/src/lib/DatePicker/DatePicker.spec.tsx
@@ -71,8 +71,6 @@ describe('<DatePicker />', () => {
             const currentMonth = DateTime.now()
             const priorMonth = DateTime.now().minus({ months: 1 })
 
-            console.log(DateTime.now(), 'date')
-
             // Open the modal
             fireEvent.click(screen.getByTestId('datepicker-toggle-icon'))
 


### PR DESCRIPTION
This PR resolves issue #126.

This fix removes the fixed date-time set by `beforeAll(() => jest.useFakeTimers().setSystemTime(new Date('2021-10-29 12:00:00')))`  and uses the current system time