### PR TITLE
Add presence validations for required fields

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,6 +1,8 @@
 class Account < ApplicationRecord
   include Syncable
 
+  validates :family_id, presence: true
+
   broadcasts_refreshes
   belongs_to :family
   has_many :balances, class_name: "AccountBalance"

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -1,7 +1,7 @@
 class Account < ApplicationRecord
   include Syncable
 
-  validates :family_id, presence: true
+  validates :family, presence: true
 
   broadcasts_refreshes
   belongs_to :family

--- a/app/models/account_balance.rb
+++ b/app/models/account_balance.rb
@@ -1,6 +1,8 @@
 class AccountBalance < ApplicationRecord
   belongs_to :account
 
+  validates :account_id, :date, :balance, presence: true
+
   scope :in_period, ->(period) { period.date_range.nil? ? all : where(date: period.date_range) }
 
   def self.to_series(account, period = Period.all)

--- a/app/models/account_balance.rb
+++ b/app/models/account_balance.rb
@@ -1,7 +1,7 @@
 class AccountBalance < ApplicationRecord
   belongs_to :account
 
-  validates :account_id, :date, :balance, presence: true
+  validates :account, :date, :balance, presence: true
 
   scope :in_period, ->(period) { period.date_range.nil? ? all : where(date: period.date_range) }
 

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -1,3 +1,0 @@
-class Credit < Account
-  validates :family_id, presence: true
-end

--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -1,2 +1,3 @@
 class Credit < Account
+  validates :family_id, presence: true
 end

--- a/app/models/exchange_rate.rb
+++ b/app/models/exchange_rate.rb
@@ -1,4 +1,6 @@
 class ExchangeRate < ApplicationRecord
+  validates :base_currency, :converted_currency, presence: true
+
   def self.convert(from, to, amount)
     return amount unless EXCHANGE_RATE_ENABLED
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,6 +2,8 @@ class Transaction < ApplicationRecord
   belongs_to :account
   belongs_to :category, optional: true
 
+  validates :name, :date, :amount, :account_id, presence: true
+
   after_commit :sync_account
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -2,7 +2,7 @@ class Transaction < ApplicationRecord
   belongs_to :account
   belongs_to :category, optional: true
 
-  validates :name, :date, :amount, :account_id, presence: true
+  validates :name, :date, :amount, :account, presence: true
 
   after_commit :sync_account
 

--- a/app/models/transaction/category.rb
+++ b/app/models/transaction/category.rb
@@ -2,7 +2,7 @@ class Transaction::Category < ApplicationRecord
   has_many :transactions
   belongs_to :family
 
-  validates :name, :color, :family_id, presence: true
+  validates :name, :color, :family, presence: true
 
   before_update :clear_internal_category, if: :name_changed?
 

--- a/app/models/transaction/category.rb
+++ b/app/models/transaction/category.rb
@@ -2,6 +2,8 @@ class Transaction::Category < ApplicationRecord
   has_many :transactions
   belongs_to :family
 
+  validates :name, :color, :family_id, presence: true
+
   before_update :clear_internal_category, if: :name_changed?
 
   DEFAULT_CATEGORIES = [

--- a/app/models/valuation.rb
+++ b/app/models/valuation.rb
@@ -1,7 +1,7 @@
 class Valuation < ApplicationRecord
   belongs_to :account
 
-  validates :account_id, :date, :value, presence: true
+  validates :account, :date, :value, presence: true
 
   after_commit :sync_account
 

--- a/app/models/valuation.rb
+++ b/app/models/valuation.rb
@@ -1,6 +1,8 @@
 class Valuation < ApplicationRecord
   belongs_to :account
 
+  validates :account_id, :date, :value, presence: true
+
   after_commit :sync_account
 
   scope :in_period, ->(period) { period.date_range.nil? ? all : where(date: period.date_range) }


### PR DESCRIPTION
In this PR:

* Adds presence validations for the non-nullable fields on models
* Delete the `credit` model which was identified by @tabertantrum as legacy cruft

Not in this PR:
* This PR does not validate the `family` which is non-nullable for `user`, because adding it breaks the basic test setup. This implies the test setup should be improved, which is out of scope for this PR.

Motivations:
1. Validating required fields before saving is more performant than raising database errors (in non-bulk operations). 
2. This is the first step in improving UX by raising proper errors for required fields. 
3. Combining this with surfacing the flash will provide UX guidance and prevent dead end errors in the app like this:


<img width="1016" alt="Screenshot 2024-03-15 at 10 21 21 AM" src="https://github.com/maybe-finance/maybe/assets/1724875/19b2ad0a-8eb2-4459-a99b-5edb44278acb">
