### PR TITLE
Add Storybook Page for 404 Error

### DIFF
--- a/apps/client/pages/404.stories.tsx
+++ b/apps/client/pages/404.stories.tsx
@@ -7,6 +7,4 @@ export default {
     component: Page404,
 } as Meta
 
-const Template: Story = () => <Page404 />
-
-export const Default = Template.bind({})
+export const Default: Story = () => <Page404 />;

--- a/apps/client/pages/404.stories.tsx
+++ b/apps/client/pages/404.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import type { Story, Meta } from '@storybook/react'
+import Page404 from './404'
+
+export default {
+    title: 'pages/Page404',
+    component: Page404,
+} as Meta
+
+const Template: Story = () => <Page404 />
+
+export const Default = Template.bind({})


### PR DESCRIPTION
## Description

This PR adds a Storybook page for the 404 Error component. The addition of this Storybook page is part of the ongoing effort to improve documentation and component testing within the project.

## Changes

- Created a new Storybook page for the 404 Error component.
- The Storybook setup includes the default state of the 404 page for visual and interaction testing.

The implementation follows the standard structure for our Storybook pages, ensuring consistency across our documentation. This setup will help in visually testing the 404 Error component in isolation and will aid in future enhancements and bug fixes.

## Visuals

Attached is an image of the final Storybook implementation for the 404 Error page, showcasing how it appears in the Storybook environment.

![Storybook Page for 404 Error](https://github.com/maybe-finance/maybe/assets/92785438/093aee6a-4015-47f4-81ba-f8ef00599d93)

## Issue Fix

This PR addresses a part of Issue #223 - "Add stories for client code." Specifically, it resolves the task of creating a Storybook page for the 404 Error component, marking one out of the 21 components outlined in the issue.

## How to Test

1. Checkout to this branch.
2. Run the Storybook server using the command `yarn nx run client:storybook`.
3. Once Storybook is running, navigate to `pages/Page404` in the Storybook UI.
4. Review the rendered 404 Error page
