### PR TITLE
Opt-in to Current fully

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -17,7 +17,7 @@ class AccountsController < ApplicationController
   end
 
   def create
-    @account = Account.new(account_params.merge(family: current_family))
+    @account = Account.new(account_params.merge(family: Current.family))
     @account.accountable = account_params[:accountable_type].constantize.new
 
     if @account.save

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -2,31 +2,21 @@ module Authentication
   extend ActiveSupport::Concern
 
   included do
-    helper_method :current_user
-    helper_method :current_family
     helper_method :user_signed_in?
   end
 
   private
 
   def authenticate_user!
-    redirect_to new_session_path unless user_signed_in?
-  end
-
-  def current_user
-    Current.user || authenticate_user_from_session
-  end
-
-  def current_family
-    current_user.family
-  end
-
-  def authenticate_user_from_session
-    User.find_by(id: session[:user_id])
+    if user = User.find_by(id: session[:user_id])
+      Current.user = user
+    else
+      redirect_to new_session_url
+    end
   end
 
   def user_signed_in?
-    current_user.present?
+    Current.user.present?
   end
 
   def login(user)

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -5,7 +5,7 @@ class PasswordsController < ApplicationController
   end
 
   def update
-    if current_user.update(password_params)
+    if Current.user.update(password_params)
       redirect_to root_path, notice: t(".success")
     else
       render :edit, status: :unprocessable_entity

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,5 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
+
+  delegate :family, to: :user
 end

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,8 +1,8 @@
 
 <h2 class="text-2xl font-semibold font-display">Cash</h2>
-<h3 class="mt-1 mb-4 text-sm text-gray-500"><%#= number_to_currency current_family.cash_balance %></h3>
+<h3 class="mt-1 mb-4 text-sm text-gray-500"><%#= number_to_currency Current.family.cash_balance %></h3>
 
-<% current_family.accounts.each do |account| %>
+<% Current.family.accounts.each do |account| %>
     <div class="flex items-center justify-between px-3 py-3 mb-2 bg-white shadow-sm rounded-xl">
       <div class="flex items-center text-sm">
         <%= account.name %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
           <% end %>
           <div class="relative" data-controller="dropdown">
             <div class="flex" data-action="click->dropdown#toggleMenu">
-              <div class="mr-1.5 text-white w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center text-lg uppercase"><%= current_user.email.first %></div>
+              <div class="mr-1.5 text-white w-8 h-8 bg-gray-400 rounded-full flex items-center justify-center text-lg uppercase"><%= Current.user.email.first %></div>
             </div>
 
             <div class="absolute z-10 hidden w-screen px-2 mt-2 -translate-x-1/2 left-1/2 max-w-min" data-dropdown-target="menu">
@@ -63,7 +63,7 @@
           <div>
             <h2 class="text-sm font-semibold font-display">Cash</h2>
 
-            <% current_family.accounts.each do |account| %>
+            <% Current.family.accounts.each do |account| %>
               <div class="flex items-center justify-between py-2">
                 <div class="flex items-center text-sm">
                   <%= account.name %>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Update Password</h1>
 
-<%= form_with model: current_user, url: password_path do |form| %>
+<%= form_with model: Current.user, url: password_path do |form| %>
   <%= auth_messages form %>
 
   <div>

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class CurrentTest < ActiveSupport::TestCase
+  test "family returns user family" do
+    user = users(:bob)
+    Current.user = user
+    assert_equal user.family, Current.family
+  end
+end


### PR DESCRIPTION
As I floated in #289, this moves towards using `Current` more fully, and replacing the helper methods like `current_user` and `current_family`.

To me, `Current` feels like the more Rails-y way of doing things, and `current_*` style helpers feel more like the Devise way of doing things. Right now we're sitting half-in half-out of both (especially considering we use a before_action called `authenticate_user!`).

* I delegate `Current.family` to the current user's family
* I take inspiration from the [`Current` docs](https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html) to set the user or redirect away in the one method

It might even be worth considering dropping `authenticate_user` to just `authenticate` but that's neither here nor there. I do think this PR is important because it makes access to the current user/family **consistent**.