### PR TITLE
Show CI badge in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/maybe-finance/maybe/actions/workflows/ci.yml/badge.svg)](https://github.com/maybe-finance/maybe/actions/workflows/ci.yml)
+
 <img width="1440" alt="dashboard" src="https://github.com/maybe-finance/maybe/assets/35243/4910781f-4bea-4a3b-8fb6-21f314548c9d">
 
 <sup><i>(Note: The image above is a mockup of what we're working towards. We're rapidly approaching the functionality shown, but not all of the parts are ready just yet.)</i></sup>


### PR DESCRIPTION
Small change to show badge in Readme file.

Right now just added for existing workflow of CI. Can add later on for Rubocop, Brakeman etc other workflows