### PR TITLE
Add accounts management list

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -49,6 +49,10 @@
   .form-field__submit {
     @apply w-full p-3 text-center text-white bg-black rounded-lg hover:bg-gray-700;
   }
+
+  input:checked + label + .toggle-switch-dot {
+    transform: translateX(100%);
+  }
 }
 
 /* Small, single purpose classes that should take precedence over other styles */

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -22,7 +22,15 @@ class AccountsController < ApplicationController
     @account = Current.family.accounts.find(params[:id])
 
     if @account.update(account_params.except(:accountable_type))
-      redirect_to accounts_path, notice: t(".success")
+      respond_to do |format|
+        format.html { redirect_to accounts_path, notice: t(".success") }
+        format.turbo_stream do
+          render turbo_stream: [
+            turbo_stream.append("notification-tray", partial: "shared/notification", locals: { type: "success", content: t(".success") }),
+            turbo_stream.replace("account_#{@account.id}", partial: "accounts/account", locals: { account: @account })
+          ]
+        end
+      end
     else
       render "edit", status: :unprocessable_entity
     end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -22,6 +22,9 @@ class AccountsController < ApplicationController
     @account = Current.family.accounts.find(params[:id])
 
     if @account.update(account_params.except(:accountable_type))
+
+      @account.sync_later if account_params[:is_active] == "1"
+
       respond_to do |format|
         format.html { redirect_to accounts_path, notice: t(".success") }
         format.turbo_stream do

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -15,6 +15,19 @@ class AccountsController < ApplicationController
     @valuation_series = @account.valuations.to_series(@account)
   end
 
+  def edit
+  end
+
+  def update
+    @account = Current.family.accounts.find(params[:id])
+
+    if @account.update(account_params.except(:accountable_type))
+      redirect_to accounts_path, notice: t(".success")
+    else
+      render "edit", status: :unprocessable_entity
+    end
+  end
+
   def create
     @account = Current.family.accounts.build(account_params.except(:accountable_type))
     @account.accountable = Accountable.from_type(account_params[:accountable_type])&.new
@@ -29,6 +42,6 @@ class AccountsController < ApplicationController
   private
 
   def account_params
-    params.require(:account).permit(:name, :accountable_type, :balance, :currency, :subtype)
+    params.require(:account).permit(:name, :accountable_type, :balance, :currency, :subtype, :is_active)
   end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,6 +7,8 @@ class Account < ApplicationRecord
   has_many :valuations
   has_many :transactions
 
+  scope :active, -> { where(is_active: true) }
+
   delegated_type :accountable, types: Accountable::TYPES, dependent: :destroy
 
   before_create :check_currency
@@ -25,7 +27,7 @@ class Account < ApplicationRecord
   # TODO: We will need a better way to encapsulate large queries & transformation logic, but leaving all in one spot until
   # we have a better understanding of the requirements
   def self.by_group(period = Period.all)
