### PR TITLE
Fix event handler removal on disconnect

### DIFF
--- a/app/javascript/controllers/account_collapse_controller.js
+++ b/app/javascript/controllers/account_collapse_controller.js
@@ -3,21 +3,19 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="account-collapse"
 export default class extends Controller {
   static values = { type: String }
-  boundOnToggle = null
   initialToggle = false
   STORAGE_NAME = "accountCollapseStates"
 
   connect() {
-    this.boundOnToggle = this.onToggle.bind(this)
-    this.element.addEventListener("toggle", this.boundOnToggle)
+    this.element.addEventListener("toggle", this.onToggle)
     this.updateFromLocalStorage()
   }
 
   disconnect() {
-    this.element.removeEventListener("toggle", this.boundOnToggle)
+    this.element.removeEventListener("toggle", this.onToggle)
   }
 
-  onToggle() {
+  onToggle = () => {
     if (this.initialToggle) {
       this.initialToggle = false
       return

--- a/app/javascript/controllers/auto_submit_form_controller.js
+++ b/app/javascript/controllers/auto_submit_form_controller.js
@@ -15,16 +15,14 @@ export default class extends Controller {
   }
 
   connect() {
-    this.inputElements.forEach(el => el.addEventListener('change', this.handler.bind(this)));
-    this.selectElements.forEach(el => el.addEventListener('change', this.handler.bind(this)));
+    [...this.inputElements, ...this.selectElements].forEach(el => el.addEventListener('change', this.handler));
   }
 
   disconnect() {
-    this.inputElements.forEach(el => el.removeEventListener('change', this.handler.bind(this)));
-    this.selectElements.forEach(el => el.removeEventListener('change', this.handler.bind(this)));
+    [...this.inputElements, ...this.selectElements].forEach(el => el.removeEventListener('change', this.handler));
   }
 
-  handler(e) {
+  handler = (e) => {
     console.log(e);
     this.element.requestSubmit();
   }

--- a/app/javascript/controllers/line_chart_controller.js
+++ b/app/javascript/controllers/line_chart_controller.js
@@ -8,14 +8,14 @@ export default class extends Controller {
 
   connect() {
     this.renderChart(this.seriesValue);
-    document.addEventListener("turbo:load", this.renderChart.bind(this));
+    document.addEventListener("turbo:load", this.renderChart);
   }
 
   disconnect() {
-    document.removeEventListener("turbo:load", this.renderChart.bind(this));
+    document.removeEventListener("turbo:load", this.renderChart);
   }
 
-  renderChart() {
+  renderChart = () => {
     this.drawChart(this.seriesValue);
   }
 

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -8,24 +8,18 @@ export default class extends Controller {
 
   connect() {
     this.updateClasses(this.defaultTabValue);
-    document.addEventListener(
-      "turbo:load",
-      this.updateClasses.bind(this, this.defaultTabValue)
-    );
+    document.addEventListener("turbo:load", this.updateClasses);
   }
 
   disconnect() {
-    document.removeEventListener(
-      "turbo:load",
-      this.updateClasses.bind(this, this.defaultTabValue)
-    );
+    document.removeEventListener("turbo:load", this.updateClasses);
   }
 
   select(event) {
     this.updateClasses(event.target.dataset.id);
   }
 
-  updateClasses(selectedId) {
+  updateClasses = (selectedId = this.defaultTabValue) => {
     this.btnTargets.forEach((btn) => btn.classList.remove(this.activeClass));
     this.tabTargets.forEach((tab) => tab.classList.add("hidden"));
 

--- a/app/javascript/controllers/tabs_controller.js
+++ b/app/javascript/controllers/tabs_controller.js
@@ -8,18 +8,22 @@ export default class extends Controller {
 
   connect() {
     this.updateClasses(this.defaultTabValue);
-    document.addEventListener("turbo:load", this.updateClasses);
+    document.addEventListener("turbo:load", this.onTurboLoad);
   }
 
   disconnect() {
-    document.removeEventListener("turbo:load", this.updateClasses);
+    document.removeEventListener("turbo:load", this.onTurboLoad);
   }
 
   select(event) {
     this.updateClasses(event.target.dataset.id);
   }
 
-  updateClasses = (selectedId = this.defaultTabValue) => {
+  onTurboLoad = () => {
+    this.updateClasses(this.defaultTabValue);
+  }
+
+  updateClasses = (selectedId) => {
     this.btnTargets.forEach((btn) => btn.classList.remove(this.activeClass));
     this.tabTargets.forEach((tab) => tab.classList.add("hidden"));
 

--- a/app/javascript/controllers/trendline_controller.js
+++ b/app/javascript/controllers/trendline_controller.js
@@ -7,14 +7,14 @@ export default class extends Controller {
 
   connect() {
     this.renderChart(this.seriesValue);
-    document.addEventListener("turbo:load", this.renderChart.bind(this));
+    document.addEventListener("turbo:load", this.renderChart);
   }
 
   disconnect() {
-    document.removeEventListener("turbo:load", this.renderChart.bind(this));
+    document.removeEventListener("turbo:load", this.renderChart);
   }
 
-  renderChart() {
+  renderChart = () => {
     this.drawChart(this.seriesValue);
   }
 


### PR DESCRIPTION
Calling `.bind(this)` always returns a new function, meaning that event handlers registered in `connect` callbacks  were never properly removed in `disconnect` callbacks. Creating event handlers as arrow functions fixed this and also makes the code simpler.