### PR TITLE
Alternate static source for exchange rate data

### DIFF
--- a/lib/tasks/currencies.rake
+++ b/lib/tasks/currencies.rake
@@ -19,8 +19,11 @@ namespace :currencies do
       end
 
       puts "Currencies created: #{Currency.count}"
-    elsif currencies.count == 1
-      Currency.find_or_create_by(iso_code: currencies.first)
+    elsif currencies.size.positive?
+      currencies.each do |iso_code|
+        currency_code = iso_code.upcase
+        Currency.find_or_create_by(iso_code: currency_code, name: currency_code)
+      end
     else
       puts "No currencies found in ENV['CURRENCIES']"
     end

--- a/lib/tasks/exchange_rates.rake
+++ b/lib/tasks/exchange_rates.rake
@@ -91,7 +91,11 @@ namespace :exchange_rates do
     DEFAULT_HOUR = "23" # Reference hour of the day to take exchange rates from
     PRECISION = 6 # 6 decimal places
     NDIGITS = 9 + PRECISION # ndigits for millions and enough decimal places
-    Date.parse(FIRST_DATE).upto(Date.today) do |date|
+
+    start_at_date = ExchangeRate.maximum(:date) || Date.parse(FIRST_DATE)
+    puts "Fetching exchange rates from #{start_at_date} to #{Date.today}..."
+
+    start_at_date.upto(Date.today) do |date|
       response = Faraday.get("https://raw.githubusercontent.com/ismartcoding/currency-api/main/#{date.iso8601}/#{DEFAULT_HOUR}.json")
       if response.success?
         rates = JSON.parse(response.body)
@@ -102,7 +106,7 @@ namespace :exchange_rates do
         based_rates = { "USD" => rates_in_usd }
         rates_in_usd.each do |currency_iso_code, value_in_usd|
           based_rates[currency_iso_code] = rates_in_usd.transform_values do |other_currency_value|
-            (BigDecimal(other_currency_value, NDIGITS) / BigDecimal(value_in_usd, NDIGITS)).round(PRECISION).to_f
+            (BigDecimal(other_currency_value, NDIGITS) / BigDecimal(value_in_usd, NDIGITS)).round(PRECISION)
           end
         end
 


### PR DESCRIPTION
Thanks so much for starting Maybe as an opensource project!

I see currency support is being added using the `openexchangerate.org` API. However there is potentially a useful free alternative (at least at the moment) which is https://github.com/ismartcoding/currency-api 

This PR is a first pass at using it as a source for fetching currency data. 

Let me know if this is something you might be interested in adding.
