### PR TITLE
Add data provider module

### DIFF
--- a/config/data_providers.yml
+++ b/config/data_providers.yml
@@ -1,0 +1,7 @@
+exchange_rates:
+  provider: Synth
+  api_key: <%= ENV["SYNTH_API_KEY"] %>
+# Add additional modules below (stock prices, crypto prices, housing data, etc.)
+# stock_prices:
+#   provider: Synth
+#   api_key: <%= ENV["SYNTH_API_KEY"] %>

--- a/config/initializers/data_providers.rb
+++ b/config/initializers/data_providers.rb
@@ -1,0 +1,16 @@
+providers_config = YAML.safe_load(ERB.new(File.read(Rails.root.join("config", "data_providers.yml"))).result)
+
+class ProviderFactory
+    def self.create(name, api_key)
+        "DataProvider::#{name}".constantize.new(api_key)
+    rescue NameError
+        raise "Unsupported provider: #{name}"
+    end
+end
+
+Rails.application.config.after_initialize do
+    DataProvider.exchange_rate_provider = ProviderFactory.create(
+        providers_config["exchange_rates"]["provider"],
+        providers_config["exchange_rates"]["api_key"]
+    )
+end

--- a/lib/data_provider.rb
+++ b/lib/data_provider.rb
@@ -1,0 +1,19 @@
+module DataProvider
+    class ExchangeRateProviderNotSet < StandardError; end
+
+    class << self
+        attr_reader :exchange_rate_provider
+
+        def exchange_rate_provider=(provider)
+            unless provider.is_a?(DataProvider::ExchangeRate::Provideable)
+                raise ArgumentError, "Exchange rate provider must include ExchangeRateProvider"
+            end
+            @exchange_rate_provider = provider
+        end
+
+        def exchange_rate(from_currency, to_currency, date = Date.current)
+            raise ExchangeRateProviderNotSet unless exchange_rate_provider
+            exchange_rate_provider.exchange_rate(from_currency, to_currency, date)
+        end
+    end
+end

--- a/lib/data_provider/exchange_rate/provideable.rb
+++ b/lib/data_provider/exchange_rate/provideable.rb
@@ -1,0 +1,5 @@
+module DataProvider::ExchangeRate::Provideable
+    def exchange_rate(from_currency, to_currency, date)
+        raise NotImplementedError
+    end
+end

--- a/lib/data_provider/synth.rb
+++ b/lib/data_provider/synth.rb
@@ -1,0 +1,22 @@
+class DataProvider::Synth
+    include DataProvider::ExchangeRate::Provideable
+
+    BASE_URL = "https://api.synthfinance.com"
+
+    def initialize(api_key)
+        @api_key = api_key
+    end
+
+    def exchange_rate(from_currency, to_currency, date)
+        response = Faraday.get("#{BASE_URL}/rates/historical") do |req|
+            req.headers["Authorization"] = "Bearer #{@api_key}"
+            req.params["from"] = from_currency
+            req.params["to"] = to_currency
+            req.params["date"] = date
+        end
+        data = JSON.parse(response.body)
+        data.dig("data", "rates", to_currency)
+    rescue StandardError
+        nil
+    end
+end


### PR DESCRIPTION
The Maybe app will use multiple data providers to pull in relevant info such as:

- Exchange rates
- Stock prices 
- Crypto prices 
- Home valuation data (Zillow, Redfin, etc.)
- Car valuation data

As a _default_, we'll use `Synth` (Maybe's B2B API) as the "provider" for each type of data.

## Overview

All data can be accessed through `DataProvider`.  For example:

```rb
DataProvider.exchange_rate("USD", "EUR")
DataProvider.home_value("123 Address", Date.current)
DataProvider.stock_price("NVIDIA")
```

Concrete provider classes can implement 1 or many of the "data modules".  For example, `Synth` might be able to provide exchange rates, stock prices, and crypto prices:

```rb
class DataProvider::Synth
  include DataProvider::ExchangeRate::Provideable
  include DataProvider::StockPrice::Provideable
  include DataProvider::CryptoPrice::Provideable
end
```

While `Zillow` only provides home price data:

```rb
class DataProvider::Zillow
  include DataProvider::HomePricing::Provideable
end
```

The goal of this PR is to make the setup process intuitive for self-hosters, as described below:

## Self hosting provider configuration example 

_Please note, providers like Zillow are not yet available and only for illustration purposes_

### Step 1: Add API keys to `.env`

```
SYNTH_API_KEY=
ZILLOW_API_KEY=
```

### Step 2: Configure `data_providers.yml` to use desired APIs

```yml
exchange_rates:
  provider: Synth 
  api_key: <%= ENV["SYNTH_API_KEY"] %>

housing_data:
  provider: Zillow 
  api_key: <%= ENV["YOUR_ZILLOW_API_KEY"] %>
```