### PR TITLE
docs: add dev containers config gotcha in README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,6 @@ SMTP_PASSWORD=
 TLS=true
 
 # Database Configuration
-DB_HOST=localhost
+DB_HOST=localhost # May need to be changed to `DB_HOST=db` if using devcontainer
 POSTGRES_PASSWORD=postgres
 POSTGRES_USER=postgres

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you'd like multi-currency support, there are a few extra steps to follow.
 
 This is 100% optional and meant for devs who don't want to worry about installing requirements manually for their platform. You can follow [this guide](https://code.visualstudio.com/docs/devcontainers/containers) to learn more about Dev Containers.
 
+If you run into `could not connect to server` errors, you may need to change your `.env`'s `DB_HOST` environment variable value to `db` to point to the Postgres container.
+
 #### Mac
 
 Please visit our [Mac dev setup guide](https://github.com/maybe-finance/maybe/wiki/Mac-Dev-Setup-Guide).


### PR DESCRIPTION
# Overview

This is a small README update for devs who choose to use dev containers to work on the project. When setting this up on my machine (Fedora Asahi Linux running on an M2 MacBook Air) via the [dev containers CLI](https://github.com/devcontainers/cli), I ran into an issue where the Rails server kept throwing a `could not connect to server: Cannot assign requested address` error. The issue was that the `.env` file that I copied from `.env.example` was trying to connect to `DB_HOST=localhost` when it needed to be pointed at `DB_HOST=db` in the Docker Compose setup.

This adds a sentence in the README to address this and it also adds a comment in `.env.example` next to the relevant line.

And as a side note, I'm very excited that you all have decided to open source this lovely project. I'm looking forward to keeping up with its developments and would love to contribute when I can.