### PR TITLE
Prepare fixture data for account sync tests

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,7 +3,7 @@ class AccountsController < ApplicationController
 
   def new
     @account = Account.new(
-      original_balance: nil,
+      balance: nil,
       accountable: Accountable.from_type(params[:type])&.new
     )
   end
@@ -41,6 +41,6 @@ class AccountsController < ApplicationController
   private
 
   def account_params
-    params.require(:account).permit(:name, :accountable_type, :original_balance, :original_currency, :subtype)
+    params.require(:account).permit(:name, :accountable_type, :balance, :currency, :subtype)
   end
 end

--- a/app/jobs/convert_currency_job.rb
+++ b/app/jobs/convert_currency_job.rb
@@ -6,11 +6,11 @@ class ConvertCurrencyJob < ApplicationJob
 
     # Convert all account balances to new currency
     family.accounts.each do |account|
-      if account.original_currency == family.currency
-        account.converted_balance = account.original_balance
-        account.converted_currency = account.original_currency
+      if account.currency == family.currency
+        account.converted_balance = account.balance
+        account.converted_currency = account.currency
       else
-        account.converted_balance = ExchangeRate.convert(account.original_currency, family.currency, account.original_balance)
+        account.converted_balance = ExchangeRate.convert(account.currency, family.currency, account.balance)
         account.converted_currency = family.currency
       end
       account.save!

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -37,11 +37,11 @@ class Account < ApplicationRecord
   end
 
   def check_currency
-    if self.original_currency == self.family.currency
-      self.converted_balance = self.original_balance
-      self.converted_currency = self.original_currency
+    if self.currency == self.family.currency
+      self.converted_balance = self.balance
+      self.converted_currency = self.currency
     else
-      self.converted_balance = ExchangeRate.convert(self.original_currency, self.family.currency, self.original_balance)
+      self.converted_balance = ExchangeRate.convert(self.currency, self.family.currency, self.balance)
       self.converted_currency = self.family.currency
     end
   end

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -27,7 +27,7 @@
           </div>
         </div>
         <div class="flex items-center space-x-2">
-          <span>Close</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+          <button data-action="modal#close">Close</button> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
         </div>
       </div>
     <% elsif params[:step] == 'method' && @account.accountable.present? %>
@@ -54,7 +54,7 @@
           </div>
         </div>
         <div class="flex items-center space-x-2">
-          <span>Close</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+          <button data-action="modal#close">Close</button> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
         </div>
       </div>
     <% else %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -1,90 +1,82 @@
 <h1 class="text-3xl font-semibold font-display"><%= t('.title')%></h1>
-
 <%= modal do %>
   <div class="flex flex-col min-h-[530px]" data-controller="list-keyboard-navigation">
