### PR TITLE
Use latest turbo-rails release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "tailwindcss-rails"
 
 # Hotwire
 gem "stimulus-rails"
-gem "turbo-rails", github: "hotwired/turbo-rails", branch: "main"
+gem "turbo-rails"
 
 # Other
 gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/hotwired/turbo-rails.git
-  revision: 3748512710a29b541a1f2b3863cc6fb2422fb7e2
-  branch: main
-  specs:
-    turbo-rails (2.0.0.pre.rc.2)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
-
-GIT
   remote: https://github.com/rails/rails.git
   revision: 554e5c2d8e8dd9f9e302a2d11c775f14c512d957
   branch: main
@@ -355,6 +345,10 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.0)
     timeout (0.4.1)
+    turbo-rails (2.0.0)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -406,7 +400,7 @@ DEPENDENCIES
   selenium-webdriver
   stimulus-rails
   tailwindcss-rails
-  turbo-rails!
+  turbo-rails
   tzinfo-data
   web-console
 


### PR DESCRIPTION
This was using main branch but since 2.0 has been released this morning we can revert to that rather than pre-release versions.

Can close https://github.com/maybe-finance/maybe/pull/350