### PR TITLE
Fix: Change className type

### DIFF
--- a/libs/design-system/src/lib/DatePicker/DatePicker.tsx
+++ b/libs/design-system/src/lib/DatePicker/DatePicker.tsx
@@ -19,7 +19,7 @@ export interface DatePickerProps {
     onChange: (date: string | null) => void
     error?: string
     label?: string
-    className?: String
+    className?: string
     placeholder?: string
     minCalendarDate?: string
     maxCalendarDate?: string


### PR DESCRIPTION
Causing build issues, this should just be a string as that's what the classNames function expects.

cc: @6ixfalls