### PR TITLE
Remove redundant `dotenv` from `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ]
   gem "brakeman", require: false
   gem "rubocop-rails-omakase", require: false
-  gem "dotenv"
   gem "dotenv-rails"
   gem "letter_opener"
   gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,6 @@ DEPENDENCIES
   brakeman
   capybara
   debug
-  dotenv
   dotenv-rails
   hotwire-livereload
   i18n-tasks


### PR DESCRIPTION
`dotenv` is already a `dotenv-rails` dependency so there is no need to specify it manually to the `Gemfile`.