### PR TITLE
Made login/register buttons full width

### DIFF
--- a/apps/client/pages/login.tsx
+++ b/apps/client/pages/login.tsx
@@ -89,6 +89,7 @@ export default function LoginPage() {
                             ) : null}
 
                             <Button
+                                className="w-full"
                                 type="submit"
                                 disabled={!isValid || isLoading}
                                 variant={isValid ? 'primary' : 'secondary'}
@@ -96,7 +97,7 @@ export default function LoginPage() {
                             >
                                 Log in
                             </Button>
-                            <div className="text-sm text-gray-50 pt-2">
+                            <div className="text-sm text-gray-50 text-center">
                                 <div>
                                     Don&apos;t have an account?{' '}
                                     <Link

--- a/apps/client/pages/register.tsx
+++ b/apps/client/pages/register.tsx
@@ -110,9 +110,8 @@ export default function RegisterPage() {
                                 </div>
                             ) : null}
 
-                            <AuthDevTools isAdmin={isAdmin} setIsAdmin={setIsAdmin} />
-
                             <Button
+                                className="w-full"
                                 type="submit"
                                 disabled={!isValid}
                                 variant={isValid ? 'primary' : 'secondary'}
@@ -120,7 +119,7 @@ export default function RegisterPage() {
                             >
                                 Register
                             </Button>
-                            <div className="text-sm text-gray-50 pt-2">
+                            <div className="text-sm text-gray-50 text-center">
                                 <div>
                                     Already have an account?{' '}
                                     <Link


### PR DESCRIPTION
Changed the CTA for login and register pages style to be full width as it looks a little bit cleaner. The text under the CTA is centered now, too. 

Before
![CleanShot 2024-01-22 at 21 40 41@2x](https://github.com/maybe-finance/maybe/assets/1017620/3895dda0-3094-4d95-bdbd-d52a0b443284)
![CleanShot 2024-01-22 at 21 41 00@2x](https://github.com/maybe-finance/maybe/assets/1017620/ec725ca1-fed1-4e60-9b66-651c5a7e4aab)

After
![CleanShot 2024-01-22 at 21 35 41@2x](https://github.com/maybe-finance/maybe/assets/1017620/0d9fd4c3-6a8e-4a37-824d-9f152d15e51f)
![CleanShot 2024-01-22 at 21 36 42@2x](https://github.com/maybe-finance/maybe/assets/1017620/bb002e57-224b-411c-be23-eff212ffc8d9)
