### PR TITLE
Make all account names human readable

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,5 +1,2 @@
 module AccountsHelper
-  def human_account_name(camelCaseName)
-    camelCaseName.gsub(/(?<!^)([A-Z])/, ' \1')
-  end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -1,2 +1,5 @@
 module AccountsHelper
+  def human_account_name(camelCaseName)
+    camelCaseName.gsub(/(?<!^)([A-Z])/, ' \1')
+  end
 end

--- a/app/models/account/credit.rb
+++ b/app/models/account/credit.rb
@@ -1,7 +1,7 @@
 class Account::Credit < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Credit Card"
   end
 end

--- a/app/models/account/depository.rb
+++ b/app/models/account/depository.rb
@@ -1,7 +1,7 @@
 class Account::Depository < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Bank Accounts"
   end
 end

--- a/app/models/account/investment.rb
+++ b/app/models/account/investment.rb
@@ -1,7 +1,7 @@
 class Account::Investment < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Investments"
   end
 end

--- a/app/models/account/loan.rb
+++ b/app/models/account/loan.rb
@@ -1,7 +1,7 @@
 class Account::Loan < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Loan"
   end
 end

--- a/app/models/account/other_asset.rb
+++ b/app/models/account/other_asset.rb
@@ -1,7 +1,7 @@
 class Account::OtherAsset < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Other Asset"
   end
 end

--- a/app/models/account/other_liability.rb
+++ b/app/models/account/other_liability.rb
@@ -1,7 +1,7 @@
 class Account::OtherLiability < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Other Liability"
   end
 end

--- a/app/models/account/property.rb
+++ b/app/models/account/property.rb
@@ -1,7 +1,7 @@
 class Account::Property < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Real Estate"
   end
 end

--- a/app/models/account/vehicle.rb
+++ b/app/models/account/vehicle.rb
@@ -1,7 +1,7 @@
 class Account::Vehicle < ApplicationRecord
   include Accountable
 
-  def type_name
+  def self.type_name
     "Vehicle"
   end
 end

--- a/app/views/accounts/_account_type.html.erb
+++ b/app/views/accounts/_account_type.html.erb
@@ -1,5 +1,5 @@
 <div class="relative flex-col items-center px-5 py-4 space-x-3 text-center bg-white border border-gray-100 shadow-sm rounded-xl hover:border-gray-200">
-  <%= link_to new_account_path(type: type.class.name.demodulize), class: "flex flex-col items-center justify-center w-full text-center focus:outline-none" do %>
+  <%= link_to new_account_path(type: type.name.demodulize), class: "flex flex-col items-center justify-center w-full text-center focus:outline-none" do %>
     <span class="absolute inset-0" aria-hidden="true"></span>
     <span class="flex w-10 h-10 shrink-0 grow-0 items-center justify-center rounded-xl <%= bg_color %> mb-2">
       <%= inline_svg_tag(icon, class: "#{text_color} stroke-current") %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -16,7 +16,7 @@
       <%= link_to new_account_path, class: "" do %>
         <%= inline_svg_tag('icon-arrow-left.svg', class: 'text-gray-500 fill-current') %>
       <% end %>
-    <h2 class="text-2xl font-semibold font-display">Enter <%= @account.accountable_type.constantize.type_name %> account</h2>
+    <h2 class="text-2xl font-semibold font-display">Enter <%= "Account::#{params[:type]}".constantize.type_name %> account</h2>
   </div>
 
   <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4" } do |f| %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -2,21 +2,21 @@
 
 <% if params[:type].blank? || Account.accountable_types.include?("Account::#{params[:type]}") == false %>
   <div class="grid grid-cols-2 gap-4 mt-8 text-sm sm:grid-cols-3 md:grid-cols-4">
-    <%= render "account_type", type: Account::Credit.new, bg_color: "bg-[#E6F6FA]", text_color: "text-[#189FC7]", icon: "icon-credit-card.svg" %>
-    <%= render "account_type", type: Account::Depository.new, bg_color: "bg-[#EAF4FF]", text_color: "text-[#3492FB]", icon: "icon-bank-accounts.svg" %>
-    <%= render "account_type", type: Account::Investment.new, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
-    <%= render "account_type", type: Account::Loan.new, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
-    <%= render "account_type", type: Account::OtherAsset.new, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
-    <%= render "account_type", type: Account::OtherLiability.new, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
-    <%= render "account_type", type: Account::Property.new, bg_color: "bg-[#FEF0F7]", text_color: "text-[#F03695]", icon: "icon-real-estate.svg" %>
-    <%= render "account_type", type: Account::Vehicle.new, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
+    <%= render "account_type", type: Account::Credit, bg_color: "bg-[#E6F6FA]", text_color: "text-[#189FC7]", icon: "icon-credit-card.svg" %>
+    <%= render "account_type", type: Account::Depository, bg_color: "bg-[#EAF4FF]", text_color: "text-[#3492FB]", icon: "icon-bank-accounts.svg" %>
+    <%= render "account_type", type: Account::Investment, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
+    <%= render "account_type", type: Account::Loan, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
+    <%= render "account_type", type: Account::OtherAsset, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
+    <%= render "account_type", type: Account::OtherLiability, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
+    <%= render "account_type", type: Account::Property, bg_color: "bg-[#FEF0F7]", text_color: "text-[#F03695]", icon: "icon-real-estate.svg" %>
+    <%= render "account_type", type: Account::Vehicle, bg_color: "bg-[#EDF7F4]", text_color: "text-[#1BD5A1]", icon: "icon-bank-accounts.svg" %>
   </div>
 <% else %>
   <div class="relative flex items-center mb-5 space-x-2">
       <%= link_to new_account_path, class: "" do %>
         <%= inline_svg_tag('icon-arrow-left.svg', class: 'text-gray-500 fill-current') %>
       <% end %>
-    <h2 class="text-2xl font-semibold font-display">Enter <%= params[:type] %> account</h2>
+    <h2 class="text-2xl font-semibold font-display">Enter <%= @account.accountable_type.constantize.type_name %> account</h2>
   </div>
 
   <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4" } do |f| %>


### PR DESCRIPTION
![Screenshot 2024-02-05 at 8 40 15 PM](https://github.com/maybe-finance/maybe/assets/57076268/ad29f2ed-5b60-467c-95e7-f7f70cb57bec)
![Screenshot 2024-02-05 at 8 40 09 PM](https://github.com/maybe-finance/maybe/assets/57076268/9a54cf02-c1fd-4c3c-a01e-1d7baebf586f)

Fixed the above two names in the form to the following:

![Screenshot 2024-02-05 at 9 04 27 PM](https://github.com/maybe-finance/maybe/assets/57076268/ae216319-dc21-4312-ba10-bca33485ad4e)
![Screenshot 2024-02-05 at 9 04 37 PM](https://github.com/maybe-finance/maybe/assets/57076268/9b76c5c3-69ac-408d-868d-16d4cba27039)

I converted the `type_name` method to a class method. To me, it makes more sense to pass the class in the `type` local for the `_account_type` partial instead of instantializing each type just to access the `type_name`. It also eliminates the need to call `.class` then on every instance of the type in the partial.