### PR TITLE
Update Profile icon on the sidebar and positioning of menu popover

### DIFF
--- a/libs/client/features/src/layout/DesktopLayout.tsx
+++ b/libs/client/features/src/layout/DesktopLayout.tsx
@@ -193,7 +193,7 @@ export function DesktopLayout({ children, sidebar }: DesktopLayoutProps) {
                     <MenuPopover
                         isHeader={false}
                         icon={<ProfileCircle />}
-                        buttonClassName="w-12 h-12 rounded-full"
+                        placement={'right-end'}
                     />
                 </div>
             </nav>

--- a/libs/client/features/src/layout/MenuPopover.tsx
+++ b/libs/client/features/src/layout/MenuPopover.tsx
@@ -6,24 +6,19 @@ import {
     RiShutDownLine as LogoutIcon,
     RiDatabase2Line,
 } from 'react-icons/ri'
-import classNames from 'classnames'
 
 export function MenuPopover({
     icon,
-    buttonClassName,
     placement = 'top-end',
     isHeader,
 }: {
     icon: JSX.Element
-    buttonClassName?: string
     placement?: ComponentProps<typeof Menu.Item>['placement']
     isHeader: boolean
 }) {
     return (
         <Menu>
-            <Menu.Button variant="icon" className={classNames(buttonClassName)}>
-                {icon}
-            </Menu.Button>
+            <Menu.Button variant="profileIcon">{icon}</Menu.Button>
             <Menu.Items
                 placement={placement}
                 className={isHeader ? 'bg-gray-600' : 'min-w-[200px]'}

--- a/libs/design-system/src/lib/Button/Button.tsx
+++ b/libs/design-system/src/lib/Button/Button.tsx
@@ -10,6 +10,7 @@ const ButtonVariants = Object.freeze({
     input: 'px-4 py-2 rounded text-base bg-transparent text-gray-25 border border-gray-200 shadow focus:bg-gray-500 focus:ring-gray-400',
     link: 'px-4 py-2 rounded text-base text-cyan hover:text-cyan-400 focus:text-cyan-300 focus:ring-cyan',
     icon: 'p-0 w-8 h-8 rounded text-2xl text-gray-25 hover:bg-gray-300 focus:bg-gray-200 focus:ring-gray-400',
+    profileIcon: 'p-0 w-12 h-12 rounded text-2xl text-gray-25',
     danger: 'px-4 py-2 rounded text-base bg-red text-gray-700 shadow hover:bg-red-400 focus:bg-red-400 focus:ring-red',
     warn: 'px-4 py-2 rounded text-base bg-gray-500 text-red-500 shadow hover:bg-gray-400 focus:bg-gray-400 focus:ring-red',
 })


### PR DESCRIPTION
This PR solves #179 and improves on #167 

Changes:

- Added a new variant of `Button` in the design system called `profileIcon` for profile icons which solves the skewed profile circle

<img width="74" alt="Screenshot 2024-01-20 at 6 59 05 PM" src="https://github.com/maybe-finance/maybe/assets/9695866/134f33b8-f6bb-4ffb-b1ab-8054d21f05fd">
<img width="82" alt="Screenshot 2024-01-20 at 7 00 32 PM" src="https://github.com/maybe-finance/maybe/assets/9695866/1ffd06b2-9d5f-4018-a882-cf321eabe221">


- Menu popover position is changed to `right-end` which should be visible now
<img width="291" alt="Screenshot 2024-01-20 at 7 00 59 PM" src="https://github.com/maybe-finance/maybe/assets/9695866/6cc75f8c-b9a9-44d2-9c8d-417f1589bc73">
