### PR TITLE
Fix: Teller not syncing with live data

### DIFF
--- a/apps/workers/src/main.ts
+++ b/apps/workers/src/main.ts
@@ -140,7 +140,7 @@ syncInstitutionQueue.add(
     'sync-teller-institutions',
     {},
     {
-        repeat: { cron: '0 0 */1 * *' }, // Run every 24 hours
+        repeat: { cron: '0 */24 * * *' }, // Run every 24 hours
     }
 )
 

--- a/libs/server/shared/src/utils/teller-utils.ts
+++ b/libs/server/shared/src/utils/teller-utils.ts
@@ -11,7 +11,7 @@ import { Duration } from 'luxon'
 /**
  * Update this with the max window that Teller supports
  */
-export const TELLER_WINDOW_MAX = Duration.fromObject({ years: 1 })
+export const TELLER_WINDOW_MAX = Duration.fromObject({ years: 2 })
 
 export function getAccountBalanceData(
     { balance, currency }: Pick<TellerTypes.AccountWithBalances, 'balance' | 'currency'>,
@@ -24,14 +24,11 @@ export function getAccountBalanceData(
     | 'availableBalanceStrategy'
     | 'currencyCode'
 > {
-    const sign = classification === 'liability' ? -1 : 1
     return {
-        currentBalanceProvider: new Prisma.Decimal(
-            balance.ledger ? sign * Number(balance.ledger) : 0
-        ),
+        currentBalanceProvider: new Prisma.Decimal(balance.ledger ? Number(balance.ledger) : 0),
         currentBalanceStrategy: 'current',
         availableBalanceProvider: new Prisma.Decimal(
-            balance.available ? sign * Number(balance.available) : 0
+            balance.available ? Number(balance.available) : 0
         ),
         availableBalanceStrategy: 'available',
         currencyCode: currency,

--- a/libs/teller-api/src/types/transactions.ts
+++ b/libs/teller-api/src/types/transactions.ts
@@ -38,7 +38,7 @@ export type Transaction = {
     details: {
         category?: DetailCategory
         processing_status: DetailProcessingStatus
-        counterparty: {
+        counterparty?: {
             name?: string
             type?: 'organization' | 'person'
         }


### PR DESCRIPTION
It was failing because sometimes the countryparty object isn't present in the payload. This also removes the unnecessary pagination wrap in the _extractTransactions, fixes the signs for transaction amount and balance to match Teller convention, and expands max transaction window to match Plaids.