### PR TITLE
Account Sync should happen at login, 1x per day, OR on-demand

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -21,7 +21,7 @@ class AccountsController < ApplicationController
   def update
     if @account.update(account_params.except(:accountable_type))
 
-      @account.sync_later if account_params[:is_active] == "1"
+      @account.sync_later if account_params[:is_active] == "1" && @account.can_sync?
 
       respond_to do |format|
         format.html { redirect_to accounts_path, notice: t(".success") }
@@ -54,15 +54,12 @@ class AccountsController < ApplicationController
   end
 
   def sync
-    @account.sync_later
+    @account.sync_later if @account.can_sync?
 
     respond_to do |format|
       format.html { redirect_to account_path(@account), notice: t(".success") }
       format.turbo_stream do
-        render turbo_stream: [
-          turbo_stream.append("notification-tray", partial: "shared/notification", locals: { type: "success", content: t(".success") }),
-          turbo_stream.replace("sync_message", partial: "accounts/sync_message", locals: { is_syncing: true })
-        ]
+        render turbo_stream: turbo_stream.append("notification-tray", partial: "shared/notification", locals: { type: "success", content: t(".success") })
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,8 @@ class ApplicationController < ActionController::Base
   include Authentication
   include Pagy::Backend
 
+  before_action :sync_accounts
+
   default_form_builder ApplicationFormBuilder
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
@@ -13,4 +15,12 @@ class ApplicationController < ActionController::Base
     ENV["HOSTED"] == "true"
   end
   helper_method :hosted_app?
+
+  def sync_accounts
+    return if Current.user.blank?
+
+    if Current.user.last_login_at.nil? || Current.user.last_login_at.before?(Date.current.beginning_of_day)
+      Current.family.sync_accounts
+    end
+  end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -3,11 +3,13 @@ module Authentication
 
   included do
     before_action :authenticate_user!
+    after_action :set_last_login_at
   end
 
   class_methods do
     def skip_authentication(**options)
       skip_before_action :authenticate_user!, **options
+      skip_after_action :set_last_login_at, **options
     end
   end
 
@@ -30,5 +32,9 @@ module Authentication
   def logout
     Current.user = nil
     reset_session
+  end
+
+  def set_last_login_at
+    Current.user.update(last_login_at: DateTime.now)
   end
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -43,4 +43,8 @@ class Family < ApplicationRecord
   def liabilities
     Money.new(accounts.active.liabilities.map { |account| account.balance_money.exchange_to(currency) || 0 }.sum, currency)
   end
+
+  def sync_accounts
+    accounts.each { |account| account.sync_later if account.can_sync? }
+  end
 end

--- a/db/migrate/20240401213443_add_last_sync_date_to_accounts.rb
+++ b/db/migrate/20240401213443_add_last_sync_date_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddLastSyncDateToAccounts < ActiveRecord::Migration[7.2]
+  def change
+    add_column :accounts, :last_sync_date, :date
+  end
+end

--- a/db/migrate/20240403192649_add_last_login_at_to_users.rb
+++ b/db/migrate/20240403192649_add_last_login_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddLastLoginAtToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :last_login_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_03_25_064211) do
+ActiveRecord::Schema[7.2].define(version: 2024_04_01_213443) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_03_25_064211) do
     t.enum "status", default: "ok", null: false, enum_type: "account_status"
     t.jsonb "sync_warnings", default: "[]", null: false
     t.jsonb "sync_errors", default: "[]", null: false
+    t.date "last_sync_date"
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["family_id"], name: "index_accounts_on_family_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_04_01_213443) do
+ActiveRecord::Schema[7.2].define(version: 2024_04_03_192649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -233,6 +233,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_04_01_213443) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "last_login_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["family_id"], name: "index_users_on_family_id"
   end


### PR DESCRIPTION
Closes #585 

To handle the account sync I've created a `can_sync?` method that:

- Skips sync if the account is not active
- Skips sync if the account is syncing in background;
- Permits account sync if `last_sync_date` is blank or is not today

There are a couple of things that I'd like to change but I don't know if this PR the right place:

### Sync account on activation/deactivation

Currently, we force an account sync in `AccountsController#update` when `account_params[:is_active] == "1"`.

https://github.com/maybe-finance/maybe/blob/ea3ba4f33a8fa06098489e7e6b34d56b38fff3e1/app/controllers/accounts_controller.rb#L21-L25

It's probably better to move this logic to an `after_save` callback, so we're always sure that account sync is triggered when the account is activated or deactivated.

### Show sync message when user clicks the "sync" button

Currently, the sync message is always shown because we pass the variable `is_syncing: true`:

https://github.com/maybe-finance/maybe/blob/ea3ba4f33a8fa06098489e7e6b34d56b38fff3e1/app/controllers/accounts_controller.rb#L56-L69

I'd simply remove the rendering of `accounts/sync_message` and let Action Cable render it when the job in the background starts.