-  <% if @account.accountable.blank? %>
-    <div class="border-b border-alpha-black-25 p-4 text-gray-400">
-      <%= t '.select_accountable_type' %>
-    </div>
-    <div class="flex flex-col p-2 text-sm grow">
-      <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious">Previous</button>
-      <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
-
-      <%= render "account_type", type: Account::Depository.new, bg_color: "bg-blue-50", text_color: "text-blue-500", icon: "landmark" %>
-      <%= render "account_type", type: Account::Investment.new, bg_color: "bg-green-50", text_color: "text-green-500", icon: "line-chart" %>
-      <%= render "account_type", type: Account::Property.new, bg_color: "bg-pink-50", text_color: "text-pink-500", icon: "home" %>
-      <%= render "account_type", type: Account::Vehicle.new, bg_color: "bg-indigo-50", text_color: "text-indigo-500", icon: "car-front" %>
-      <%= render "account_type", type: Account::Credit.new, bg_color: "bg-violet-50", text_color: "text-violet-500", icon: "credit-card" %>
-      <%= render "account_type", type: Account::Loan.new, bg_color: "bg-yellow-50", text_color: "text-yellow-500", icon: "hand-coins" %>
-      <%= render "account_type", type: Account::OtherAsset.new, bg_color: "bg-green-50", text_color: "text-green-500", icon: "plus" %>
-      <%= render "account_type", type: Account::OtherLiability.new, bg_color: "bg-red-50", text_color: "text-red-500", icon: "minus" %>
-    </div>
-    <div class="border-t border-alpha-black-25 p-4 text-gray-500 text-sm flex justify-between">
-      <div class="flex space-x-5">
-        <div class="flex items-center space-x-2">
-          <span>Select</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('corner-down-left', class: 'inline w-3 h-3')%></kbd>
+    <% if @account.accountable.blank? %>
+      <div class="border-b border-alpha-black-25 p-4 text-gray-400">
+        <%= t '.select_accountable_type' %>
+      </div>
+      <div class="flex flex-col p-2 text-sm grow">
+        <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious">Previous</button>
+        <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
+        <%= render "account_type", type: Account::Depository.new, bg_color: "bg-blue-50", text_color: "text-blue-500", icon: "landmark" %>
+        <%= render "account_type", type: Account::Investment.new, bg_color: "bg-green-50", text_color: "text-green-500", icon: "line-chart" %>
+        <%= render "account_type", type: Account::Property.new, bg_color: "bg-pink-50", text_color: "text-pink-500", icon: "home" %>
+        <%= render "account_type", type: Account::Vehicle.new, bg_color: "bg-indigo-50", text_color: "text-indigo-500", icon: "car-front" %>
+        <%= render "account_type", type: Account::Credit.new, bg_color: "bg-violet-50", text_color: "text-violet-500", icon: "credit-card" %>
+        <%= render "account_type", type: Account::Loan.new, bg_color: "bg-yellow-50", text_color: "text-yellow-500", icon: "hand-coins" %>
+        <%= render "account_type", type: Account::OtherAsset.new, bg_color: "bg-green-50", text_color: "text-green-500", icon: "plus" %>
+        <%= render "account_type", type: Account::OtherLiability.new, bg_color: "bg-red-50", text_color: "text-red-500", icon: "minus" %>
+      </div>
+      <div class="border-t border-alpha-black-25 p-4 text-gray-500 text-sm flex justify-between">
+        <div class="flex space-x-5">
+          <div class="flex items-center space-x-2">
+            <span>Select</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('corner-down-left', class: 'inline w-3 h-3')%></kbd>
+          </div>
+          <div class="flex items-center space-x-2">
+            <span>Navigate</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-up', class: 'inline w-3 h-3')%></kbd> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-down', class: 'inline w-3 h-3')%></kbd>
+          </div>
         </div>
         <div class="flex items-center space-x-2">
-          <span>Navigate</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-up', class: 'inline w-3 h-3')%></kbd> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-down', class: 'inline w-3 h-3')%></kbd>
+          <span>Close</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
         </div>
       </div>
-      <div class="flex items-center space-x-2">
-        <span>Close</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+    <% elsif params[:step] == 'method' && @account.accountable.present? %>
+      <div class="border-b border-alpha-black-25 p-4 text-gray-400 flex items-center space-x-3">
+        <%= link_to new_account_path, class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-alpha-black-50 back focus:outline-gray-300 focus:outline" do %>
+          <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
+        <% end %>
+        <span>How would you like to add it?</span>
       </div>
-    </div>
-  <% elsif params[:step] == 'method' && @account.accountable.present? %>
-    <div class="border-b border-alpha-black-25 p-4 text-gray-400 flex items-center space-x-3">
-      <%= link_to new_account_path, class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-alpha-black-50 back focus:outline-gray-300 focus:outline" do %>
-        <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
-      <% end %>
-      <span>How would you like to add it?</span>
-    </div>
-    <div class="flex flex-col p-2 text-sm grow">
-      <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious">Previous</button>
-      <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
-
-      <%= render "entry_method", type: @account.accountable, text: 'Enter account balance manually', icon: "keyboard" %>
-      <%= render "entry_method", type: @account.accountable, text: 'Securely link bank account with data provider (coming soon)', icon: "link-2", disabled: true %>
-      <%= render "entry_method", type: @account.accountable, text: 'Upload spreadsheet (coming soon)', icon: "sheet", disabled: true %>
-    </div>
-    <div class="border-t border-alpha-black-25 p-4 text-gray-500 text-sm flex justify-between">
-      <div class="flex space-x-5">
+      <div class="flex flex-col p-2 text-sm grow">
+        <button hidden data-controller="hotkey" data-hotkey="k,K,ArrowUp,ArrowLeft" data-action="list-keyboard-navigation#focusPrevious">Previous</button>
+        <button hidden data-controller="hotkey" data-hotkey="j,J,ArrowDown,ArrowRight" data-action="list-keyboard-navigation#focusNext">Next</button>
+        <%= render "entry_method", type: @account.accountable, text: 'Enter account balance manually', icon: "keyboard" %>
+        <%= render "entry_method", type: @account.accountable, text: 'Securely link bank account with data provider (coming soon)', icon: "link-2", disabled: true %>
+        <%= render "entry_method", type: @account.accountable, text: 'Upload spreadsheet (coming soon)', icon: "sheet", disabled: true %>
+      </div>
+      <div class="border-t border-alpha-black-25 p-4 text-gray-500 text-sm flex justify-between">
+        <div class="flex space-x-5">
+          <div class="flex items-center space-x-2">
+            <span>Select</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('corner-down-left', class: 'inline w-3 h-3')%></kbd>
+          </div>
+          <div class="flex items-center space-x-2">
+            <span>Navigate</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-up', class: 'inline w-3 h-3')%></kbd> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-down', class: 'inline w-3 h-3')%></kbd>
+          </div>
+        </div>
         <div class="flex items-center space-x-2">
