### PR TITLE
Logout Placement

### DIFF
--- a/libs/client/features/src/layout/DesktopLayout.tsx
+++ b/libs/client/features/src/layout/DesktopLayout.tsx
@@ -16,7 +16,6 @@ import {
     RiFolderOpenLine,
     RiMenuFoldLine,
     RiMenuUnfoldLine,
-    RiMore2Fill,
     RiPieChart2Line,
     RiFlagLine,
     RiArrowRightSLine,
@@ -191,7 +190,11 @@ export function DesktopLayout({ children, sidebar }: DesktopLayoutProps) {
                         </div>
                     </Tooltip>
 
-                    <ProfileCircle />
+                    <MenuPopover
+                        isHeader={false}
+                        icon={<ProfileCircle />}
+                        buttonClassName="w-12 h-12 rounded-full"
+                    />
                 </div>
             </nav>
 
@@ -342,7 +345,6 @@ function DefaultContent({
                     <p data-testid="user-name">{name ?? ''}</p>
                     <p className="text-gray-100">{email ?? ''}</p>
                 </div>
-                <MenuPopover isHeader={false} icon={<RiMore2Fill />} />
             </div>
         </>
     )

--- a/libs/client/features/src/layout/MenuPopover.tsx
+++ b/libs/client/features/src/layout/MenuPopover.tsx
@@ -6,19 +6,24 @@ import {
     RiShutDownLine as LogoutIcon,
     RiDatabase2Line,
 } from 'react-icons/ri'
+import classNames from 'classnames'
 
 export function MenuPopover({
     icon,
+    buttonClassName,
     placement = 'top-end',
     isHeader,
 }: {
     icon: JSX.Element
+    buttonClassName?: string
     placement?: ComponentProps<typeof Menu.Item>['placement']
     isHeader: boolean
 }) {
     return (
         <Menu>
-            <Menu.Button variant="icon">{icon}</Menu.Button>
+            <Menu.Button variant="icon" className={classNames(buttonClassName)}>
+                {icon}
+            </Menu.Button>
             <Menu.Items
                 placement={placement}
                 className={isHeader ? 'bg-gray-600' : 'min-w-[200px]'}


### PR DESCRIPTION
Issue: https://github.com/maybe-finance/maybe/issues/162

Made the following changes in desktop mode:

- Removed the `<ProfileCircle/>`'s link to `/settings`
- Moved the `<MenuPopover/>` into the `<ProfileCircle/>`
- Added `buttonClassName` to `<MenuPopover/>` so we can customise the styling of `<Menu.Button/>`

Now when you press the profile icon, instead of going directly to settings, the menu popover appears and you can choose to go to settings, fix data or logout.

Before:

![image](https://github.com/maybe-finance/maybe/assets/72618814/099784c5-18a6-4106-9da1-c80d8cd44e56)


After:

![image](https://github.com/maybe-finance/maybe/assets/72618814/cb7f8e67-e6c6-4ca9-9ef6-8a091b076a7c)

Feedback is appreciated.

