### PR TITLE
Removes unused model and routes

### DIFF
--- a/app/models/credit.rb
+++ b/app/models/credit.rb
@@ -1,2 +1,0 @@
-class Credit < Account
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,16 +12,6 @@ Rails.application.routes.draw do
     resources :valuations
   end
 
-  scope "accounts/new" do
-    scope "bank" do
-      get "", to: "accounts#new_bank", as: "new_bank"
-    end
-
-    scope "credit" do
-      get "", to: "accounts#new_credit", as: "new_credit"
-    end
-  end
-
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
The credit.rb model appears to have been created when delegated types were being introduced to Account. This PR removes this unused file, as well as some unnecessary routes that are now handled through delegated typing on the Account resource.