-          <span>Select</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('corner-down-left', class: 'inline w-3 h-3')%></kbd>
-        </div>
-        <div class="flex items-center space-x-2">
-          <span>Navigate</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-up', class: 'inline w-3 h-3')%></kbd> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon('arrow-down', class: 'inline w-3 h-3')%></kbd>
+          <span>Close</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
         </div>
       </div>
-      <div class="flex items-center space-x-2">
-        <span>Close</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+    <% else %>
+      <div class="border-b border-alpha-black-25 p-4 text-gray-800 flex items-center space-x-3">
+        <%= link_to new_account_path(step: 'method', type: params[:type]), class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-alpha-black-50 focus:outline-gray-300 focus:outline" do %>
+          <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
+        <% end %>
+        <span>Add <%= @account.accountable.model_name.human.downcase %></span>
       </div>
-    </div>
-  <% else %>
-    <div class="border-b border-alpha-black-25 p-4 text-gray-800 flex items-center space-x-3">
-      <%= link_to new_account_path(step: 'method', type: params[:type]), class: "flex w-8 h-8 shrink-0 grow-0 items-center justify-center rounded-lg bg-alpha-black-50 focus:outline-gray-300 focus:outline" do %>
-        <%= lucide_icon('arrow-left', class: 'text-gray-500 w-5 h-5') %>
-      <% end %>
-      <span>Add <%= @account.accountable.model_name.human.downcase %></span>
-    </div>
-
-    <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "m-5 mt-1 flex flex-col justify-between grow", data: { turbo: false } } do |f| %>
+      <%= form_with model: @account, url: accounts_path, scope: :account, html: { class: "m-5 mt-1 flex flex-col justify-between grow", data: { turbo: false } } do |f| %>
         <div class="space-y-4 grow">
           <%= f.hidden_field :accountable_type %>
-
           <%= f.text_field :name, placeholder: t('accounts.new.name.placeholder'), required: 'required', label: t('accounts.new.name.label'), autofocus: true %>
-
           <%= render "accounts/#{permitted_accountable_partial(@account.accountable_type)}", f: f %>
-
-        <%= form_field_tag do %>
-          <%= f.label :original_balance, class: "form-field__label" %>
-          <%= f.number_field :original_balance, step: :any, placeholder: number_to_currency(0), in: 0.00..100000000.00, required: 'required', class: 'form-field__input max-w-[80%]' %>
-          <%= currency_dropdown(f: f, options: Currency.all.order(:iso_code).pluck(:iso_code)) if Currency.count > 1 %>
-        <% end %>
-      </div>
-
-      <%= f.submit "Add #{@account.accountable.model_name.human.downcase}" %>
+          <%= form_field_tag do %>
+            <%= f.label :balance, class: "form-field__label" %>
+            <%= f.number_field :balance, step: :any, placeholder: number_to_currency(0), in: 0.00..100000000.00, required: 'required', class: 'form-field__input max-w-[80%]' %>
+            <%= currency_dropdown(f: f, options: Currency.all.order(:iso_code).pluck(:iso_code)) if Currency.count > 1 %>
+          <% end %>
+        </div>
+        <%= f.submit "Add #{@account.accountable.model_name.human.downcase}" %>
+      <% end %>
     <% end %>
-  <% end %>
   </div>
 <% end %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -11,7 +11,7 @@
     <div class="flex items-center gap-3">
       <div class="relative cursor-not-allowed">
         <div class="flex items-center gap-2 px-3 py-2">
