### PR TITLE
Fix: Populate balance_cents with add_monetize method

### DIFF
--- a/db/migrate/20240206031739_replace_money_field.rb
+++ b/db/migrate/20240206031739_replace_money_field.rb
@@ -6,7 +6,7 @@ class ReplaceMoneyField < ActiveRecord::Migration[7.2]
     Account.reset_column_information
 
     Account.find_each do |account|
-      account.update_columns(balance_cents: Money.from_amount(account.balance, account.currency).cents)
+      account.update_columns(balance_cents: Money.from_amount(account.balance_in_database, account.currency).cents)
     end
 
     remove_column :accounts, :balance


### PR DESCRIPTION
Closes https://github.com/maybe-finance/maybe/pull/268#issuecomment-1930614845

When adding the `add_monetize :accounts, :balance` in the migration, the `balance` attribute is transformed into a `money` object instead of remaining `numeric`. However, this transformation is causing an error during attempts to populate `balance_cents`.