### PR TITLE
Close new account modal when clicking outside of it

### DIFF
--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (content:) -%>
 <%= turbo_frame_tag "modal" do %>
-  <dialog class="bg-white border border-alpha-black-25 rounded-2xl max-h-[556px] max-w-[580px] w-full shadow-xs h-full" data-controller="modal" data-action="click->modal#click_outside">
+  <dialog class="bg-white border border-alpha-black-25 rounded-2xl max-h-[556px] max-w-[580px] w-full shadow-xs h-full" data-controller="modal" data-action="click->modal#clickOutside">
     <div class="flex flex-col h-full">
       <%= content %>
     </div>


### PR DESCRIPTION
You can't close new account modal when clicking outside of it;

![image](https://github.com/maybe-finance/maybe/assets/35230028/9fe7ed87-83ec-417c-bbf8-065c23149f3c)