-          <span class="text-gray-900"><%= @account.original_currency %> <%= @account.original_currency.unit %></span>
+          <span class="text-gray-900"><%= @account.currency %> <%= @account.currency.unit %></span>
           <%= lucide_icon("chevron-down", class: "w-5 h-5 text-gray-500") %>
         </div>
       </div>
@@ -29,10 +29,10 @@
         <p class="text-sm text-gray-500">Total Value</p>
         <%# TODO: Will need a better way to split a formatted monetary value into these 3 parts %>
         <p class="text-gray-900">
-          <span class="text-gray-500"><%= @account.original_currency.unit %></span>
-          <span class="text-xl font-medium"><%= format_currency(@account.original_balance, precision: 0, unit: '') %></span>
-          <%- if @account.original_currency.precision.positive? -%>
-            <span class="text-gray-500"><%= @account.original_currency.separator %><%= @account.original_balance.cents(precision: @account.original_currency.precision) %></span>
+          <span class="text-gray-500"><%= @account.currency.unit %></span>
+          <span class="text-xl font-medium"><%= format_currency(@account.balance, precision: 0, unit: '') %></span>
+          <%- if @account.currency.precision.positive? -%>
+            <span class="text-gray-500"><%= @account.currency.separator %><%= @account.balance.cents(precision: @account.currency.precision) %></span>
           <% end %>
         </p>
         <% if @balance_series.nil? %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -29,9 +29,9 @@
         <p class="text-sm text-gray-500">Total Value</p>
         <%# TODO: Will need a better way to split a formatted monetary value into these 3 parts %>
         <p class="text-gray-900">
-          <span class="text-gray-500"><%= number_to_currency(@account.original_balance)[0] %></span>
-          <span class="text-xl font-medium"><%= number_with_delimiter(@account.original_balance.round) %></span>
-          <span class="text-gray-500">.<%= number_to_currency(@account.original_balance, precision: 2)[-2, 2] %></span>
+          <span class="text-gray-500"><%= number_to_currency(@account.balance)[0] %></span>
+          <span class="text-xl font-medium"><%= number_with_delimiter(@account.balance.round) %></span>
+          <span class="text-gray-500">.<%= number_to_currency(@account.balance, precision: 2)[-2, 2] %></span>
         </p>
         <% if @balance_series.nil? %>
           <p class="text-sm text-gray-500">Data not available for the selected period</p>

--- a/app/views/shared/_currency_dropdown.html.erb
+++ b/app/views/shared/_currency_dropdown.html.erb
@@ -1,14 +1,14 @@
 <div data-controller="currency-dropdown" class="absolute right-1 bottom-[10px] flex items-end">
   <button type="button" class="flex items-center justify-between w-20 px-2 py-1 text-sm rounded-lg hover:bg-gray-100 focus:bg-gray-100" data-action="click->currency-dropdown#toggleMenu">
-    <div data-currency-dropdown-target="label"><%= f.object.original_currency %></div>
+    <div data-currency-dropdown-target="label"><%= f.object.currency %></div>
     <%# Example of how account currency value is updated %>
-    <%= f.hidden_field :original_currency, data: {currency_dropdown_target: "input"} %>
+    <%= f.hidden_field :currency, data: {currency_dropdown_target: "input"} %>
     <%= lucide_icon("chevron-down", class: "text-gray-500 w-5 h-5" ) %>
   </button>
   <ul data-currency-dropdown-target="menu" class="hidden fixed p-1 bg-white rounded-[10px] min-w-[112px] z-50 translate-y-2 border border-alpha-black-100 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)]">
     <% options.each do |option| %>
-      <li data-action="click->currency-dropdown#selectOption" data-currency-dropdown-target="option" data-value="<%= option %>" class="flex justify-between items-center p-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer rounded-lg <%= "bg-gray-100" if option === f.object.original_currency %>"><%= option %>
-        <%= inline_svg_tag('icn-check.svg', class: "text-gray-500 fill-current #{'hidden'if option != f.object.original_currency}") %>
+      <li data-action="click->currency-dropdown#selectOption" data-currency-dropdown-target="option" data-value="<%= option %>" class="flex justify-between items-center p-2 text-sm text-gray-700 hover:bg-gray-100 cursor-pointer rounded-lg <%= "bg-gray-100" if option === f.object.currency %>"><%= option %>
+        <%= inline_svg_tag('icn-check.svg', class: "text-gray-500 fill-current #{'hidden'if option != f.object.currency}") %>
       </li>
     <% end %>
   </ul>

