### PR TITLE
Find account first and build transaction through association

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -17,12 +17,9 @@ class TransactionsController < ApplicationController
   end
 
   def create
-    @transaction = Transaction.new(transaction_params)
     account = Current.family.accounts.find(params[:transaction][:account_id])
 
-    raise ActiveRecord::RecordNotFound, "Account not found or not accessible" if account.nil?
-
-    @transaction.account = account
+    @transaction = account.transactions.build(transaction_params)
 
     respond_to do |format|
       if @transaction.save

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -17,11 +17,12 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should create transaction" do
+    name = "transaction_name"
     assert_difference("Transaction.count") do
-      post transactions_url, params: { transaction: { account_id: @transaction.account_id, amount: @transaction.amount, currency: @transaction.currency, date: @transaction.date, name: @transaction.name } }
+      post transactions_url, params: { transaction: { account_id: @transaction.account_id, amount: @transaction.amount, currency: @transaction.currency, date: @transaction.date, name: } }
     end
 
-    assert_redirected_to transaction_url(Transaction.last)
+    assert_redirected_to transaction_url(Transaction.find_by(name:))
   end
 
   test "should show transaction" do


### PR DESCRIPTION
`find` should throw `ActiveRecord::RecordNotFound` if it can't find the record, so there's no need to manually raise.

You can then simply build the transaction through that association.

(It may make sense to nest this endpoint like a Rails resource... `/accounts/123/transaction` and access the account ID that way instead of passing it through as a param).