### PR TITLE
Add Rails LSP plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.3.0"
+ruby File.read(".ruby-version").strip
 
 # Use main development branch of Rails
 gem "rails", github: "rails/rails", branch: "main"
@@ -66,6 +66,7 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
   gem "hotwire-livereload"
+  gem "ruby-lsp-rails"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip
+ruby file: ".ruby-version"
 
 # Use main development branch of Rails
 gem "rails", github: "rails/rails", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
+    prism (0.19.0)
     propshaft (0.8.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -271,6 +272,16 @@ GEM
       rubocop-minitest
       rubocop-performance
       rubocop-rails
+    ruby-lsp (0.13.4)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 0.19.0, < 0.20)
+      sorbet-runtime (>= 0.5.10782)
+    ruby-lsp-rails (0.2.9)
+      actionpack (>= 6.0)
+      activerecord (>= 6.0)
+      railties (>= 6.0)
+      ruby-lsp (>= 0.13.0, < 0.14.0)
+      sorbet-runtime (>= 0.5.9897)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -279,6 +290,7 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sorbet-runtime (0.5.11226)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
@@ -344,6 +356,7 @@ DEPENDENCIES
   rails!
   redis (>= 4.0.1)
   rubocop-rails-omakase
+  ruby-lsp-rails
   selenium-webdriver
   stimulus-rails
   tailwindcss-rails


### PR DESCRIPTION
This PR adds the [ruby-lsp-rails](https://github.com/Shopify/ruby-lsp-rails) gem in development.

It injects a Rack app into development on /ruby_lsp_rails/ so that the ruby-lsp can show attributes and types in your editor, should be useful for helping anyone new to the codebase get to grips with all the things that exist.

I've also updated the Gemfile to read the ruby version from .ruby-version, which reduces some duplication and makes it a little easier to upgrade the version in future.