### PR TITLE
Use account_type name for Add Account modal

### DIFF
--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -64,7 +64,9 @@
       <%= link_to new_account_path(step: 'method', type: params[:type]), class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-[#141414]/5" do %>
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
-      <span>Add account</span>
+      <% if params[:type].present? && Account.accountable_types.include?("Account::#{params[:type]}") %>
+        <span>Add <%= t('.'+params[:type]) %></span>
+      <% end %>
     </div>
 
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>

--- a/config/locales/views/account/en.yml
+++ b/config/locales/views/account/en.yml
@@ -7,3 +7,13 @@ en:
       title: Cash
     new:
       title: Add an account
+  shared:
+    modal:
+      Depository: Bank Account
+      Credit: Credit Card
+      Investment: Investment
+      Property: Property
+      Vehicle: Vehicle
+      Loan: Loan
+      OtherAsset: Asset
+      OtherLiability: Liability


### PR DESCRIPTION
fixes #382 

![image](https://github.com/maybe-finance/maybe/assets/3138933/ab8a9446-f7c1-4fbc-90a2-3125ff2c08fb)

Just saw #390, but had already started working on this.

@Shpigford what do you think about this approach with the locales?

A little new to ruby, but `t('.'+params[:type]` feels messy. Let me know if there is a better way to implement the translation