### PR TITLE
Fix accountable type references in new account flow

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -2,16 +2,10 @@ class AccountsController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    if params[:type].blank? || Account.accountable_types.include?("Account::#{params[:type]}")
-      @account = if params[:type].blank?
-        Account.new
-      else
-        Account.new(accountable_type: "Account::#{params[:type]}", balance: nil)
-          .tap(&:build_accountable)
-      end
-    else
-      head :not_found
-    end
+    @account = Account.new(
+      balance: nil,
+      accountable: Accountable.from_type(params[:type])&.new
+    )
   end
 
   def show

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -12,8 +12,8 @@ class AccountsController < ApplicationController
   end
 
   def create
-    @account = Current.family.accounts.build(account_params)
-    @account.accountable = account_params[:accountable_type].constantize.new
+    @account = Current.family.accounts.build(account_params.except(:accountable_type))
+    @account.accountable = Accountable.from_type(account_params[:accountable_type])&.new
 
     if @account.save
       redirect_to accounts_path, notice: t(".success")
@@ -26,13 +26,5 @@ class AccountsController < ApplicationController
 
   def account_params
     params.require(:account).permit(:name, :accountable_type, :balance, :balance_cents, :subtype)
-  end
-
-  def account_type_class
-    if params[:type].present? && Account.accountable_types.include?(params[:type])
-      params[:type].constantizes
-    else
-      Account # Default to Account if type is not provided or invalid
-    end
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -7,6 +7,7 @@ class AccountsController < ApplicationController
         Account.new
       else
         Account.new(accountable_type: "Account::#{params[:type]}", balance: nil)
+          .tap(&:build_accountable)
       end
     else
       head :not_found

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,7 @@
 class Account < ApplicationRecord
   belongs_to :family
 
-  delegated_type :accountable, types: %w[ Account::Credit Account::Depository Account::Investment Account::Loan Account::OtherAsset Account::OtherLiability Account::Property Account::Vehicle], dependent: :destroy
+  delegated_type :accountable, types: Accountable::TYPES, dependent: :destroy
 
   delegate :type_name, to: :accountable
 

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -4,8 +4,8 @@ module Accountable
   TYPES = %w[ Account::Credit Account::Depository Account::Investment Account::Loan Account::OtherAsset Account::OtherLiability Account::Property Account::Vehicle ]
 
   def self.from_type(type)
-    return nil unless types.include?(type)
-    "Account::#{type}".constantize
+    return nil unless types.include?(type) || TYPES.include?(type)
+    "Account::#{type.demodulize}".constantize
   end
 
   def self.types

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -1,6 +1,17 @@
 module Accountable
   extend ActiveSupport::Concern
 
+  TYPES = %w[ Account::Credit Account::Depository Account::Investment Account::Loan Account::OtherAsset Account::OtherLiability Account::Property Account::Vehicle ]
+
+  def self.from_type(type)
+    return nil unless types.include?(type)
+    "Account::#{type}".constantize
+  end
+
+  def self.types
+    TYPES.map { |type| type.demodulize }
+  end
+
   included do
     has_one :account, as: :accountable, touch: true
   end

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -42,7 +42,7 @@
       <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious">Previous</button>
       <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
 
-      <%= render "entry_method", type: Account::Depository.new, text: 'Enter account balance manually', icon: "keyboard" %>
+      <%= render "entry_method", type: @account.accountable, text: 'Enter account balance manually', icon: "keyboard" %>
       <%= render "entry_method", type: Account::Depository.new, text: 'Securely link bank account with data provider (coming soon)', icon: "link-2", disabled: true %>
       <%= render "entry_method", type: Account::Depository.new, text: 'Upload spreadsheet (coming soon)', icon: "sheet", disabled: true %>
     </div>
@@ -86,7 +86,7 @@
 
       <div class="">
         <button type="submit" class="w-full p-3 text-center text-white bg-black rounded-lg hover:bg-gray-700" title="Submit">
-          Add account
+          Add <%= @account.accountable.model_name.human.downcase %> 
         </button>
       </div>
     <% end %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-3xl font-semibold font-display"><%= t('.title')%></h1>
 
 <%= modal do %>
-  <% if params[:type].blank? || Account.accountable_types.include?("Account::#{params[:type]}") == false %>
+  <% if @account.accountable.blank? %>
     <div class="border-b border-[#141414]/2 p-4 text-gray-400">
       What would you like to add?
     </div>
@@ -31,7 +31,7 @@
         <span>Close</span> <kbd class="bg-[#141414]/5 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
       </div>
     </div>
-  <% elsif params[:step] == 'method' && params[:type].present? %>
+  <% elsif params[:step] == 'method' && @account.accountable.present? %>
     <div class="border-b border-[#141414]/2 p-4 text-gray-400 flex items-center space-x-3">
       <%= link_to new_account_path, class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-[#141414]/5" do %>
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -43,8 +43,8 @@
       <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
 
       <%= render "entry_method", type: @account.accountable, text: 'Enter account balance manually', icon: "keyboard" %>
-      <%= render "entry_method", type: Account::Depository.new, text: 'Securely link bank account with data provider (coming soon)', icon: "link-2", disabled: true %>
-      <%= render "entry_method", type: Account::Depository.new, text: 'Upload spreadsheet (coming soon)', icon: "sheet", disabled: true %>
+      <%= render "entry_method", type: @account.accountable, text: 'Securely link bank account with data provider (coming soon)', icon: "link-2", disabled: true %>
+      <%= render "entry_method", type: @account.accountable, text: 'Upload spreadsheet (coming soon)', icon: "sheet", disabled: true %>
     </div>
     <div class="border-t border-[#141414]/2 p-4 text-gray-500 text-sm flex justify-between">
       <div class="flex space-x-5">
@@ -64,7 +64,7 @@
       <%= link_to new_account_path(step: 'method', type: params[:type]), class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-[#141414]/5" do %>
         <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
       <% end %>
-      <span>Add account</span>
+      <span>Add <%= @account.accountable.model_name.human.downcase %></span>
     </div>
 
     <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "space-y-4 m-5 mt-1", data: { turbo: false } } do |f| %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,8 +70,8 @@
             <p><%= t('.new_account') %></p>
           <% end %>
 
-          <% Account.accountable_types.each do |type| %>
-            <%= render 'accounts/account_list', type: type.constantize %>
+          <% Accountable.types.each do |type| %>
+            <%= render 'accounts/account_list', type: Accountable.from_type(type) %>
           <% end %>
         </div>
       </div>


### PR DESCRIPTION
This is a bit rushed as it's getting late here but think there's an elegant solution here that can fix some of the issues around calling constantize on the params[:type] all over the place.

This allows you to create accounts of all types using the new account flow now.

Resolves #381 and #382 