### PR TITLE
Fix ZeroDivisionError

### DIFF
--- a/app/models/value_group.rb
+++ b/app/models/value_group.rb
@@ -40,7 +40,8 @@
     end
 
     def percent_of_total
-        return 100 if parent.nil?
+        return 100 if parent.nil? || parent.sum.zero?
+
         ((sum / parent.sum) * 100).round(1)
     end
 


### PR DESCRIPTION
It's been a little while since I've had time to check in on this project, I pulled the latest changes and ran the migration and ran into a ZeroDivisionError.

I didn't have any liabilities set so the sum was equal to 0.

This change fixes the error so that page can render:
![Screenshot 2024-03-20 at 16 44 14](https://github.com/maybe-finance/maybe/assets/1793797/4fb0e589-eb97-477e-ba31-e9a721144fda)
