### PR TITLE
Remove dead Maybe.co links from sidebar resources

### DIFF
--- a/libs/client/features/src/insights/explainers/investments/AverageReturn.tsx
+++ b/libs/client/features/src/insights/explainers/investments/AverageReturn.tsx
@@ -1,20 +1,13 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
 
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-    ExplainerPerformanceBlock,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 export function AverageReturn(): JSX.Element {
     const scrollContainer = useRef<HTMLDivElement>(null)
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -27,10 +20,6 @@ export function AverageReturn(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -60,16 +49,6 @@ export function AverageReturn(): JSX.Element {
                         Modified Dietz Return
                     </a>{' '}
                     method to calculate this from your holding and transaction data.
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/equities-as-an-asset-class"
-                    >
-                        Article from the Maybe blog on making equity investing part of your
-                        portfolio
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/investments/Contributions.tsx
+++ b/libs/client/features/src/insights/explainers/investments/Contributions.tsx
@@ -1,18 +1,12 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 export function Contributions(): JSX.Element {
     const scrollContainer = useRef<HTMLDivElement>(null)
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -25,10 +19,6 @@ export function Contributions(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -51,16 +41,6 @@ export function Contributions(): JSX.Element {
                     <ExplainerInfoBlock title="Formula">
                         <span className="font-mono italic">Total Deposits - Total Withdrawals</span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/equities-as-an-asset-class"
-                    >
-                        Article from the Maybe blog on making equity investing part of your
-                        portfolio
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/investments/PotentialGainLoss.tsx
+++ b/libs/client/features/src/insights/explainers/investments/PotentialGainLoss.tsx
@@ -1,18 +1,12 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 export function PotentialGainLoss(): JSX.Element {
     const scrollContainer = useRef<HTMLDivElement>(null)
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -25,10 +19,6 @@ export function PotentialGainLoss(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -51,16 +41,6 @@ export function PotentialGainLoss(): JSX.Element {
                     <ExplainerInfoBlock title="Formula">
                         <span className="font-mono italic">Total value - total cost basis</span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/equities-as-an-asset-class"
-                    >
-                        Article from the Maybe blog on making equity investing part of your
-                        portfolio
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/investments/SectorAllocation.tsx
+++ b/libs/client/features/src/insights/explainers/investments/SectorAllocation.tsx
@@ -1,18 +1,12 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import { useRef } from 'react'
-import { RiArticleLine, RiMicLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 export function SectorAllocation(): JSX.Element {
     const scrollContainer = useRef<HTMLDivElement>(null)
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -25,10 +19,6 @@ export function SectorAllocation(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -56,22 +46,6 @@ export function SectorAllocation(): JSX.Element {
                             portfolio value
                         </span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/equities-as-an-asset-class"
-                    >
-                        Article from the Maybe blog on making equity investing part of your
-                        portfolio
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiMicLine}
-                        href="https://maybe.co/podcast/11-how-can-i-match-my-investment-retirement-portfolio-with-my-risk-tolerance"
-                    >
-                        Podcast episode on matching your portfolio with your risk tolerance
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/investments/TotalFees.tsx
+++ b/libs/client/features/src/insights/explainers/investments/TotalFees.tsx
@@ -1,18 +1,12 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 export function TotalFees(): JSX.Element {
     const scrollContainer = useRef<HTMLDivElement>(null)
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -25,10 +19,6 @@ export function TotalFees(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -52,16 +42,6 @@ export function TotalFees(): JSX.Element {
                     <ExplainerInfoBlock title="Formula">
                         <span className="font-mono italic">Total fees paid to brokerage</span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/equities-as-an-asset-class"
-                    >
-                        Article from the Maybe blog on making equity investing part of your
-                        portfolio
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/BadDebt.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/BadDebt.tsx
@@ -1,12 +1,7 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine, RiMicLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 const Em = ({ children }: { children: ReactNode }) => (
     <em className="not-italic text-gray-25">{children}</em>
@@ -17,7 +12,6 @@ export function BadDebt(): JSX.Element {
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const resources = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -30,10 +24,6 @@ export function BadDebt(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Resources',
-                            elementRef: resources,
                         },
                     ]}
                 />
@@ -58,27 +48,6 @@ export function BadDebt(): JSX.Element {
                             All liabilities - [Liability type = investment or property]
                         </span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Resources" ref={resources}>
-                    <ExplainerExternalLink
-                        icon={RiMicLine}
-                        href="https://maybe.co/podcast/6-should-you-invest-more-or-pay-off-debt"
-                    >
-                        Podcast episode on investing vs. paying debt
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/ask-the-advisor-invest-more-or-pay-off-debt"
-                    >
-                        Article from the Maybe blog on investing vs. paying debt
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/asset-allocation-and-how-to-use-it-to-reach-your-financial-goals"
-                    >
-                        Article from the Maybe blog on asset allocation
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/GoodDebt.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/GoodDebt.tsx
@@ -1,12 +1,7 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine, RiMicLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 const Em = ({ children }: { children: ReactNode }) => (
     <em className="not-italic text-gray-25">{children}</em>
@@ -17,7 +12,6 @@ export function GoodDebt(): JSX.Element {
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const resources = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -30,10 +24,6 @@ export function GoodDebt(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Resources',
-                            elementRef: resources,
                         },
                     ]}
                 />
@@ -59,27 +49,6 @@ export function GoodDebt(): JSX.Element {
                             Liability type = investment or property
                         </span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Resources" ref={resources}>
-                    <ExplainerExternalLink
-                        icon={RiMicLine}
-                        href="https://maybe.co/podcast/6-should-you-invest-more-or-pay-off-debt"
-                    >
-                        Podcast episode on investing vs. paying debt
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/ask-the-advisor-invest-more-or-pay-off-debt"
-                    >
-                        Article from the Maybe blog on investing vs. paying debt
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/asset-allocation-and-how-to-use-it-to-reach-your-financial-goals"
-                    >
-                        Article from the Maybe blog on asset allocation
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/IlliquidAssets.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/IlliquidAssets.tsx
@@ -1,12 +1,7 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 const Em = ({ children }: { children: ReactNode }) => (
     <em className="not-italic text-gray-25">{children}</em>
@@ -17,7 +12,6 @@ export function IlliquidAssets(): JSX.Element {
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const resources = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -30,10 +24,6 @@ export function IlliquidAssets(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Resources',
-                            elementRef: resources,
                         },
                     ]}
                 />
@@ -56,15 +46,6 @@ export function IlliquidAssets(): JSX.Element {
                     <ExplainerInfoBlock title="Formula">
                         <span className="font-mono italic">Asset type = property</span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Resources" ref={resources}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/asset-allocation-and-how-to-use-it-to-reach-your-financial-goals"
-                    >
-                        Article from the Maybe blog on asset allocation
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/IncomePayingDebt.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/IncomePayingDebt.tsx
@@ -3,11 +3,9 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine, RiMicLine } from 'react-icons/ri'
 import type { InsightState } from '../../'
 import { InsightStateNames, InsightStateColors } from '../../'
 import {
-    ExplainerExternalLink,
     ExplainerInfoBlock,
     ExplainerSection,
     ExplainerPerformanceBlock,
@@ -24,7 +22,6 @@ export function IncomePayingDebt({ defaultState }: { defaultState: InsightState 
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
     const whyYouShouldCare = useRef<HTMLDivElement>(null)
     const incorrectData = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     const [performance, setPerformance] = useState<InsightState>(defaultState)
 
@@ -47,10 +44,6 @@ export function IncomePayingDebt({ defaultState }: { defaultState: InsightState 
                         {
                             name: 'Incorrect data?',
                             elementRef: incorrectData,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -166,21 +159,6 @@ export function IncomePayingDebt({ defaultState }: { defaultState: InsightState 
                             incorrect value, make sure to add all your accounts
                         </li>
                     </ul>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiMicLine}
-                        href="https://maybe.co/podcast/6-should-you-invest-more-or-pay-off-debt"
-                    >
-                        Podcast episode on investing vs. paying debt
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/ask-the-advisor-invest-more-or-pay-off-debt"
-                    >
-                        Article from the Maybe blog on investing vs. paying debt
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/LiquidAssets.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/LiquidAssets.tsx
@@ -1,12 +1,7 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 const Em = ({ children }: { children: ReactNode }) => (
     <em className="not-italic text-gray-25">{children}</em>
@@ -17,7 +12,6 @@ export function LiquidAssets(): JSX.Element {
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const resources = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -30,10 +24,6 @@ export function LiquidAssets(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Resources',
-                            elementRef: resources,
                         },
                     ]}
                 />
@@ -56,15 +46,6 @@ export function LiquidAssets(): JSX.Element {
                     <ExplainerInfoBlock title="Formula">
                         <span className="font-mono italic">Asset type = cash</span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Resources" ref={resources}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/asset-allocation-and-how-to-use-it-to-reach-your-financial-goals"
-                    >
-                        Article from the Maybe blog on asset allocation
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/NetWorthTrend.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/NetWorthTrend.tsx
@@ -3,9 +3,8 @@ import classNames from 'classnames'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArrowRightDownLine, RiArrowRightUpLine, RiArticleLine } from 'react-icons/ri'
+import { RiArrowRightDownLine, RiArrowRightUpLine } from 'react-icons/ri'
 import {
-    ExplainerExternalLink,
     ExplainerInfoBlock,
     ExplainerSection,
     ExplainerPerformanceBlock,
@@ -22,7 +21,6 @@ export function NetWorthTrend(): JSX.Element {
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
     const whyYouShouldCare = useRef<HTMLDivElement>(null)
     const incorrectData = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -44,10 +42,10 @@ export function NetWorthTrend(): JSX.Element {
                             name: 'Incorrect data?',
                             elementRef: incorrectData,
                         },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
-                        },
+                        // {
+                        //     name: 'Learn more',
+                        //     elementRef: learnMore,
+                        // },
                     ]}
                 />
             </div>
@@ -152,15 +150,6 @@ export function NetWorthTrend(): JSX.Element {
                             incorrect value, make sure to add all your accounts
                         </li>
                     </ul>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/the-complete-guide-to-managing-and-optimizing-your-expenses"
-                    >
-                        Article from the Maybe blog on expenses
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/SafetyNet.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/SafetyNet.tsx
@@ -3,11 +3,9 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine, RiMicLine } from 'react-icons/ri'
 import type { InsightState } from '../../'
 import { InsightStateNames, InsightStateColors } from '../../'
 import {
-    ExplainerExternalLink,
     ExplainerInfoBlock,
     ExplainerSection,
     ExplainerPerformanceBlock,
@@ -24,7 +22,6 @@ export function SafetyNet({ defaultState }: { defaultState: InsightState }): JSX
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
     const whyYouShouldCare = useRef<HTMLDivElement>(null)
     const incorrectData = useRef<HTMLDivElement>(null)
-    const learnMore = useRef<HTMLDivElement>(null)
 
     const [performance, setPerformance] = useState<InsightState>(defaultState)
 
@@ -47,10 +44,6 @@ export function SafetyNet({ defaultState }: { defaultState: InsightState }): JSX
                         {
                             name: 'Incorrect data?',
                             elementRef: incorrectData,
-                        },
-                        {
-                            name: 'Learn more',
-                            elementRef: learnMore,
                         },
                     ]}
                 />
@@ -174,21 +167,6 @@ export function SafetyNet({ defaultState }: { defaultState: InsightState }): JSX
                             incorrect value, make sure to add all your accounts
                         </li>
                     </ul>
-                </ExplainerSection>
-
-                <ExplainerSection title="Learn more" ref={learnMore}>
-                    <ExplainerExternalLink
-                        icon={RiMicLine}
-                        href="https://maybe.co/podcast/4-how-much-cash-should-you-have-on-hand"
-                    >
-                        Podcast episode on safety net
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/ask-the-advisor-invest-more-or-pay-off-debt-cash-on-hand"
-                    >
-                        Article from the Maybe blog on safety net
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/TotalDebtRatio.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/TotalDebtRatio.tsx
@@ -1,12 +1,7 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine, RiMicLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 const Em = ({ children }: { children: ReactNode }) => (
     <em className="not-italic text-gray-25">{children}</em>
@@ -17,7 +12,6 @@ export function TotalDebtRatio(): JSX.Element {
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const resources = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -30,10 +24,6 @@ export function TotalDebtRatio(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Resources',
-                            elementRef: resources,
                         },
                     ]}
                 />
@@ -59,21 +49,6 @@ export function TotalDebtRatio(): JSX.Element {
                     <ExplainerInfoBlock title="Formula">
                         <span className="font-mono italic">Liabilities &divide; Assets</span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Resources" ref={resources}>
-                    <ExplainerExternalLink
-                        icon={RiMicLine}
-                        href="https://maybe.co/podcast/6-should-you-invest-more-or-pay-off-debt"
-                    >
-                        Podcast episode on investing vs. paying debt
-                    </ExplainerExternalLink>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/ask-the-advisor-invest-more-or-pay-off-debt"
-                    >
-                        Article from the Maybe blog on investing vs. paying debt
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>

--- a/libs/client/features/src/insights/explainers/net-worth/YieldingAssets.tsx
+++ b/libs/client/features/src/insights/explainers/net-worth/YieldingAssets.tsx
@@ -1,12 +1,7 @@
 import { IndexTabs } from '@maybe-finance/design-system'
 import type { ReactNode } from 'react'
 import { useRef } from 'react'
-import { RiArticleLine } from 'react-icons/ri'
-import {
-    ExplainerExternalLink,
-    ExplainerInfoBlock,
-    ExplainerSection,
-} from '@maybe-finance/client/shared'
+import { ExplainerInfoBlock, ExplainerSection } from '@maybe-finance/client/shared'
 
 const Em = ({ children }: { children: ReactNode }) => (
     <em className="not-italic text-gray-25">{children}</em>
@@ -17,7 +12,6 @@ export function YieldingAssets(): JSX.Element {
 
     const definition = useRef<HTMLDivElement>(null)
     const howAreWeGettingThisValue = useRef<HTMLDivElement>(null)
-    const resources = useRef<HTMLDivElement>(null)
 
     return (
         <div className="flex flex-col w-full h-full">
@@ -30,10 +24,6 @@ export function YieldingAssets(): JSX.Element {
                         {
                             name: 'How are we getting this value?',
                             elementRef: howAreWeGettingThisValue,
-                        },
-                        {
-                            name: 'Resources',
-                            elementRef: resources,
                         },
                     ]}
                 />
@@ -58,15 +48,6 @@ export function YieldingAssets(): JSX.Element {
                             Asset type = investment or property
                         </span>
                     </ExplainerInfoBlock>
-                </ExplainerSection>
-
-                <ExplainerSection title="Resources" ref={resources}>
-                    <ExplainerExternalLink
-                        icon={RiArticleLine}
-                        href="https://maybe.co/articles/asset-allocation-and-how-to-use-it-to-reach-your-financial-goals"
-                    >
-                        Article from the Maybe blog on asset allocation
-                    </ExplainerExternalLink>
                 </ExplainerSection>
             </div>
         </div>


### PR DESCRIPTION
Removes from the sidebar the Resources/Learn More links to Maybe.co resources that are no longer available.
It would be spectacular for these to return in some form someday as internal documents, external resources, or back on Maybe.co, but for now they are inaccessible.