### PR TITLE
add uniq index for users email to ensure uniqueness

### DIFF
--- a/db/migrate/20240325064211_add_uniq_index_to_users_email.rb
+++ b/db/migrate/20240325064211_add_uniq_index_to_users_email.rb
@@ -1,0 +1,5 @@
+class AddUniqIndexToUsersEmail < ActiveRecord::Migration[7.2]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_03_19_154732) do
+ActiveRecord::Schema[7.2].define(version: 2024_03_25_064211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -232,6 +232,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_19_154732) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["family_id"], name: "index_users_on_family_id"
   end
 


### PR DESCRIPTION
I noticed that the User model has a uniqueness validation for the email. It is usually recommended to back this uniqueness at the database level too. This PR adds this uniq index.

The default Rails rubocop settings does not provide this out of the box but there is a cop for that. It is personally one of the few extra rules I add as it is quit easy to forget

If needed, the rule is 

```yml
Rails/UniqueValidationWithoutIndex:
  Enabled: true
```

