### PR TITLE
Fix dynamic classname generation

### DIFF
--- a/app/views/shared/_auth_messages.html.erb
+++ b/app/views/shared/_auth_messages.html.erb
@@ -1,5 +1,5 @@
 <% flash.each do |type, msg| %>
-  <div class="p-4 bg-<%= type == 'notice' ? 'blue' : 'red' %>-200 rounded-lg"><%= msg %></div>
+  <div class="p-4 <%= type == 'notice' ? 'bg-blue-200' : 'bg-red-200' %> rounded-lg"><%= msg %></div>
 <% end %>
 
 <% errors.each do |message| %>


### PR DESCRIPTION
Tailwinds JIT compiler doesn't recognize concatenated partial class names and will therefore not include these in the generated css.

Ref: https://tailwindcss.com/docs/content-configuration#dynamic-class-names