### PR TITLE
Fixes #382 Changed Add Account to use account model name

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -2,4 +2,28 @@ module AccountsHelper
   def to_accountable_title(accountable)
     accountable.model_name.human
   end
+  def find_model_class(type)
+    case type
+    when "Credit"
+      Account::Credit
+    when "Depository"
+      Account::Depository
+    when "Investment"
+      Account::Investment
+    when "Property"
+      Account::Property
+    when "Loan"
+      Account::Loan
+    when "OtherAsset"
+      Account::OtherAsset
+    when "OtherLiability"
+      Account::OtherLiability
+    when "Property"
+      Account::Property
+    when "Vehicle"
+      Account::Vehicle
+    else
+      nil
+    end
+  end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,8 +6,4 @@ class Account < ApplicationRecord
   delegate :type_name, to: :accountable
 
   monetize :balance_cents
-
-  def self.allowable_account_types
-    accountable_types.map { |type| type.demodulize }
-  end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,8 +7,8 @@ class Account < ApplicationRecord
 
   monetize :balance_cents
 
-  def self.allowable_accountable_types
+  def self.allowable_account_types
     accountable_types.map { |type| type.demodulize }
   end
-  
+
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -10,5 +10,4 @@ class Account < ApplicationRecord
   def self.allowable_account_types
     accountable_types.map { |type| type.demodulize }
   end
-
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -6,4 +6,9 @@ class Account < ApplicationRecord
   delegate :type_name, to: :accountable
 
   monetize :balance_cents
+
+  def self.allowable_accountable_types
+    accountable_types.map { |type| type.demodulize }
+  end
+  
 end

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -65,11 +65,11 @@
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
       <span>
-        <% if params[:type].in? Account.allowable_account_types %>
-          <% model_class = "Account::#{params[:type]}".constantize %>
-          Add <%= model_class.model_name.human(count: 2).downcase %>
+        <% model_class = find_model_class(params[:type]) %>
+        <% if model_class %>
+          Add <%= model_class.model_name.human(count: 2) %>
         <% else %>
-          Add account
+          Add Account
         <% end %>
       </span>
     </div>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -66,12 +66,12 @@
       <% end %>
       <span>
         <% if params[:type].in? Account.allowable_account_types %>
-          Account::#{params[:type]}".constantize
-          end %>
-          Add <%= model_class ? model_class.model_name.human(count: 2).downcase : "account" %>
+          <% model_class = "Account::#{params[:type]}".constantize %>
+          Add <%= model_class.model_name.human(count: 2).downcase %>
         <% else %>
-          Add Account
-        ß<% end %>
+          Add account
+        <% end %>
+      </span>
     </div>
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>
       <%= f.hidden_field :accountable_type %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -65,10 +65,13 @@
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
       <span>
-        <% model_class = if params[:type].in?(["Depository", "Investment", "Property", "Vehicle", "Credit", "Loan", "OtherAsset", "OtherLiability"])
-          "Account::#{params[:type]}".constantize
-        end %>
-        Add <%= model_class ? model_class.model_name.human(count: 2).downcase : "account" %>
+        <% if params[:type].in? Account.allowable_account_types %>
+          Account::#{params[:type]}".constantize
+          end %>
+          Add <%= model_class ? model_class.model_name.human(count: 2).downcase : "account" %>
+        <% else %>
+          Add Account
+        ß<% end %>
     </div>
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>
       <%= f.hidden_field :accountable_type %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -65,11 +65,19 @@
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
       <span>
-          <% model_class = "Account::#{params[:type]}".constantize %>
-          Add <%= model_class.model_name.human(count: 2) %>
+        <% if params[:type].present? %>
+          <% allowable_types = ["Depository", "Investment", "Property", "Vehicle", "Credit", "Loan", "OtherAsset", "OtherLiability"] %>
+          <% if allowable_types.include?(params[:type]) %>
+            <% model_class = "Account::#{params[:type]}".constantize %>
+            Add <%= model_class.model_name.human(count: 2) %>
+          <% else %>
+            Add Account
+          <% end %>
+        <% else %>
+          Add Account
+        <% end %>
       </span>
     </div>
-
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>
       <%= f.hidden_field :accountable_type %>
 

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -65,18 +65,10 @@
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
       <span>
-        <% if params[:type].present? %>
-          <% allowable_types = ["Depository", "Investment", "Property", "Vehicle", "Credit", "Loan", "OtherAsset", "OtherLiability"] %>
-          <% if allowable_types.include?(params[:type]) %>
-            <% model_class = "Account::#{params[:type]}".constantize %>
-            Add <%= model_class.model_name.human(count: 2) %>
-          <% else %>
-            Add Account
-          <% end %>
-        <% else %>
-          Add Account
-        <% end %>
-      </span>
+        <% model_class = if params[:type].in?(["Depository", "Investment", "Property", "Vehicle", "Credit", "Loan", "OtherAsset", "OtherLiability"])
+          "Account::#{params[:type]}".constantize
+        end %>
+        Add <%= model_class ? model_class.model_name.human(count: 2).downcase : "account" %>
     </div>
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>
       <%= f.hidden_field :accountable_type %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -64,7 +64,10 @@
       <%= link_to new_account_path(step: 'method', type: params[:type]), class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-[#141414]/5" do %>
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
-      <span>Add account</span>
+      <span>
+          <% model_class = "Account::#{params[:type]}".constantize %>
+          Add <%= model_class.model_name.human(count: 2) %>
+      </span>
     </div>
 
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>


### PR DESCRIPTION
Fixes #382 The change currently only works for adding a 'Bank Account' as adding other types of accounts only creates a new Bank Account. When new types of accounts are added this will use the account name in the models as the title.

Signed-off-by: 2000rosser
