### PR TITLE
chore: add ability to change DB_PORT from standard 5432

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,5 +26,6 @@ TLS=true
 
 # Database Configuration
 DB_HOST=localhost
+DB_PORT=5432
 POSTGRES_PASSWORD=postgres
 POSTGRES_USER=postgres

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,6 +19,7 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
+  port: <%= ENV.fetch("DB_PORT") { "5432" } %>
   password: <%= ENV.fetch("POSTGRES_PASSWORD") { nil } %>
   user: <%= ENV.fetch("POSTGRES_USER") { nil } %>
 


### PR DESCRIPTION
Add the ability to change the default port config in the database.yml with a new env variable: `DB_PORT`