### PR TITLE
Hide the additional arrow shown on safari browser for summary tag

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,9 +1,1 @@
 /* Application styles */
-details > summary {
-  list-style: none;
-}
-
-details > summary::marker, /* Latest Chrome, Edge, Firefox */
-details > summary::-webkit-details-marker /* Safari */ {
-  display: none;
-}

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,1 +1,9 @@
 /* Application styles */
+details > summary {
+  list-style: none;
+}
+
+details > summary::marker, /* Latest Chrome, Edge, Firefox */
+details > summary::-webkit-details-marker /* Safari */ {
+  display: none;
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,6 +4,9 @@
 
 /* Reset rules, default styles applied to plain HTML */
 @layer base {
+  details > summary::-webkit-details-marker {
+    @apply hidden;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Default browser arrow gets added on safari browser.
![Screenshot 2024-02-28 at 5 14 04 PM](https://github.com/maybe-finance/maybe/assets/8499149/9edf388d-4ed4-4093-86e5-ecd51d3f2398)

Fixing it based on [this](https://stackoverflow.com/a/66814239) stackoverflow answer