### PR TITLE
Prevent duplicate listeners and memory leak

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -14,10 +14,10 @@ export default class extends Controller {
   }
 
   connect() {
-    document.addEventListener("click", this.hideMenu;
+    document.addEventListener("click", this.hideMenu);
   }
 
   disconnect() {
-    document.removeEventListener("click", this.hideMenu;
+    document.removeEventListener("click", this.hideMenu);
   }
 }

--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -9,15 +9,15 @@ export default class extends Controller {
     this.menuTarget.classList.toggle("hidden");
   }
 
-  hideMenu() {
+  hideMenu = () => {
     this.menuTarget.classList.add("hidden");
   }
 
   connect() {
-    document.addEventListener("click", () => this.hideMenu());
+    document.addEventListener("click", this.hideMenu;
   }
 
   disconnect() {
-    document.removeEventListener("click", () => this.hideMenu());
+    document.removeEventListener("click", this.hideMenu;
   }
 }


### PR DESCRIPTION
I've written about this a lot but TLDR is this:

```js
connect () {
  // Creates an anonymous function that we'll never be able to reference again.
  document.addEventListener("click", () => this.hideMenu())
}

disconnect () {
  // Never actually removes anything
  document.removeEventListener("click", () => this.hideMenu())
}
```

The above showcases why anonymous function in connect / disconnect will never work as expected. They create a new function everytime so the browser will never be able to dedupe the listeners, and you'll end up with a memory leak and duplicate listeners.