--- a/config/locales/models/account/en.yml
+++ b/config/locales/models/account/en.yml
@@ -3,11 +3,11 @@ en:
   activerecord:
     attributes:
       account:
+        balance: Balance
+        currency: Currency
         family: Family
         family_id: Family
         name: Name
-        balance: Balance
-        currency: Currency
         subtype: Subtype
     models:
       account: Account

--- a/config/locales/models/account/en.yml
+++ b/config/locales/models/account/en.yml
@@ -6,8 +6,8 @@ en:
         family: Family
         family_id: Family
         name: Name
-        original_balance: Balance
-        original_currency: Currency
+        balance: Balance
+        currency: Currency
         subtype: Subtype
     models:
       account: Account

--- a/db/migrate/20240227142457_rename_account_balance.rb
+++ b/db/migrate/20240227142457_rename_account_balance.rb
@@ -1,0 +1,6 @@
+class RenameAccountBalance < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :accounts, :original_balance, :balance
+    rename_column :accounts, :original_currency, :currency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,7 +79,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_02_27_142457) do
     t.decimal "converted_balance", precision: 19, scale: 4, default: "0.0"
     t.string "converted_currency", default: "USD"
     t.string "status", default: "OK"
-    t.date "start_date"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["family_id"], name: "index_accounts_on_family_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_02_23_162105) do
+ActiveRecord::Schema[7.2].define(version: 2024_02_27_142457) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -74,11 +74,12 @@ ActiveRecord::Schema[7.2].define(version: 2024_02_23_162105) do
     t.datetime "updated_at", null: false
     t.string "accountable_type"
     t.uuid "accountable_id"
-    t.decimal "original_balance", precision: 19, scale: 4, default: "0.0"
-    t.string "original_currency", default: "USD"
+    t.decimal "balance", precision: 19, scale: 4, default: "0.0"
+    t.string "currency", default: "USD"
     t.decimal "converted_balance", precision: 19, scale: 4, default: "0.0"
     t.string "converted_currency", default: "USD"
     t.string "status", default: "OK"
+    t.date "start_date"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["family_id"], name: "index_accounts_on_family_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ Currency.find_or_create_by(iso_code: "USD", name: "United States Dollar")
 
 current_balance = 350000
 
-account = Account.create_or_find_by(name: "Seed Property Account", accountable: Account::Property.new, family: family, original_balance: current_balance, original_currency: "USD")
+account = Account.create_or_find_by(name: "Seed Property Account", accountable: Account::Property.new, family: family, balance: current_balance, currency: "USD")
 puts "Account created: #{account.name}"
 
 # Represent user-defined "Valuations" at various dates

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class AccountsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in @user = users(:bob)
-    @account = accounts(:dylan_checking)
+    sign_in @user = users(:family_admin)
+    @account = accounts(:generic)
   end
 
   test "new" do

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in users(:bob)
+    sign_in users(:family_admin)
   end
 
   test "dashboard" do

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @user = users(:bob)
+    @user = users(:family_admin)
   end
 
   test "new" do

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class TransactionsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in @user = users(:bob)
-    @transaction = transactions(:one)
+    sign_in @user = users(:family_admin)
+    @transaction = transactions(:checking_one)
   end
 
   test "should get index" do

--- a/test/controllers/valuations_controller_test.rb
+++ b/test/controllers/valuations_controller_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class ValuationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in @user = users(:bob)
-    @account = accounts(:dylan_checking)
+    sign_in @user = users(:family_admin)
+    @account = accounts(:generic)
   end
 
   test "new" do

--- a/test/fixtures/account/credits.yml
+++ b/test/fixtures/account/credits.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account/depositories.yml
+++ b/test/fixtures/account/depositories.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one: {}
-# column: value
-#
-two: {}
-# column: value
+checking: {}

--- a/test/fixtures/account/investments.yml
+++ b/test/fixtures/account/investments.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account/loans.yml
+++ b/test/fixtures/account/loans.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account/other_assets.yml
+++ b/test/fixtures/account/other_assets.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account/other_liabilities.yml
+++ b/test/fixtures/account/other_liabilities.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account/properties.yml
+++ b/test/fixtures/account/properties.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account/vehicles.yml
+++ b/test/fixtures/account/vehicles.yml
@@ -1,11 +1,1 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the "{}" from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 one: {}
-# column: value
-#
-two: {}
-# column: value

