### PR TITLE
Fix arguments to find_by_token_for

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -31,7 +31,7 @@ class PasswordResetsController < ApplicationController
   private
 
   def set_user_by_token
-    @user = User.find_by_token_for(password_reset: params[:token])
+    @user = User.find_by_token_for(:password_reset, params[:token])
     redirect_to new_password_reset_path, alert: t("password_resets.update.invalid_token") unless @user.present?
   end
 

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:bob)
+  end
+
+  test "new" do
+    get new_password_reset_path
+    assert_response :ok
+  end
+
+  test "create" do
+    assert_enqueued_emails 1 do
+      post password_reset_path, params: { email: @user.email }
+      assert_redirected_to root_url
+    end
+  end
+
+  test "edit" do
+    get edit_password_reset_path(token: @user.generate_token_for(:password_reset))
+    assert_response :ok
+  end
+
+  test "update" do
+    patch password_reset_path(token: @user.generate_token_for(:password_reset)),
+      params: { user: { password: "password", password_confirmation: "password" } }
+    assert_redirected_to new_session_url
+  end
+end


### PR DESCRIPTION
This fixes an issue where `find_by_token_for` expects two arguments, not a hash. The first argument should be the token purpose. 

Adds test coverage for it too. I'll slow down on these test PRs and see what direction you take things going forward.

I really wanted to get `assert_enqueued_email_with PasswordMailer, :password_reset do ... end` working, but it just wasn't having it. I've had this same issue in my own apps too and not sure what the problem is, perhaps a bug in the assertion itself.