### PR TITLE
Fix transaction sign

### DIFF
--- a/libs/server/features/src/providers/teller/teller.etl.ts
+++ b/libs/server/features/src/providers/teller/teller.etl.ts
@@ -181,7 +181,7 @@ export class TellerETL implements IETL<Connection, TellerRawData, TellerData> {
                         maxRetries: 3,
                     }
                 )
-                if (account!.classification === AccountClassification.liability) {
+                if (account!.classification === AccountClassification.asset) {
                     transactions.forEach((t) => {
                         t.amount = String(Number(t.amount) * -1)
                     })
@@ -226,7 +226,7 @@ export class TellerETL implements IETL<Connection, TellerRawData, TellerData> {
                                 ${transactionId},
                                 ${date}::date,
                                 ${description},
-                                ${DbUtil.toDecimal(Number(-amount))},
+                                ${DbUtil.toDecimal(Number(amount))},
                                 ${status === 'pending'},
                                 ${'USD'},
                                 ${details.counterparty?.name ?? ''},

--- a/libs/server/shared/src/utils/teller-utils.ts
+++ b/libs/server/shared/src/utils/teller-utils.ts
@@ -1,10 +1,6 @@
-import {
-    Prisma,
-    AccountCategory,
-    AccountType,
-    type Account,
-    type AccountClassification,
-} from '@prisma/client'
+import { Prisma, AccountCategory, AccountType } from '@prisma/client'
+import type { AccountClassification } from '@prisma/client'
+import type { Account } from '@prisma/client'
 import type { TellerTypes } from '@maybe-finance/teller-api'
 import { Duration } from 'luxon'
 


### PR DESCRIPTION
Addresses #171 
Reverse the sign on assets coming from teller API to follow convention expected by rest of the app.

![CleanShot 2024-01-20 at 12 10 05](https://github.com/maybe-finance/maybe/assets/1218724/aaf2cb3d-b0b2-494f-a2d1-ec7dd8cfb3bc)
![CleanShot 2024-01-20 at 12 10 14](https://github.com/maybe-finance/maybe/assets/1218724/b95d34dc-c7a3-48c5-a348-2647a7c09929)
![CleanShot 2024-01-20 at 12 10 20](https://github.com/maybe-finance/maybe/assets/1218724/c96f8ec0-5ad8-4016-a810-a00a5c15d1c8)