--- a/test/fixtures/account_balances.yml
+++ b/test/fixtures/account_balances.yml
@@ -1,13 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  account: dylan_checking
-  date: 2024-02-12
-  balance: 9.99
-  currency: MyString
+# one:
+#   account: generic
+#   date: 2024-02-12
+#   balance: 9.99
+#   currency: MyString
 
-two:
-  account: richards_savings
-  date: 2024-02-12
-  balance: 9.99
-  currency: MyString
+# two:
+#   account: generic
+#   date: 2024-02-13
+#   balance: 9.99
+#   currency: MyString

--- a/test/fixtures/accounts.yml
+++ b/test/fixtures/accounts.yml
@@ -1,14 +1,23 @@
-dylan_checking:
+# No transactions, no valuations, just a generic account
+generic:
   family: dylan_family
-  name: Bob's Checking
-  original_balance: 1200
+  name: No history, generic account
+  balance: 1200
 
-dylan_roth:
+# Account with only valuations
+collectible:
   family: dylan_family
-  name: Bob's Roth IRA
-  original_balance: 1200
+  name: Collectible Account
+  balance: 500
 
-richards_savings:
-  family: richards_family
-  name: Keef's HYSA
-  original_balance: 1500
+# Account with only transactions
+checking:
+  family: dylan_family
+  name: Checking Account
+  balance: 5000
+
+# Account with both transactions and valuations
+savings_with_valuation_overrides:
+  family: dylan_family
+  name: Savings account with valuation overrides
+  balance: 20000

--- a/test/fixtures/exchange_rates.yml
+++ b/test/fixtures/exchange_rates.yml
@@ -1,13 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  base_currency: one
-  converted_currency: one
-  rate: 9.99
-  date: 2024-02-09
+# one:
+#   base_currency: one
+#   converted_currency: one
+#   rate: 9.99
+#   date: 2024-02-09
 
-two:
-  base_currency: two
-  converted_currency: two
-  rate: 9.99
-  date: 2024-02-09
+# two:
+#   base_currency: two
+#   converted_currency: two
+#   rate: 9.99
+#   date: 2024-02-09

--- a/test/fixtures/families.yml
+++ b/test/fixtures/families.yml
@@ -1,7 +1,2 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 dylan_family:
   name: The Dylan Family
-
-richards_family:
-  name: The Richards Family

--- a/test/fixtures/transactions.yml
+++ b/test/fixtures/transactions.yml
@@ -1,15 +1,55 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# Checking account transactions
+checking_one:
+  name: Starbucks
+  date: <%= 5.days.ago.to_date %>
+  amount: 10
+  account: checking
 
-one:
-  name: MyString
-  date: 2024-02-23
-  amount: 9.99
-  currency: MyString
-  account: dylan_checking
+checking_two:
+  name: Chipotle
+  date: <%= 12.days.ago.to_date %>
+  amount: 30
+  account: checking
 
-two:
-  name: MyString
-  date: 2024-02-20
-  amount: 9.99
-  currency: MyString
-  account: dylan_checking
+checking_three:
+  name: Amazon
+  date: <%= 15.days.ago.to_date %>
+  amount: 20
+  account: checking
+
+checking_four:
+  name: Paycheck
+  date: <%= 22.days.ago.to_date %>
+  amount: -1075
+  account: checking
+
+checking_five:
+  name: Netflix
+  date: <%= 30.days.ago.to_date %>
+  amount: 15
+  account: checking
+
+# Savings account that has these transactions and valuation overrides
+savings_one:
+  name: Interest Received
+  date: <%= 5.days.ago.to_date %>
+  amount: -200
+  account: savings_with_valuation_overrides
+
+savings_two:
+  name: Check Deposit
+  date: <%= 12.days.ago.to_date %>
+  amount: -50
+  account: savings_with_valuation_overrides
+
+savings_three:
+  name: Withdrawal
+  date: <%= 18.days.ago.to_date %>
+  amount: 2000
+  account: savings_with_valuation_overrides
+
+savings_four:
+  name: Check Deposit
+  date: <%= 30.days.ago.to_date %>
+  amount: -500
+  account: savings_with_valuation_overrides

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,20 +1,13 @@
-bob:
+family_admin:
   family: dylan_family
   first_name: Bob
   last_name: Dylan
   email: bob@bobdylan.com
   password_digest: <%= BCrypt::Password.create('password') %>
 
