### PR TITLE
Add notification UI

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,6 +11,13 @@ module ApplicationHelper
     name.underscore
   end
 
+  def notification(text, **options, &block)
+    content = tag.p(text)
+    content = capture &block if block_given?
+
+    render partial: "shared/notification", locals: { type: options[:type], content: content }
+  end
+
   # Wrap view with <%= modal do %> ... <% end %> to have it open in a modal
   # Make sure to add data-turbo-frame="modal" to the link/button that opens the modal
   def modal(&block)

--- a/app/javascript/controllers/element_removal_controller.js
+++ b/app/javascript/controllers/element_removal_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller="element-removal"
+export default class extends Controller {
+  remove() {
+    this.element.remove()
+  }
+}
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,9 +24,8 @@
   </head>
 
   <body class="h-full">
-    <% if notice = flash[:notice] || flash[:alert] %>
-      <%= notification notice %>
-    <% end %>
+    <div id="notification-tray" class="fixed top-6 right-6 space-y-1 z-50"></div>
+    <%= notification(notice) if notice = flash[:notice] || flash[:alert] %>
 
     <div class="flex">
       <div class="flex-col p-5 min-w-80">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
   <body class="h-full">
     <div id="notification-tray" class="fixed top-6 right-6 space-y-1 z-50"></div>
-    <%= notification(notice) if notice = flash[:notice] || flash[:alert] %>
+    <%= safe_join(flash.map { |type, message| notification(message, type: type) }) %>
 
     <div class="flex">
       <div class="flex-col p-5 min-w-80">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,10 @@
   </head>
 
   <body class="h-full">
+    <% if notice = flash[:notice] || flash[:alert] %>
+      <%= notification notice %>
+    <% end %>
+
     <div class="flex">
       <div class="flex-col p-5 min-w-80">
         <div class="flex items-center justify-between">

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,16 +1,16 @@
 <%# locals: (type: "success", content:) -%>
 
 <div
-  class="fixed top-6 right-6 max-w-80 bg-white shadow-xs border border-[#141414/0.05] border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_6s_300ms_both]"
+  class="fixed top-6 right-6 max-w-80 bg-white shadow-xs border border-alpha-black-50 border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_6s_300ms_both]"
   data-controller="element-removal"
   data-action="click->element-removal#remove animationend->element-removal#remove"
 >
   <% if type == "success" %>
-    <div class="w-[20px] h-[20px] text-white bg-[#10A861] flex shrink-0 items-center justify-center rounded-full">
+    <div class="w-5 h-5 text-white bg-success flex shrink-0 items-center justify-center rounded-full">
       <%= lucide_icon("check", class: "w-3 h-3") %>
     </div>
   <% elsif type == "error" %>
-    <div class="w-[20px] h-[20px] text-white bg-[#EC2222] flex shrink-0 items-center justify-center rounded-full">
+    <div class="w-5 h-5 text-white bg-error flex shrink-0 items-center justify-center rounded-full">
       <%= lucide_icon("x", class: "w-3 h-3") %>
     </div>
   <% end %>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,0 +1,23 @@
+<%# locals: (type: "success", content:) -%>
+
+<div
+  class="fixed top-6 right-6 max-w-80 bg-white shadow-xs border border-[#141414/0.05] border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-appear-then-fade"
+  data-controller="element-removal"
+  data-action="click->element-removal#remove animationend->element-removal#remove"
+  >
+  <% if type == "success" %>
+    <div class="w-[20px] h-[20px] text-white bg-[#10A861] flex shrink-0 items-center justify-center rounded-full">
+      <%= lucide_icon("check", class: "w-3 h-3") %>
+    </div>
+  <% elsif type == "error" %>
+    <div class="w-[20px] h-[20px] text-white bg-[#EC2222] flex shrink-0 items-center justify-center rounded-full">
+      <%= lucide_icon("x", class: "w-3 h-3") %>
+    </div>
+  <% end %>
+
+  <%= content %>
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
+    <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
+    <circle class="origin-center -rotate-90 animate-stroke-fill" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
+  </svg>
+</div>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -16,7 +16,7 @@
       <button aria-label="Close notification" data-action="click->element-removal#remove" class="shrink-0 h-5">
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
           <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
