### PR TITLE
Use our .ruby-version file in Bundler so it is managed in only 1 place

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.3.0"
+ruby file: ".ruby-version"
 
 # Rails
 gem "rails", github: "rails/rails", branch: "main"


### PR DESCRIPTION
This provides a single source of truth and simplifies staying current on Ruby.

Background writeup: https://gorails.com/episodes/bundler-ruby-version-file
Original issue: https://github.com/rubygems/rubygems/issues/6742
Implementation: https://github.com/rubygems/rubygems/pull/6876