-jakob:
+family_member:
   family: dylan_family
   first_name: Jakob
   last_name: Dylan
   email: jakobdylan@yahoo.com
-  password_digest: <%= BCrypt::Password.create('password') %>
-
-keith:
-  family: richards_family
-  first_name: Keith
-  last_name: Richards
-  email: keith@rollingstones.com
   password_digest: <%= BCrypt::Password.create('password') %>

--- a/test/fixtures/valuations.yml
+++ b/test/fixtures/valuations.yml
@@ -1,11 +1,26 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# For collectible account that only has valuations (no transactions)
+collectible_one:
+  value: 550
+  date: <%= 4.days.ago.to_date %>
+  account: collectible
 
-one:
-  value: 9.99
-  date: 2024-02-15
-  account: dylan_checking
+collectible_two:
+  value: 700
+  date: <%= 12.days.ago.to_date %>
+  account: collectible
 
-two:
-  value: 9.99
-  date: 2024-02-15
-  account: richards_savings
+collectible_three:
+  value: 400
+  date: <%= 30.days.ago.to_date %>
+  account: collectible
+
+# For checking account that has valuations and transactions
+savings_one:
+  value: 20500
+  date: <%= 3.days.ago.to_date %>
+  account: savings_with_valuation_overrides
+
+savings_two:
+  value: 19500
+  date: <%= 12.days.ago.to_date %>
+  account: savings_with_valuation_overrides

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -2,8 +2,9 @@ require "test_helper"
 
 class AccountTest < ActiveSupport::TestCase
   def setup
-    depository = Account::Depository.create!
-    @account = Account.create!(family: families(:dylan_family), name: "Explicit Checking", original_balance: 1200, accountable: depository)
+    depository = account_depositories(:checking)
+    @account = accounts(:checking)
+    @account.accountable = depository
   end
 
   test "new account should be valid" do

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class CurrentTest < ActiveSupport::TestCase
   test "family returns user family" do
-    user = users(:bob)
+    user = users(:family_admin)
     Current.user = user
     assert_equal user.family, Current.family
   end

--- a/test/models/family_test.rb
+++ b/test/models/family_test.rb
@@ -6,12 +6,12 @@ class FamilyTest < ActiveSupport::TestCase
   end
 
   test "should have many users" do
-    assert_equal 2, @dylan_family.users.size
-    assert @dylan_family.users.include?(users(:bob))
+    assert @dylan_family.users.size > 0
+    assert @dylan_family.users.include?(users(:family_admin))
   end
 
   test "should have many accounts" do
-    assert_equal 2, @dylan_family.accounts.size
+    assert @dylan_family.accounts.size > 0
   end
 
   test "should destroy dependent users" do

--- a/test/models/transaction_test.rb
+++ b/test/models/transaction_test.rb
@@ -1,7 +1,4 @@
 require "test_helper"
 
 class TransactionTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UserTest < ActiveSupport::TestCase
   def setup
-    @user = users(:bob)
+    @user = users(:family_admin)
   end
 
   test "should be valid" do

--- a/test/models/valuation_test.rb
+++ b/test/models/valuation_test.rb
@@ -1,7 +1,4 @@
 require "test_helper"
 
 class ValuationTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
 end

--- a/test/system/accounts_test.rb
+++ b/test/system/accounts_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class AccountsTest < ApplicationSystemTestCase
   setup do
-    sign_in @user = users(:bob)
+    sign_in @user = users(:family_admin)
   end
 
   test "should create account" do


### PR DESCRIPTION
This PR prepares some test data for account syncing, which I'll be opening a PR for shortly.

There are 4 primary account scenarios that need to be tested:

1. Syncing an account with no history - `generic` fixture
2. Syncing an account with only valuations (no txns) - `collectible` fixture
3. Syncing an account with only transactions (no valuations) - `checking` fixture
4. Syncing an account with both transactions and valuations (where the valuations act as balance "overrides") - `savings_with_valuation_overrides` fixture

In addition, adds a tweak to naming of account balances.  Going from `original_balance` -> `balance` because "original" may imply that this field represents a "historical" or "old" balance, which it does not.  It represents "current balance" of the account.