### PR TITLE
Add back json handling to express

### DIFF
--- a/apps/server/src/app/app.ts
+++ b/apps/server/src/app/app.ts
@@ -109,6 +109,7 @@ app.use(
 app.use('/v1/stripe', express.raw({ type: 'application/json' }))
 
 app.use(express.urlencoded({ extended: true }))
+app.use(express.json())
 
 // =========================================
 //                 API ⬇️


### PR DESCRIPTION
Looks like this was accidentally removed which breaks all the API requests
Solves issue #176 