### PR TITLE
Refactor 'new' action in AccountsController for better readability and efficiency

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -2,12 +2,10 @@ class AccountsController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    if params[:type].blank? || Account.accountable_types.include?("Account::#{params[:type]}")
-      @account = if params[:type].blank?
-        Account.new
-      else
-        Account.new(accountable_type: "Account::#{params[:type]}")
-      end
+    type = params[:type].presence
+
+    if type.blank? || Account.accountable_types.include?("Account::#{type}")
+      @account = Account.new(accountable_type: "Account::#{type}")
     else
       head :not_found
     end


### PR DESCRIPTION
- Used '.presence' instead of '.blank?' for handling both nil and empty string in 'params[:type]'
- Removed redundant condition for 'params[:type].blank?' by using 'type' directly
- Combined 'Account.new' calls into a single line

The distinction between `.blank?` and `.presence` lies in how they handle nil and empty strings.

`.blank?`: This method returns true if the object is nil, empty, or consists only of whitespace characters. However, it does not handle nil directly; instead, it relies on the truthiness of the object.

`.presence`: This method is particularly useful when you want to obtain a non-nil value. It returns nil if the object is blank (empty or consists only of whitespace characters), and it returns the object itself if it is present.

In the context of the action code, using `.presence` allows handling both nil and an empty string in a concise manner. If params[:type] is nil, it will be assigned to type as nil, and if it's an empty string, it will be assigned to type as nil as well. This makes the subsequent check (type.blank? || ...) more straightforward, as it covers both cases.

For more details, refer to the link https://api.rubyonrails.org/classes/Object.html#method-i-presence