### PR TITLE
feat: add crypto account type to demo data

### DIFF
--- a/app/models/account/crypto.rb
+++ b/app/models/account/crypto.rb
@@ -1,0 +1,3 @@
+class Account::Crypto < ApplicationRecord
+  include Accountable
+end

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -1,7 +1,7 @@
 module Accountable
   extend ActiveSupport::Concern
 
-  ASSET_TYPES = %w[ Account::Depository Account::Investment Account::OtherAsset Account::Property Account::Vehicle ]
+  ASSET_TYPES = %w[ Account::Depository Account::Investment Account::Crypto Account::OtherAsset Account::Property Account::Vehicle ]
   LIABILITY_TYPES = %w[ Account::Credit Account::Loan Account::OtherLiability ]
   TYPES = ASSET_TYPES + LIABILITY_TYPES
 

--- a/db/migrate/20240319154732_create_account_cryptos.rb
+++ b/db/migrate/20240319154732_create_account_cryptos.rb
@@ -1,0 +1,7 @@
+class CreateAccountCryptos < ActiveRecord::Migration[7.2]
+  def change
+    create_table :account_cryptos, id: :uuid do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_03_09_180636) do
+ActiveRecord::Schema[7.2].define(version: 2024_03_19_154732) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -31,6 +31,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_09_180636) do
   end
 
   create_table "account_credits", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "account_cryptos", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -82,7 +87,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_09_180636) do
     t.string "currency", default: "USD"
     t.decimal "converted_balance", precision: 19, scale: 4, default: "0.0"
     t.string "converted_currency", default: "USD"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Account::Loan'::character varying, 'Account::Credit'::character varying, 'Account::OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Account::Loan'::character varying)::text, ('Account::Credit'::character varying)::text, ('Account::OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.boolean "is_active", default: true, null: false
     t.enum "status", default: "ok", null: false, enum_type: "account_status"
     t.jsonb "sync_warnings", default: "[]", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -87,7 +87,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_19_154732) do
     t.string "currency", default: "USD"
     t.decimal "converted_balance", precision: 19, scale: 4, default: "0.0"
     t.string "converted_currency", default: "USD"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Account::Loan'::character varying)::text, ('Account::Credit'::character varying)::text, ('Account::OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Account::Loan'::character varying, 'Account::Credit'::character varying, 'Account::OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.boolean "is_active", default: true, null: false
     t.enum "status", default: "ok", null: false, enum_type: "account_status"
     t.jsonb "sync_warnings", default: "[]", null: false

--- a/lib/tasks/demo_data.rake
+++ b/lib/tasks/demo_data.rake
@@ -222,14 +222,15 @@ namespace :demo_data do
     crypto = Account.find_or_create_by(name: "Bitcoin Account") do |a|
       a.family = family
       a.accountable = Account::Crypto.new
-      a.balance = 10000
+      a.currency = "BTC"
+      a.balance = 0.1
       end
 
     crypto_valuations = [
-    { date: 1.year.ago.to_date, value: 9000 },
-    { date: 200.days.ago.to_date, value: 9500 },
-    { date: 100.days.ago.to_date, value: 9444.96 },
-    { date: 20.days.ago.to_date, value: 10000 }
+    { date: 1.year.ago.to_date, value: 0.05, currency: "BTC" },
+    { date: 200.days.ago.to_date, value: 0.06, currency: "BTC" },
+    { date: 100.days.ago.to_date, value: 0.08, currency: "BTC" },
+    { date: 20.days.ago.to_date, value: 0.1, currency: "BTC" }
     ]
 
     crypto.valuations.upsert_all(crypto_valuations, unique_by: :index_valuations_on_account_id_and_date)

--- a/lib/tasks/demo_data.rake
+++ b/lib/tasks/demo_data.rake
@@ -219,6 +219,23 @@ namespace :demo_data do
 
     brokerage.sync
 
+    crypto = Account.find_or_create_by(name: "Bitcoin Account") do |a|
+      a.family = family
+      a.accountable = Account::Crypto.new
+      a.balance = 10000
+      end
+
+    crypto_valuations = [
+    { date: 1.year.ago.to_date, value: 9000 },
+    { date: 200.days.ago.to_date, value: 9500 },
+    { date: 100.days.ago.to_date, value: 9444.96 },
+    { date: 20.days.ago.to_date, value: 10000 }
+    ]
+
+    crypto.valuations.upsert_all(crypto_valuations, unique_by: :index_valuations_on_account_id_and_date)
+
+    crypto.sync
+
     mortgage = Account.find_or_create_by(name: "Demo Mortgage") do |a|
       a.family = family
       a.accountable = Account::Loan.new

--- a/test/fixtures/account/cryptos.yml
+++ b/test/fixtures/account/cryptos.yml
@@ -4,8 +4,8 @@
 # model remove the "{}" from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+# one: {}
 # column: value
 #
-two: {}
+# two: {}
 # column: value

--- a/test/fixtures/account/cryptos.yml
+++ b/test/fixtures/account/cryptos.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/account/crypto_test.rb
+++ b/test/models/account/crypto_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Account::CryptoTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/time_series_test.rb
+++ b/test/models/time_series_test.rb
@@ -39,12 +39,12 @@ class TimeSeriesTest < ActiveSupport::TestCase
     expected_values = {
       values: [
         {
-          date: "2024-03-17",
+          date: 1.day.ago.to_date,
           value: { amount: "100.0", currency: "USD" },
           trend: { type: "normal", direction: "flat", value: { amount: "0.0", currency: "USD" }, percent: 0.0 }
         },
         {
-          date: "2024-03-18",
+          date: Date.current,
           value: { amount: "200.0", currency: "USD" },
           trend: { type: "normal", direction: "up", value: { amount: "100.0", currency: "USD" }, percent: 100.0 }
         }


### PR DESCRIPTION
This adds a Crypto asset account type to the demo data, to more accurately resemble the main screenshot on the repo