### PR TITLE
Remove billing & upgrade references when STRIPE_API_KEY is missing

### DIFF
--- a/apps/client/pages/settings.tsx
+++ b/apps/client/pages/settings.tsx
@@ -35,7 +35,7 @@ export default function SettingsPage() {
                     <Tab.List>
                         <Tab>Details</Tab>
                         <Tab>Security</Tab>
-                        <Tab>Billing</Tab>
+                        {process.env.STRIPE_API_KEY && <Tab>Billing</Tab>}
                     </Tab.List>
                     <Tab.Panels>
                         <Tab.Panel>
@@ -46,9 +46,11 @@ export default function SettingsPage() {
                                 <SecurityPreferences />
                             </div>
                         </Tab.Panel>
-                        <Tab.Panel>
-                            <BillingPreferences />
-                        </Tab.Panel>
+                        {process.env.STRIPE_API_KEY && (
+                            <Tab.Panel>
+                                <BillingPreferences />
+                            </Tab.Panel>
+                        )}
                     </Tab.Panels>
                 </Tab.Group>
             </section>

--- a/apps/workers/src/env.ts
+++ b/apps/workers/src/env.ts
@@ -33,6 +33,8 @@ const envSchema = z.object({
 
     NX_CDN_PRIVATE_BUCKET: z.string().default('REPLACE_THIS'),
     NX_CDN_PUBLIC_BUCKET: z.string().default('REPLACE_THIS'),
+
+    STRIPE_API_KEY: z.string().optional(),
 })
 
 const env = envSchema.parse(process.env)

--- a/apps/workers/src/main.ts
+++ b/apps/workers/src/main.ts
@@ -154,11 +154,13 @@ syncInstitutionQueue.add(
  */
 sendEmailQueue.process('send-email', async (job) => await emailProcessor.send(job.data))
 
-sendEmailQueue.add(
-    'send-email',
-    { type: 'trial-reminders' },
-    { repeat: { cron: '0 */12 * * *' } } // Run every 12 hours
-)
+if (env.STRIPE_API_KEY) {
+    sendEmailQueue.add(
+        'send-email',
+        { type: 'trial-reminders' },
+        { repeat: { cron: '0 */12 * * *' } } // Run every 12 hours
+    )
+}
 
 // Fallback - usually triggered by errors not handled (or thrown) within the Bull event handlers (see above)
 process.on(

--- a/libs/client/features/src/layout/DesktopLayout.tsx
+++ b/libs/client/features/src/layout/DesktopLayout.tsx
@@ -313,7 +313,6 @@ function DefaultContent({
     email,
 }: PropsWithChildren<{ onboarding?: ReactNode; name?: string; email?: string }>) {
     const { addAccount } = useAccountContext()
-
     return (
         <>
             <div className="flex items-center justify-between mb-4">
@@ -338,7 +337,7 @@ function DefaultContent({
 
             {onboarding && onboarding}
 
-            <UpgradePrompt />
+            {process.env.STRIPE_API_KEY && <UpgradePrompt />}
 
             <div className="flex items-center justify-between">
                 <div className="text-base">

--- a/libs/client/features/src/layout/MobileLayout.tsx
+++ b/libs/client/features/src/layout/MobileLayout.tsx
@@ -174,7 +174,7 @@ export function MobileLayout({ children, sidebar }: MobileLayoutProps) {
                         </section>
 
                         <div className="pt-6 shrink-0">
-                            <UpgradePrompt />
+                            {process.env.STRIPE_API_KEY && <UpgradePrompt />}
                         </div>
                     </div>
                 </div>

--- a/libs/client/features/src/user-billing/BillingPreferences.tsx
+++ b/libs/client/features/src/user-billing/BillingPreferences.tsx
@@ -78,7 +78,9 @@ export function BillingPreferences() {
                     </div>
                 )}
             </div>
-            <UpgradeTakeover open={takeoverOpen} onClose={() => setTakeoverOpen(false)} />
+            {process.env.STRIPE_API_KEY && (
+                <UpgradeTakeover open={takeoverOpen} onClose={() => setTakeoverOpen(false)} />
+            )}
         </>
     )
 }


### PR DESCRIPTION
This PR takes a stab at removing upgrade and billing references when STRIPE_API_KEY is not set in the `.env` file. #151 

I'm unsure if there are other places that reference billing and upgrade, but I would be happy to update those as well. Just spun up this repo this morning, so I'm unsure if there are other places these are mentioned.

