### PR TITLE
Add missing classification local when using account_valuation_list view

### DIFF
--- a/app/views/valuations/create.turbo_stream.erb
+++ b/app/views/valuations/create.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.replace Valuation.new, body: turbo_frame_tag(dom_id(Valuation.new)) %>
 <%= turbo_stream.append "notification-tray", partial: "shared/notification", locals: { type: "success", content: "Valuation created" } %>
-<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuation_series } %>
+<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuation_series, classification: @account.classification } %>
 <%= turbo_stream.replace "sync_message", partial: "accounts/sync_message", locals: { is_syncing: true } %>

--- a/app/views/valuations/destroy.turbo_stream.erb
+++ b/app/views/valuations/destroy.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.remove @valuation %>
 <%= turbo_stream.append "notification-tray", partial: "shared/notification", locals: { type: "success", content: "Valuation deleted" } %>
-<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuation_series } %>
+<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuation_series, classification: @account.classification } %>
 <%= turbo_stream.replace "sync_message", partial: "accounts/sync_message", locals: { is_syncing: true } %>


### PR DESCRIPTION
There was a missing `locals` when referencing the `accounts/account_valuation_list` partial view, causing a crash whenever a new valuation history entry was created in the UI.