### PR TITLE
Update database migrations and strengthen db smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
-        run: bin/rails db:reset
+        run: bin/rails db:drop db:create db:migrate db:seed
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/db/migrate/20240206031739_replace_money_field.rb
+++ b/db/migrate/20240206031739_replace_money_field.rb
@@ -1,6 +1,6 @@
 class ReplaceMoneyField < ActiveRecord::Migration[7.2]
   def change
-    add_column :accounts, :balance_cents
+    add_column :accounts, :balance_cents, :integer
     change_column :accounts, :balance_cents, :integer, limit: 8
 
     Account.reset_column_information

--- a/db/migrate/20240209174912_redo_money_storage.rb
+++ b/db/migrate/20240209174912_redo_money_storage.rb
@@ -6,7 +6,6 @@ class RedoMoneyStorage < ActiveRecord::Migration[7.2]
     add_column :accounts, :converted_currency, :string, default: "USD"
 
     remove_column :accounts, :balance_cents
-    remove_column :accounts, :balance_currency
     remove_column :accounts, :currency
   end
 end


### PR DESCRIPTION
Follow up to the talks in #459 

- fix migrations
- strengthen the db smoke test to run the full db:drop db:create db:migrate db:seed steps

Co-authored-by: Christian Helgeson <62450112+cmhhelgeson@users.noreply.github.com>
