### PR TITLE
Add Toast partial view and JS controller

### DIFF
--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="toast"
+export default class extends Controller {
+  static targets = ["circle"]
+
+  // time the toast was opened
+  // used to calculate filled percentage of loading circle
+  // automatically set by connect
+  baseTime;
+
+  // this tells the refresh loop to stop refreshing the circle when closing
+  closing = false;
+
+  // closes the toast gracefully
+  closeToast() {
+    this.closing = true;
+    this.element.style.opacity = 0;
+    setTimeout(() => {
+      this.element.remove();
+    }, 500);
+  }
+
+  connect() {
+    // close toast when clicked
+    this.element.addEventListener("click", this.closeToast.bind(this));
+
+    this.baseTime = Date.now();
+
+    // refresh loop: updates loading circle on every animation frame
+    const doRefresh = () => {
+      const progress = (Date.now() - this.baseTime) / 5000;
+
+      if (progress < 1) {
+        // stroke-dasharray is set up on HTML-side using static circle circumference
+        // stroke-dashoffset = circumference * (1 - progress)
+        this.circleTarget.style.strokeDashoffset = 45.238934 * (1 - progress);
+
+        // Don't loop on next frame if toast is being closed
+        if (!this.closing) {
+          requestAnimationFrame(doRefresh);
+        }
+      } else {
+        // if stroke-dashoffset = 0, progress circle is filled
+        this.circleTarget.style.strokeDashoffset = 0;
+        this.closeToast();
+      }
+    }
+
+    // kickstart refresh loop
+    doRefresh();
+  }
+}

--- a/app/views/shared/_toast.html.erb
+++ b/app/views/shared/_toast.html.erb
@@ -14,6 +14,6 @@
     </p>
     <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
         <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5"/>
-        <circle data-toast-target="circle" class="progress-ring__circle origin-center -rotate-90" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="45.238934, 45.238934" stroke-dashoffset="45.238934" />
+        <circle data-toast-target="circle" class="origin-center -rotate-90" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="45.238934, 45.238934" stroke-dashoffset="45.238934" />
     </svg>
 </div>

--- a/app/views/shared/_toast.html.erb
+++ b/app/views/shared/_toast.html.erb
@@ -1,0 +1,19 @@
+<%# locals: (success:, content:) -%>
+<div data-controller="toast" class="absolute right-6 top-6 border border-gray-[#1414140D] bg-white rounded-[.5rem] shadow-xs flex p-4 max-w-[300px] gap-3 transition-opacity duration-500 hover:bg-[#FDFDFD] cursor-pointer">
+    <% if success %>
+        <div class="p-0.5 bg-[#10A861] w-4 h-4 rounded-full m-0.5 shrink-0">
+            <%= lucide_icon("check", class: "w-3 h-3 text-white") %>
+        </div>
+    <% else %>
+        <div class="p-0.5 bg-[#EC2222] w-4 h-4 rounded-full m-0.5 shrink-0">
+            <%= lucide_icon("x", class: "w-3 h-3 text-white") %>
+        </div>
+    <% end %>
+    <p class="leading-tight text-[#141414]">
+        <%= content %>
+    </p>
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
+        <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5"/>
+        <circle data-toast-target="circle" class="progress-ring__circle origin-center -rotate-90" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="45.238934, 45.238934" stroke-dashoffset="45.238934" />
+    </svg>
+</div>


### PR DESCRIPTION
Fixes #447 
/claim #447 

This PR adds a shared partial view `_toast.html.erb`. This partial view can be used to render a notification, like described in #447. The toast's timer and disappearing logic is driven by the `toast_controller.js` Stimulus controller.

A notification can be triggered by rendering the toast view. Examples (from Figma):
```erb
<%= render "shared/toast", success: true, content: "Emergency cash has been successfully created" %>
<%= render "shared/toast", success: false, content: "Account addition failed" %>
```

Opinionated implementation choices:
 - The toast's background turns to `#FDFDFD` when hovered.