### PR TITLE
Fix dropdown issues and add dummy transaction category edit dropdown

### DIFF
--- a/app/javascript/controllers/dropdown_controller.js
+++ b/app/javascript/controllers/dropdown_controller.js
@@ -6,12 +6,15 @@ export default class extends Controller {
   static values = { closeOnClick: { type: Boolean, default: true } }
 
   toggleMenu = (e) => {
-    e.stopPropagation(); // Prevent event from closing the menu immediately
     this.menuTarget.classList.contains("hidden") ? this.showMenu() : this.hideMenu();
   }
 
   showMenu = () => {
-    document.addEventListener("click", this.onDocumentClick);
+    setTimeout(() => {
+      // Registering the listener asynchronously prevents event from closing the menu immediately
+      document.addEventListener("click", this.onDocumentClick);
+    }, 0)
+
     this.menuTarget.classList.remove("hidden");
   }
 
@@ -25,7 +28,7 @@ export default class extends Controller {
   }
 
   onDocumentClick = (e) => {
-    if (this.menuTarget.contains(e.target) && !this.closeOnClickValue ) {
+    if (this.element.contains(e.target) && !this.closeOnClickValue ) {
       // user has clicked inside of the dropdown
       e.stopPropagation();
       return;

--- a/app/javascript/tailwindColors.js
+++ b/app/javascript/tailwindColors.js
@@ -3,21 +3,6 @@
  * Stimulus controllers to reference our color palette.  Mostly used for D3 charts.
  */
 
-export const categoryColors = [
-   "#e99537",
-   "#4da568",
-   "#6471eb",
-   "#db5a54",
-   "#df4e92",
-   "#c44fe9",
-   "#eb5429",
-   "#61c9ea",
-   "#805dee",
-   "#6ad28a"
-]
-
-export const categoryDefaultColor = "#737373"
-
 export default {
   transparent: "transparent",
   current: "currentColor",

--- a/app/models/transaction/category.rb
+++ b/app/models/transaction/category.rb
@@ -6,15 +6,19 @@ class Transaction::Category < ApplicationRecord
 
   before_update :clear_internal_category, if: :name_changed?
 
+  COLORS = %w[#e99537 #4da568 #6471eb #db5a54 #df4e92 #c44fe9 #eb5429 #61c9ea #805dee #6ad28a]
+
+  UNCATEGORIZED_COLOR = "#737373"
+
   DEFAULT_CATEGORIES = [
-    { internal_category: "income", color: "#e99537" },
-    { internal_category: "food_and_drink", color: "#4da568" },
-    { internal_category: "entertainment", color: "#6471eb" },
-    { internal_category: "personal_care", color: "#db5a54" },
-    { internal_category: "general_services", color: "#df4e92" },
-    { internal_category: "auto_and_transport", color: "#c44fe9" },
-    { internal_category: "rent_and_utilities", color: "#eb5429" },
-    { internal_category: "home_improvement", color: "#61c9ea" }
+    { internal_category: "income", color: COLORS[0] },
+    { internal_category: "food_and_drink", color: COLORS[1] },
+    { internal_category: "entertainment", color: COLORS[2] },
+    { internal_category: "personal_care", color: COLORS[3] },
+    { internal_category: "general_services", color: COLORS[4] },
+    { internal_category: "auto_and_transport", color: COLORS[5] },
+    { internal_category: "rent_and_utilities", color: COLORS[6] },
+    { internal_category: "home_improvement", color: COLORS[7] }
   ]
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/views/shared/_category_badge.html.erb
+++ b/app/views/shared/_category_badge.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (name: "Uncategorized", color: "#737373") %>
+<%# locals: (name: "Uncategorized", color: Transaction::Category::UNCATEGORIZED_COLOR) %>
 <% background_color = "color-mix(in srgb, #{color} 5%, white)" %>
 <% border_color = "color-mix(in srgb, #{color} 10%, white)" %>
 <span class="border text-sm font-medium px-2.5 py-1 rounded-full cursor-pointer" style="background-color: <%= background_color %>; border-color: <%= border_color %>; color: <%= color %>"><%= name %></span>

--- a/app/views/transactions/_category_dropdown.html.erb
+++ b/app/views/transactions/_category_dropdown.html.erb
@@ -17,19 +17,7 @@
             No categories found
           </div>
           <% Current.family.transaction_categories.each do |category| %>
-            <% is_selected = category.id == transaction.category.try(:id) %>
-            <%= content_tag :div, class: ["filterable-item flex items-center hover:bg-gray-25 border-none rounded-lg px-2 py-1 group", { "bg-gray-25": is_selected }], data: { filter_name: category.name } do %>
-              <%= form.radio_button :category_id, category.id, class: "hidden", data: { auto_submit_form_target: "auto" } %>
-              <%= label dom_id(transaction), :transaction_category_id, value: category.id, class: "flex w-full items-center gap-1.5 cursor-pointer" do %>
-                <span class="w-5 h-5">
-                  <%= lucide_icon("check", class: "w-5 h-5 text-gray-500") if is_selected %>
-                </span>
-                <%= render partial: "shared/category_badge", locals: { name: category.name, color: category.color } %>
-              <% end %>
-              <button class="ml-auto flex items-center justify-center hover:bg-gray-50 w-8 h-8 rounded-lg invisible group-hover:visible cursor-not-allowed" type="button" disabled>
-                <%= lucide_icon("more-horizontal", class: "w-5 h-5 text-gray-500") %>
-              </button>
-            <% end %>
+            <%= render partial: "transactions/category_dropdown/category_row", locals: { form:, category:, is_selected: category.id == transaction.category.try(:id), namespace: dom_id(transaction) } %>
           <% end %>
         <% end %>
         <hr/>

--- a/app/views/transactions/category_dropdown/_category_row.html.erb
+++ b/app/views/transactions/category_dropdown/_category_row.html.erb
@@ -1,0 +1,12 @@
+<%# locals: (form:, category:, is_selected:, namespace:) %>
+<%= content_tag :div, class: ["filterable-item flex items-center hover:bg-gray-25 border-none rounded-lg px-2 py-1 group", { "bg-gray-25": is_selected }], data: { filter_name: category.name } do %>
+  <%= form.radio_button :category_id, category.id, class: "hidden", data: { auto_submit_form_target: "auto" } %>
+  <%= label namespace, :transaction_category_id, value: category.id, class: "flex w-full items-center gap-1.5 cursor-pointer" do %>
+    <span class="w-5 h-5">
+      <%= lucide_icon("check", class: "w-5 h-5 text-gray-500") if is_selected %>
+    </span>
+    <%= render partial: "shared/category_badge", locals: { name: category.name, color: category.color } %>
+  <% end %>
+
+  <%= render partial: "transactions/category_dropdown/edit_category_dropdown", locals: { category: } %>
+<% end %>

--- a/app/views/transactions/category_dropdown/_color_picker.html.erb
+++ b/app/views/transactions/category_dropdown/_color_picker.html.erb
@@ -1,0 +1,8 @@
+<%# locals: (value:) %>
+<div class="flex gap-1.5 p-2">
+  <% Transaction::Category::COLORS.each do |color| %>
+    <% is_selected = value === color %>
+    <% border_color = "color-mix(in srgb, #{color} 30%, white)" %>
+    <span class="w-7 h-7 rounded-full inline-block border-4" style="background-color: <%= color %>; border-color: <%= is_selected ? border_color : "white" %>" ></span>
+  <% end %>
+</div>

--- a/app/views/transactions/category_dropdown/_edit_category_dropdown.html.erb
+++ b/app/views/transactions/category_dropdown/_edit_category_dropdown.html.erb
@@ -1,0 +1,28 @@
+<%# locals: (category:) %>
+<div data-controller="dropdown" data-dropdown-close-on-click-value="false">
+  <button class="flex items-center justify-center hover:bg-gray-50 w-8 h-8 rounded-lg" type="button" data-action="click->dropdown#toggleMenu">
+    <%= lucide_icon("more-horizontal", class: "w-5 h-5 text-gray-500") %>
+  </button>
+  <div class="absolute z-30 hidden w-screen mt-2 max-w-min" data-dropdown-target="menu">
+    <div class="w-96 text-sm font-semibold leading-6 text-gray-900 bg-white shadow-lg shrink rounded-xl ring-1 ring-gray-900/5">
+      <div class="flex flex-col">
+        <div class="flex flex-col p-1.5 gap-1.5">
+          <div class="relative flex items-center border border-gray-200 rounded-lg">
+            <input value="<%= category.name %>" class="cursor-not-allowed font-normal h-10 relative pl-6 w-full border-none rounded-lg" disabled />
+            <div class="w-2 h-5 ml-2 absolute inset-0 transform top-1/2 -translate-y-1/2 rounded-md" style="background-color: <%= category.color %>"></div>
+          </div>
+          <div class="cursor-not-allowed">
+            <%= render partial: "transactions/category_dropdown/color_picker", locals: { value: category.color } %>
+          </div>
+        </div>
+        <hr/>
+        <div class="p-1.5 w-full">
+          <button class="cursor-not-allowed flex text-sm font-medium items-center gap-2 text-red-600 w-full rounded-lg p-2 hover:bg-gray-100" disabled>
+            <%= lucide_icon("trash-2", class: "w-5 h-5") %>
+            Delete category
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Somewhat related to #572 but due to limited free time in the upcoming two weeks I won't be able to finish the issue all the way through. Hopefully the things I've managed to do will still be of some value, hence this PR. Feel free to take this over or merge it as it is (I'll be able to address feedback tomorrow).

This PR focuses on improvements to the dropdown component:
- dropdowns now close when you click some other element that also triggers them (e.g. try clicking one category badge and then clicking another one - in `main` you'd end up with two dropdowns being open at the same time)
- fixes "nested" dropdowns not opening correctly (which I've demonstrated by adding a dummy category edit form)

<img width="1096" alt="Screenshot 2024-04-02 at 19 37 23" src="https://github.com/maybe-finance/maybe/assets/113784/35ec5585-cac5-463e-b866-9bff1bc172bd">

There's still a scrolling bug where, upon scrolling through the list of categories, the opened edit dropdown stays in places:

<img width="654" alt="Screenshot 2024-04-02 at 19 46 37" src="https://github.com/maybe-finance/maybe/assets/113784/eb92fd85-63a5-4271-bc37-d194f381f52d">

