### PR TITLE
Display account type instead of accoumtable object on accounts index

### DIFF
--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -8,7 +8,7 @@
         <%= account.name %>
       </div>
       <div class="flex items-center text-sm">
-        <%= account.accountable %>
+        <%= account.accountable.type_name %>
       </div>
       <p class="text-sm text-right">
         <span class="block mb-1"><%= number_to_currency account.balance %></span>


### PR DESCRIPTION
- Displays the type of account on the accounts index page

<img width="1485" alt="image" src="https://github.com/maybe-finance/maybe/assets/4531477/ad915010-f51e-4f12-84ee-270316574ab9">
 
instead of the object information

![image](https://github.com/maybe-finance/maybe/assets/4531477/3f83bf7d-e829-49f7-bca9-81fd396718d0)

Resolves: https://github.com/maybe-finance/maybe/issues/319