-          <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
+          <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_300ms_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
         </svg>
       </button>
     </div>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,18 +1,21 @@
 <%# locals: (type: "success", content:) -%>
 
-<div
-  class="fixed top-6 right-6 max-w-80 bg-white shadow-xs border border-alpha-black-50 border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_6s_300ms_both]"
-  data-controller="element-removal"
-  data-action="click->element-removal#remove animationend->element-removal#remove"
->
-  <% base_class = "w-5 h-5 p-1 text-white flex shrink-0 items-center justify-center rounded-full" %>
-  <%= lucide_icon("check", class: "#{base_class} bg-success") if type == "success" %>
-  <%= lucide_icon("x", class: "#{base_class} bg-error") if type == "error" %>
+<turbo-stream action="append" target="notification-tray">
+  <template>
+    <div
+      class="max-w-80 bg-white shadow-xs border border-alpha-black-50 border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_6s_300ms_both]"
+      data-controller="element-removal"
+      data-action="click->element-removal#remove animationend->element-removal#remove">
+      <% base_class = "w-5 h-5 p-1 text-white flex shrink-0 items-center justify-center rounded-full" %>
+      <%= lucide_icon("check", class: "#{base_class} bg-success") if type == "success" %>
+      <%= lucide_icon("x", class: "#{base_class} bg-error") if type == "error" %>
 
-  <%= content %>
+      <%= content %>
 
-  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
-    <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
-    <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
-  </svg>
-</div>
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
+        <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
+        <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
+      </svg>
+    </div>
+  </template>
+</turbo-stream>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -4,6 +4,7 @@
   <template>
     <div
       class="max-w-80 bg-white shadow-xs border border-alpha-black-50 border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_5s_300ms_both]"
+      role="<%= type == "error" ? "alert" : "status" %>"
       data-controller="element-removal"
       data-action="click->element-removal#remove animationend->element-removal#remove">
       <% base_class = "w-5 h-5 p-1 text-white flex shrink-0 items-center justify-center rounded-full" %>
@@ -12,10 +13,12 @@
 
       <%= content %>
 
-      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
-        <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
-        <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
-      </svg>
+      <button aria-label="Close notification" data-action="click->element-removal#remove">
+        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
+          <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
+          <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
+        </svg>
+      </button>
     </div>
   </template>
 </turbo-stream>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,10 +1,10 @@
 <%# locals: (type: "success", content:) -%>
 
 <div
-  class="fixed top-6 right-6 max-w-80 bg-white shadow-xs border border-[#141414/0.05] border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-appear-then-fade"
+  class="fixed top-6 right-6 max-w-80 bg-white shadow-xs border border-[#141414/0.05] border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_6s_300ms_both]"
   data-controller="element-removal"
   data-action="click->element-removal#remove animationend->element-removal#remove"
-  >
+>
   <% if type == "success" %>
     <div class="w-[20px] h-[20px] text-white bg-[#10A861] flex shrink-0 items-center justify-center rounded-full">
       <%= lucide_icon("check", class: "w-3 h-3") %>
@@ -16,8 +16,9 @@
   <% end %>
 
   <%= content %>
+
   <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
     <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
-    <circle class="origin-center -rotate-90 animate-stroke-fill" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
+    <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />
   </svg>
 </div>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -5,15 +5,9 @@
   data-controller="element-removal"
   data-action="click->element-removal#remove animationend->element-removal#remove"
 >
-  <% if type == "success" %>
-    <div class="w-5 h-5 text-white bg-success flex shrink-0 items-center justify-center rounded-full">
-      <%= lucide_icon("check", class: "w-3 h-3") %>
-    </div>
-  <% elsif type == "error" %>
-    <div class="w-5 h-5 text-white bg-error flex shrink-0 items-center justify-center rounded-full">
-      <%= lucide_icon("x", class: "w-3 h-3") %>
-    </div>
-  <% end %>
+  <% base_class = "w-5 h-5 p-1 text-white flex shrink-0 items-center justify-center rounded-full" %>
+  <%= lucide_icon("check", class: "#{base_class} bg-success") if type == "success" %>
+  <%= lucide_icon("x", class: "#{base_class} bg-error") if type == "error" %>
 
   <%= content %>
 

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -13,7 +13,7 @@
 
       <%= content %>
 
