### PR TITLE
Enable turbo refresh in layouts/auth & Fix registrations controller create fail w/ status

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -19,7 +19,7 @@ class RegistrationsController < ApplicationController
       redirect_to root_path
     else
       flash[:alert] = t(".failure")
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -23,6 +23,7 @@
     <%= javascript_importmap_tags %>
 
     <%= hotwire_livereload_tags if Rails.env.development? %>
+    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
   </head>
 
   <body class="h-full">


### PR DESCRIPTION
This PR modification contains two contents

1. `layouts/auth` enable turbo refresh    
2. return difference status w/ registrations controller create fail, void `Error: Form responses must redirect to another location`