-    ranked_balances_cte = joins(:balances)
+    ranked_balances_cte = active.joins(:balances)
         .select("
           account_balances.account_id,
           account_balances.balance,

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -17,6 +17,11 @@ class Account < ApplicationRecord
     Trend.new(current: last.balance, previous: first.balance, type: classification)
   end
 
+  def self.by_provider
+    # TODO: When 3rd party providers are supported, dynamically load all providers and their accounts
+    [ { name: "Manual accounts", accounts: all.order(balance: :desc).group_by(&:accountable_type) } ]
+  end
+
   # TODO: We will need a better way to encapsulate large queries & transformation logic, but leaving all in one spot until
   # we have a better understanding of the requirements
   def self.by_group(period = Period.all)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -4,15 +4,15 @@ class Family < ApplicationRecord
   has_many :transactions, through: :accounts
 
   def net_worth
-    accounts.sum("CASE WHEN classification = 'asset' THEN balance ELSE -balance END")
+    accounts.active.sum("CASE WHEN classification = 'asset' THEN balance ELSE -balance END")
   end
 
   def assets
-    accounts.where(classification: "asset").sum(:balance)
+    accounts.active.where(classification: "asset").sum(:balance)
   end
 
   def liabilities
-    accounts.where(classification: "liability").sum(:balance)
+    accounts.active.where(classification: "liability").sum(:balance)
   end
 
   def net_worth_series(period = nil)

--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -1,0 +1,23 @@
+<%= turbo_frame_tag dom_id(account) do %>
+  <div class="p-4 flex items-center justify-between gap-3">
+    <div class="flex items-center gap-3">
+      <div class="w-8 h-8 flex items-center justify-center rounded-full text-xs font-medium <%= account.is_active ? "bg-blue-500/10 text-blue-500" : "bg-gray-500/10 text-gray-500" %>">
+        <%= account.name[0].upcase %>
+      </div>
+      <p class="text-sm font-medium <%= account.is_active ? "text-gray-900" : "text-gray-400" %>">
+        <%= account.name %>
+      </p>
+    </div>
+    <div class="flex items-center gap-8">
+      <p class="text-sm font-medium <%= account.is_active ? "text-gray-900" : "text-gray-400" %>">
+        <%= format_currency account.balance %>
+      </p>
+      <%= form_with model: account, method: :patch, html: { class: "flex items-center", data: { turbo_frame: "_top" } } do |form| %>
+        <div class="relative inline-block select-none">
+          <%= form.check_box :is_active, class: "sr-only peer", id: "is_active_#{account.id}", onchange: "this.form.requestSubmit();" %>
+          <label for="is_active_<%= account.id %>" class="block bg-gray-100 w-9 h-5 rounded-full cursor-pointer after:content-[''] after:block after:absolute after:top-0.5 after:left-0.5 after:bg-white after:w-4 after:h-4 after:rounded-full after:transition-transform after:duration-300 after:ease-in-out peer-checked:bg-green-600 peer-checked:after:translate-x-4"></label>
+        </div>
+      <% end %>
+    </div>
+  </div>
+<% end%>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -1,17 +1,66 @@
-
-<h2 class="text-2xl font-semibold font-display"><%= t('.title')%></h2>
-<h3 class="mt-1 mb-4 text-sm text-gray-500"><%#= number_to_currency Current.family.cash_balance %></h3>
-
-<% Current.family.accounts.each do |account| %>
-    <div class="flex flex-row items-center justify-between px-3 py-3 mb-2 bg-white shadow-sm rounded-xl">
-      <div class="flex items-center w-1/3 text-sm">
-        <%= account.name %>
-      </div>
-      <div class="flex items-center w-1/3 text-sm">
-        <%= to_accountable_title(account.accountable) %>
-      </div>
-      <p class="flex w-1/3 text-sm text-right">
-        <span class="block mb-1"><%= format_currency account.converted_balance %></span>
-      </p>
-    </div>
-<% end %>
+<div class="space-y-4">
+  <div class="flex items-center justify-between">
+    <h1 class="text-xl font-medium text-gray-900">Accounts</h1>
+    <%= link_to new_account_path, class: "flex text-white text-sm font-medium items-center gap-1 bg-gray-900 rounded-lg p-2", data: { turbo_frame: "modal" } do %>
+      <%= lucide_icon("plus", class: "w-5 h-5") %>
+      <span><%= t('.new_account') %></span>
+    <% end %>
+  </div>
+  <div>
+    <% Current.family.accounts.by_provider.each do |item| %>
+      <details class="bg-white group p-4 border border-alpha-black-25 shadow-xs rounded-xl">
+        <summary class="flex items-center gap-2">
+          <%= lucide_icon("chevron-down", class: "hidden group-open:block w-5 h-5 text-gray-500") %>
+          <%= lucide_icon("chevron-right", class: "group-open:hidden w-5 h-5 text-gray-500") %>
+          <% if item[:name] == "Manual accounts" %>
+            <div class="flex items-center justify-center h-8 w-8 rounded-full bg-black/5">
+              <%= lucide_icon("folder-pen", class: "w-5 h-5 text-gray-500") %>
+            </div>
+          <% end %>
+          <span class="text-sm font-medium text-gray-900">
+            <%= item[:name] %>
+          </span>
+        </summary>
+        <div class="space-y-4 mt-4">
+          <% item[:accounts].each do |group, accounts| %>
+            <div class="bg-gray-25 p-1 rounded-xl">
+              <div class="flex items-center px-4 py-2 text-xs font-medium text-gray-500">
+                <p><%= to_accountable_title(Accountable.from_type(group)) %></p>
+                <span class="text-gray-400 mx-2">&middot;</span>
+                <p><%= accounts.count %></p>
+                <p class="ml-auto"><%= format_currency accounts.sum(&:balance) %></p>
+              </div>
+              <div class="bg-white">
+                <% accounts.each do |account| %>
+                  <div class="p-4 flex items-center justify-between gap-3">
+                    <div class="flex items-center gap-3">
+                      <div class="w-8 h-8 flex items-center justify-center rounded-full text-xs font-medium <%= account.is_active ? "bg-blue-500/10 text-blue-500" : "bg-gray-500/10 text-gray-500" %>">
+                        <%= account.name[0].upcase %>
+                      </div>
+                      <p class="text-sm font-medium <%= account.is_active ? "text-gray-900" : "text-gray-400" %>">
+                        <%= account.name %>
+                      </p>
+                    </div>
+                    <div class="flex items-center gap-8">
+                      <p class="text-sm font-medium <%= account.is_active ? "text-gray-900" : "text-gray-400" %>">
+                        <%= format_currency account.balance %>
+                      </p>
+                      <%= turbo_frame_tag "toggle_form_#{account.id}" do %>
+                        <%= form_with model: account, method: :patch, local: true, html: { class: "flex items-center" } do |form| %>
+                          <div class="relative inline-block select-none">
+                            <%= form.check_box :is_active, class: "sr-only peer", id: "is_active_#{account.id}", onchange: "this.form.submit();" %>
+                            <label for="is_active_<%= account.id %>" class="block bg-gray-100 w-9 h-5 rounded-full cursor-pointer after:content-[''] after:block after:absolute after:top-0.5 after:left-0.5 after:bg-white after:w-4 after:h-4 after:rounded-full after:transition-transform after:duration-300 after:ease-in-out peer-checked:bg-green-600 peer-checked:after:translate-x-4"></label>
+                          </div>
+                        <% end %>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </details>
+    <% end %>
+  </div>
+</div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -6,39 +6,52 @@
       <span><%= t('.new_account') %></span>
     <% end %>
   </div>
-  <div>
-    <% Current.family.accounts.by_provider.each do |item| %>
-      <details class="bg-white group p-4 border border-alpha-black-25 shadow-xs rounded-xl">
-        <summary class="flex items-center gap-2">
-          <%= lucide_icon("chevron-down", class: "hidden group-open:block w-5 h-5 text-gray-500") %>
-          <%= lucide_icon("chevron-right", class: "group-open:hidden w-5 h-5 text-gray-500") %>
-          <% if item[:name] == "Manual accounts" %>
-            <div class="flex items-center justify-center h-8 w-8 rounded-full bg-black/5">
-              <%= lucide_icon("folder-pen", class: "w-5 h-5 text-gray-500") %>
-            </div>
-          <% end %>
-          <span class="text-sm font-medium text-gray-900">
-            <%= item[:name] %>
-          </span>
-        </summary>
-        <div class="space-y-4 mt-4">
-          <% item[:accounts].each do |group, accounts| %>
-            <div class="bg-gray-25 p-1 rounded-xl">
-              <div class="flex items-center px-4 py-2 text-xs font-medium text-gray-500">
-                <p><%= to_accountable_title(Accountable.from_type(group)) %></p>
-                <span class="text-gray-400 mx-2">&middot;</span>
-                <p><%= accounts.count %></p>
-                <p class="ml-auto"><%= format_currency accounts.sum(&:balance) %></p>
+  <% if Current.family.accounts.empty? %>
+    <div class="flex justify-center items-center h-[800px] text-sm">
+      <div class="text-center flex flex-col items-center max-w-[300px]">
+        <p class="text-gray-900 mb-1 font-medium">No accounts yet</p>
+        <p class="text-gray-500 mb-4">Add an account either via connection, importing or entering manually.</p>
+        <%= link_to new_account_path, class: "w-fit flex text-white text-sm font-medium items-center gap-1 bg-gray-900 rounded-lg p-2", data: { turbo_frame: "modal" } do %>
+          <%= lucide_icon("plus", class: "w-5 h-5") %>
+          <span><%= t('.new_account') %></span>
+        <% end %>
+      </div>
+    </div>
+  <% else %>
+    <div>
+      <% Current.family.accounts.by_provider.each do |item| %>
+        <details class="bg-white group p-4 border border-alpha-black-25 shadow-xs rounded-xl">
+          <summary class="flex items-center gap-2">
+            <%= lucide_icon("chevron-down", class: "hidden group-open:block w-5 h-5 text-gray-500") %>
+            <%= lucide_icon("chevron-right", class: "group-open:hidden w-5 h-5 text-gray-500") %>
+            <% if item[:name] == "Manual accounts" %>
+              <div class="flex items-center justify-center h-8 w-8 rounded-full bg-black/5">
+                <%= lucide_icon("folder-pen", class: "w-5 h-5 text-gray-500") %>
               </div>
-              <div class="bg-white">
-                <% accounts.each do |account| %>
-                  <%= render account %>
-                <% end %>
+            <% end %>
+            <span class="text-sm font-medium text-gray-900">
+              <%= item[:name] %>
+            </span>
+          </summary>
+          <div class="space-y-4 mt-4">
+            <% item[:accounts].each do |group, accounts| %>
+              <div class="bg-gray-25 p-1 rounded-xl">
+                <div class="flex items-center px-4 py-2 text-xs font-medium text-gray-500">
+                  <p><%= to_accountable_title(Accountable.from_type(group)) %></p>
+                  <span class="text-gray-400 mx-2">&middot;</span>
+                  <p><%= accounts.count %></p>
+                  <p class="ml-auto"><%= format_currency accounts.sum(&:balance) %></p>
+                </div>
+                <div class="bg-white">
+                  <% accounts.each do |account| %>
+                    <%= render account %>
+                  <% end %>
+                </div>
               </div>
-            </div>
-          <% end %>
-        </div>
-      </details>
-    <% end %>
-  </div>
+            <% end %>
+          </div>
+        </details>
+      <% end %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -32,29 +32,7 @@
               </div>
               <div class="bg-white">
                 <% accounts.each do |account| %>
-                  <div class="p-4 flex items-center justify-between gap-3">
-                    <div class="flex items-center gap-3">
-                      <div class="w-8 h-8 flex items-center justify-center rounded-full text-xs font-medium <%= account.is_active ? "bg-blue-500/10 text-blue-500" : "bg-gray-500/10 text-gray-500" %>">
-                        <%= account.name[0].upcase %>
-                      </div>
-                      <p class="text-sm font-medium <%= account.is_active ? "text-gray-900" : "text-gray-400" %>">
-                        <%= account.name %>
-                      </p>
-                    </div>
-                    <div class="flex items-center gap-8">
-                      <p class="text-sm font-medium <%= account.is_active ? "text-gray-900" : "text-gray-400" %>">
-                        <%= format_currency account.balance %>
-                      </p>
-                      <%= turbo_frame_tag "toggle_form_#{account.id}" do %>
-                        <%= form_with model: account, method: :patch, local: true, html: { class: "flex items-center" } do |form| %>
-                          <div class="relative inline-block select-none">
-                            <%= form.check_box :is_active, class: "sr-only peer", id: "is_active_#{account.id}", onchange: "this.form.submit();" %>
-                            <label for="is_active_<%= account.id %>" class="block bg-gray-100 w-9 h-5 rounded-full cursor-pointer after:content-[''] after:block after:absolute after:top-0.5 after:left-0.5 after:bg-white after:w-4 after:h-4 after:rounded-full after:transition-transform after:duration-300 after:ease-in-out peer-checked:bg-green-600 peer-checked:after:translate-x-4"></label>
-                          </div>
-                        <% end %>
-                      <% end %>
-                    </div>
-                  </div>
+                  <%= render account %>
                 <% end %>
               </div>
             </div>

--- a/app/views/valuations/create.turbo_stream.erb
+++ b/app/views/valuations/create.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.replace Valuation.new, body: turbo_frame_tag(dom_id(Valuation.new)) %>
 <%= turbo_stream.append "notification-tray", partial: "shared/notification", locals: { type: "success", content: "Valuation created" } %>
-<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuation_series, classification: @account.classification } %>
+<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuations.to_series(@account) } %>
 <%= turbo_stream.replace "sync_message", partial: "accounts/sync_message", locals: { is_syncing: true } %>

