### PR TITLE
Add stories for data-editor component

### DIFF
--- a/apps/client/.storybook/main.js
+++ b/apps/client/.storybook/main.js
@@ -4,7 +4,7 @@ module.exports = {
     ...rootMain,
     core: { ...rootMain.core, builder: 'webpack5' },
     stories: ['../**/*.stories.@(js|jsx|ts|tsx)', '../stories/**/*.stories.@(js|jsx|ts|tsx)'],
-    addons: [...rootMain.addons, '@nrwl/react/plugins/storybook'],
+    addons: [...rootMain.addons, '@nrwl/react/plugins/storybook', 'storybook-addon-next-router'],
     webpackFinal: async (config, { configType }) => {
         // apply any global webpack configs that might have been specified in .storybook/main.js
         if (rootMain.webpackFinal) {

--- a/apps/client/.storybook/preview.js
+++ b/apps/client/.storybook/preview.js
@@ -1,9 +1,13 @@
 import '../styles.css'
+import { RouterContext } from 'next/dist/shared/lib/router-context'
 
 import theme from './theme'
 
 export const parameters = {
     docs: {
         theme,
+    },
+    nextRouter: {
+        Provider: RouterContext.Provider,
     },
 }

--- a/apps/client/pages/data-editor.tsx
+++ b/apps/client/pages/data-editor.tsx
@@ -11,7 +11,7 @@ import { Tab } from '@maybe-finance/design-system'
 import { useQueryParam } from '@maybe-finance/client/shared'
 import { useRouter } from 'next/router'
 
-export default function DataEditor() {
+function DataEditor() {
     const currentTab = useQueryParam('tab', 'string')
 
     const router = useRouter()
@@ -63,3 +63,5 @@ export default function DataEditor() {
 DataEditor.getLayout = function getLayout(page: ReactElement) {
     return <WithSidebarLayout sidebar={<AccountSidebar />}>{page}</WithSidebarLayout>
 }
+
+export default DataEditor

--- a/apps/client/stories/data-editor.stories.tsx
+++ b/apps/client/stories/data-editor.stories.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import type { Story, Meta } from '@storybook/react'
+import DataEditor from '../pages/data-editor'
+
+export default {
+    title: 'pages/DataEditor',
+    component: DataEditor,
+} as Meta
+
+export const Default: Story = () => <DataEditor />

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
         "prettier": "2.7.1",
         "react-refresh": "^0.10.0",
         "react-test-renderer": "18.2.0",
+        "storybook-addon-next-router": "^4.0.2",
         "style-loader": "^3.3.0",
         "stylus": "^0.55.0",
         "stylus-loader": "^7.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18166,6 +18166,13 @@ store2@^2.12.0:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
+storybook-addon-next-router@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/storybook-addon-next-router/-/storybook-addon-next-router-4.0.2.tgz#fb45a4b7d9c4f92cd63b509f4d378c51164aca7d"
+  integrity sha512-0rjGAl7HziW4ecDq+VU03H1dwkw5f6phqA+PMquPzdowNVl29ejVwVadLMGlovG6x2snaxMGxtySR2c5bwegSw==
+  dependencies:
+    tslib "2.4.0"
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -19124,6 +19131,11 @@ tsconfig-paths@^4.0.0, tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
+tslib@2.4.0, tslib@^2.0.3, tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -19133,11 +19145,6 @@ tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
-tslib@^2.0.3, tslib@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
### Description
This PR address a part of #223 
This PR adds a Storybook page for the data-editor component. The addition of this Storybook page is part of the ongoing effort to improve documentation and component testing within the project.

### Changes
Created a new Storybook page for the data-editor component.
Install a new addon to replicate next router

### Visuals
Attached is an image of the final Storybook implementation for the data-editor, showcasing how it appears in the Storybook environment.
<img width="1315" alt="Screenshot 2024-01-28 at 1 43 04 AM" src="https://github.com/maybe-finance/maybe/assets/44577841/715ca297-afc2-4ae2-ba87-85a46ae58328">