-      <button aria-label="Close notification" data-action="click->element-removal#remove">
+      <button aria-label="Close notification" data-action="click->element-removal#remove" class="shrink-0 h-5">
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" class="shrink-0">
           <path d="M18 10C18 14.4183 14.4183 18 10 18C5.58172 18 2 14.4183 2 10C2 5.58172 5.58172 2 10 2C14.4183 2 18 5.58172 18 10ZM3.6 10C3.6 13.5346 6.46538 16.4 10 16.4C13.5346 16.4 16.4 13.5346 16.4 10C16.4 6.46538 13.5346 3.6 10 3.6C6.46538 3.6 3.6 6.46538 3.6 10Z" fill="#E5E5E5" />
           <circle class="origin-center -rotate-90 animate-[stroke-fill_5s_linear_forwards]" stroke="#141414" stroke-opacity="0.4" r="7.2" cx="10" cy="10" stroke-dasharray="43.9822971503" stroke-dashoffset="43.9822971503" />

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -3,7 +3,7 @@
 <turbo-stream action="append" target="notification-tray">
   <template>
     <div
-      class="max-w-80 bg-white shadow-xs border border-alpha-black-50 border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_6s_300ms_both]"
+      class="max-w-80 bg-white shadow-xs border border-alpha-black-50 border-solid py-3 px-4 rounded-[10px] text-sm font-medium flex gap-3 animate-[appear-then-fade_5s_300ms_both]"
       data-controller="element-removal"
       data-action="click->element-removal#remove animationend->element-removal#remove">
       <% base_class = "w-5 h-5 p-1 text-white flex shrink-0 items-center justify-center rounded-full" %>

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -8,8 +8,7 @@
       data-controller="element-removal"
       data-action="click->element-removal#remove animationend->element-removal#remove">
       <% base_class = "w-5 h-5 p-1 text-white flex shrink-0 items-center justify-center rounded-full" %>
-      <%= lucide_icon("check", class: "#{base_class} bg-success") if type == "success" %>
-      <%= lucide_icon("x", class: "#{base_class} bg-error") if type == "error" %>
+      <%= type.in?(["error", "alert"]) ? lucide_icon("x", class: "#{base_class} bg-error") : lucide_icon("check", class: "#{base_class} bg-success") %>
 
       <%= content %>
 

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -207,7 +207,7 @@ module.exports = {
       keyframes: {
         'appear-then-fade': {
           '0%,100%': { opacity: 0 },
-          '5%,60%': { opacity: 1 },
+          '5%,90%': { opacity: 1 },
         },
         'stroke-fill': {
           to: { 'stroke-dashoffset': 0 },

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -204,6 +204,19 @@ module.exports = {
       fontSize: {
         "2xs": ".625rem",
       },
+      animation: {
+        'appear-then-fade': 'appear-then-fade 6s 300ms both',
+        'stroke-fill': 'stroke-fill 5s linear forwards',
+      },
+      keyframes: {
+        'appear-then-fade': {
+          '0%,100%': { opacity: 0 },
+          '5%,60%': { opacity: 1 },
+        },
+        'stroke-fill': {
+          to: { 'stroke-dashoffset': 0 },
+        }
+      }
     },
   },
   plugins: [

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -204,10 +204,6 @@ module.exports = {
       fontSize: {
         "2xs": ".625rem",
       },
-      animation: {
-        'appear-then-fade': 'appear-then-fade 6s 300ms both',
-        'stroke-fill': 'stroke-fill 5s linear forwards',
-      },
       keyframes: {
         'appear-then-fade': {
           '0%,100%': { opacity: 0 },


### PR DESCRIPTION
Resolves #447
/claim #447

This approach uses a simple stimulus controller to remove the element after the animation has completed.

Notifications can be generated by simply rendering a notification helper anywhere within the application, this could be in a view, as a turbo stream response, or over a turbo stream subscription. By default Rails flash messages types are mapped to notification types, icons for additional types can easily be added in future.

It supports multiple notifications at once, by stacking them in a notification-tray element.

The video below demonstrates the default flash messages in action, and then I update the code to force some hardcoded notifications where the type is passed as error or success.

https://github.com/maybe-finance/maybe/assets/1793797/a17f7e7f-e647-4250-b64e-bb3964cdda81

The circle is animated with CSS also using an SVG animation stroke fill animation technique (https://css-tricks.com/svg-line-animation-works/)
