### PR TITLE
Ignore DS_Store and devcontainer generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@
 
 # Ignore Jetbrains IDEs
 .idea
+
+# Ignore macOS specific files
+*/.DS_Store
+.DS_Store
+
+# Ignore .devcontainer files
+compose-dev.yaml


### PR DESCRIPTION
Automatically generated files on macos are ignored to avoid committing by accident.