### PR TITLE
Fix database config for non-devcontainer environments

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     environment:
       DB_HOST: db
       HOST: "0.0.0.0"
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
 
     depends_on:
       - db

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,8 +19,8 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
-  password: postgres
-  user: postgres
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") { nil } %>
+  user: <%= ENV.fetch("POSTGRES_USER") { nil } %>
 
 development:
   <<: *default


### PR DESCRIPTION
Back in this [commit](https://github.com/maybe-finance/maybe/commit/5f50ea3f02bfc1797816e3c679065c611fc61347#diff-5a674c769541a71f2471a45c0e9dde911b4455344e3131bddc5a363701ba6325R22-R23) I added a default postgres user and password.

Often this is not the user and password that is used in non-devcontainer environments.

This commit uses environment variables that are set in the devcontainer to set the user and password in the database.yml file, but only if using the devcontainer.  

If the environment variables are not set, it falls back to the default user and password on the users system (so unset in the database.yml file - as it was prior to the commit linked above).