### PR TITLE
Prevent "Enter" continuing in onboarding when step is invalid

### DIFF
--- a/libs/client/features/src/onboarding/steps/Profile.tsx
+++ b/libs/client/features/src/onboarding/steps/Profile.tsx
@@ -366,6 +366,7 @@ function Question({
 
             switch (e.key) {
                 case 'Enter':
+                    if (!valid) break
                     if (next) next()
                     else if (submit) submit()
                     break
@@ -374,7 +375,7 @@ function Question({
                     break
             }
         },
-        [open, back, next, submit]
+        [open, back, next, submit, valid]
     )
 
     useEffect(() => {


### PR DESCRIPTION
## Description

I noticed in the onboarding steps the Enter keydown event did not have the same validation check against it as the buttons do. This PR returns early if the field is not valid on Enter keypress.

✔️ I searched through the Issues/PRs before opening this PR

## How to Reproduce

1. Create a new user and enter the onboarding page
2. Add the users birthday and press "Enter" which will proceed to the next step.
3. Press "Enter" again and you will proceed to the next step again even though the form is invalid
4. Also notice the Up/Down arrow buttons are disabled but your keyboard commands of Enter/Backslash allow you to navigate next/prev for each step

| Before | After |
| ----- | ------ |
| https://github.com/maybe-finance/maybe/assets/2111847/1484962c-c703-4fb3-896c-ef5042095acd | https://github.com/maybe-finance/maybe/assets/2111847/d342d22b-d6a6-4592-bce8-f88f69af2509 |

*Note in the videos, I use keyCastr to showcase the keyboard keys I am pressing. Sometimes Github shows the videos inline, bummer it didn't this time