--- a/app/views/valuations/destroy.turbo_stream.erb
+++ b/app/views/valuations/destroy.turbo_stream.erb
@@ -1,4 +1,4 @@
 <%= turbo_stream.remove @valuation %>
 <%= turbo_stream.append "notification-tray", partial: "shared/notification", locals: { type: "success", content: "Valuation deleted" } %>
-<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuation_series, classification: @account.classification } %>
+<%= turbo_stream.replace "valuations_list", partial: "accounts/account_valuation_list", locals: { valuation_series: @account.valuations.to_series(@account) } %>
 <%= turbo_stream.replace "sync_message", partial: "accounts/sync_message", locals: { is_syncing: true } %>

--- a/config/locales/views/account/en.yml
+++ b/config/locales/views/account/en.yml
@@ -1,8 +1,6 @@
 ---
 en:
   accounts:
-    update:
-      success: Account updated successfully
     create:
       success: New account created successfully
     index:
@@ -13,3 +11,5 @@ en:
         placeholder: Example account name
       select_accountable_type: What would you like to add?
       title: Add an account
+    update:
+      success: Account updated successfully

--- a/config/locales/views/account/en.yml
+++ b/config/locales/views/account/en.yml
@@ -1,10 +1,12 @@
 ---
 en:
   accounts:
+    update:
+      success: Account updated successfully
     create:
       success: New account created successfully
     index:
-      title: Cash
+      new_account: New account
     new:
       name:
         label: Account name

--- a/db/migrate/20240306193345_add_is_active_to_account.rb
+++ b/db/migrate/20240306193345_add_is_active_to_account.rb
@@ -1,0 +1,5 @@
+class AddIsActiveToAccount < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :is_active, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_03_02_145715) do
+ActiveRecord::Schema[7.2].define(version: 2024_03_06_193345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -79,7 +79,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_02_145715) do
     t.decimal "converted_balance", precision: 19, scale: 4, default: "0.0"
     t.string "converted_currency", default: "USD"
     t.string "status", default: "OK"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Account::Loan'::character varying, 'Account::Credit'::character varying, 'Account::OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Account::Loan'::character varying)::text, ('Account::Credit'::character varying)::text, ('Account::OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.boolean "is_active", default: true, null: false
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["family_id"], name: "index_accounts_on_family_id"
   end


### PR DESCRIPTION
Since all accounts are manual at this point, this is a V1 for the accounts management page which will eventually be the primary place where a user can see the connection status of various 3rd party connected accounts.

This page also enables the user to "disable" an account, which will exclude the account from queries and analytics.

![CleanShot 2024-03-06 at 15 32 30](https://github.com/maybe-finance/maybe/assets/16676157/0481aa17-651d-424e-9014-046acd20e984)
