### PR TITLE
Fixed Migration Errors

### DIFF
--- a/db/migrate/20240206031739_replace_money_field.rb
+++ b/db/migrate/20240206031739_replace_money_field.rb
@@ -1,7 +1,6 @@
 class ReplaceMoneyField < ActiveRecord::Migration[7.2]
   def change
-    add_column :accounts, :balance_cents
-    change_column :accounts, :balance_cents, :integer, limit: 8
+    add_column :accounts, :balance_cents, :integer, limit: 8
 
     Account.reset_column_information
 

--- a/db/migrate/20240209174912_redo_money_storage.rb
+++ b/db/migrate/20240209174912_redo_money_storage.rb
@@ -6,7 +6,7 @@ class RedoMoneyStorage < ActiveRecord::Migration[7.2]
     add_column :accounts, :converted_currency, :string, default: "USD"
 
     remove_column :accounts, :balance_cents
-    remove_column :accounts, :balance_currency
+    # remove_column :accounts, :balance_currency
     remove_column :accounts, :currency
   end
 end


### PR DESCRIPTION
When attempting to migrate new model/database code into the schema on a different branch, I encountered errors in redo_money_storage.rb and replace_money_field.rb which I described here:
https://discord.com/channels/1191501936281784361/1194410011863035904/1207137319572742144

This branch implements the changes discussed in the subsequent Discord posts (I've only commented out balance_currency under the assumption that it will be implemented later).