### PR TITLE
Remove unused gem jbuilder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "good_job"
 # Other
 gem "bcrypt", "~> 3.1.7"
 gem "inline_svg"
+gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "faraday"
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ gem "good_job"
 # Other
 gem "bcrypt", "~> 3.1.7"
 gem "inline_svg"
-gem "jbuilder"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "faraday"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,9 @@ GEM
     irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
+    jbuilder (2.11.5)
+      actionview (>= 5.0.0)
+      activesupport (>= 5.0.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
@@ -401,6 +404,7 @@ DEPENDENCIES
   i18n-tasks
   importmap-rails
   inline_svg
+  jbuilder
   letter_opener
   lucide-rails!
   pg (~> 1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,9 +193,6 @@ GEM
     irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
@@ -404,7 +401,6 @@ DEPENDENCIES
   i18n-tasks
   importmap-rails
   inline_svg
-  jbuilder
   letter_opener
   lucide-rails!
   pg (~> 1.5)


### PR DESCRIPTION
Here's how we know `jbuilder` is unused:
1. We search the codebase for `json.` since the Jbuilder API is all built around using the `json` object to render
2. We search the repo files for any ending in `.jbuilder`
3. We remove the gem, re-bundle, and run all the tests: ✅ green. We read the tests and realize we need more tests. 
4. We restart the dev server and poke at the app without Jbuilder and see that it all seems to work the same. 
5. We read all the views, and then we search the codebase for other common Jbuilder methods like `array!`. `to_builder`,  `partial!` etc.
6. In summary, we conclude that the gem is unused and is only included because of its role as a Rails default:
https://github.com/rails/rails/blob/f7353283fd771e99b9675bcb9394e398964195f8/railties/lib/rails/generators/app_base.rb#L481

See Gem readme for more info: https://github.com/rails/jbuilder