### PR TITLE
Centralize authentication

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,6 +1,5 @@
 class AccountsController < ApplicationController
   include Filterable
-  before_action :authenticate_user!
   before_action :set_account, only: %i[ show update destroy sync ]
 
   def new

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -2,7 +2,13 @@ module Authentication
   extend ActiveSupport::Concern
 
   included do
-    helper_method :user_signed_in?
+    before_action :authenticate_user!
+  end
+
+  class_methods do
+    def skip_authentication(**options)
+      skip_before_action :authenticate_user!, **options
+    end
   end
 
   private
@@ -13,10 +19,6 @@ module Authentication
     else
       redirect_to new_session_url
     end
-  end
-
-  def user_signed_in?
-    Current.user.present?
   end
 
   def login(user)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,5 @@
 class PagesController < ApplicationController
   include Filterable
-  before_action :authenticate_user!
 
   def dashboard
     snapshot = Current.family.snapshot(@period)

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -1,4 +1,6 @@
 class PasswordResetsController < ApplicationController
+  skip_authentication
+
   layout "auth"
 
   before_action :set_user_by_token, only: :update

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,6 +1,4 @@
 class PasswordsController < ApplicationController
-  before_action :authenticate_user!
-
   def edit
   end
 

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,4 +1,6 @@
 class RegistrationsController < ApplicationController
+  skip_authentication
+
   layout "auth"
 
   before_action :set_user, only: :create

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_authentication only: %i[new create]
+
   layout "auth"
 
   def new

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,6 +1,4 @@
 class SettingsController < ApplicationController
-  before_action :authenticate_user!
-
   def edit
   end
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,5 +1,4 @@
 class TransactionsController < ApplicationController
-  before_action :authenticate_user!
   before_action :set_transaction, only: %i[ show edit update destroy ]
 
   def index

--- a/app/controllers/valuations_controller.rb
+++ b/app/controllers/valuations_controller.rb
@@ -1,6 +1,4 @@
 class ValuationsController < ApplicationController
-  before_action :authenticate_user!
-
   def create
     @account = Current.family.accounts.find(params[:account_id])
 


### PR DESCRIPTION
By default, every page in the app should require authentication except registration/login/password resets.

Centralizing auth allows us to [implement actions that run around the authentication](https://github.com/maybe-finance/maybe/pull/594#discussion_r1549657005) lifecycle easier.