### PR TITLE
Simplify setup using Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# You can safely generate one with
+# cat /dev/urandom | head -n 10 | sha256sum
+SECRET_KEY_BASE=
+
 # Exchange Rate API
 # This is used to convert between different currencies in the app. We use Synth, which is a Maybe product. You can sign up for a free account at synthfinance.com.
 SYNTH_API_KEY=
@@ -12,10 +16,10 @@ SMTP_PASSWORD=
 TLS=true
 
 # Database Configuration
-DB_HOST=localhost # May need to be changed to `DB_HOST=db` if using devcontainer
+DB_HOST=db
 DB_PORT=5432
-POSTGRES_PASSWORD=postgres
-POSTGRES_USER=postgres
+POSTGRES_USER=maybe
+POSTGRES_PASSWORD=changeme
 
 # App Domain
 # This is the domain that your Maybe instance will be hosted at. It is used to generate links in emails and other places.

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@
 
 # Ignore .devcontainer files
 compose-dev.yaml
+compose.yml

--- a/compose.yml.sample
+++ b/compose.yml.sample
@@ -1,0 +1,18 @@
+services:
+  db:
+    image: postgres:16-alpine
+    restart: always
+    env_file: .env
+    volumes:
+      - db:/var/lib/postgresql/data
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file: .env
+    ports:
+      - "127.0.0.1:3000:3000"
+
+volumes:
+  db:

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,88 +1,20 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
   port: <%= ENV.fetch("DB_PORT") { "5432" } %>
-  password: <%= ENV.fetch("POSTGRES_PASSWORD") { nil } %>
   user: <%= ENV.fetch("POSTGRES_USER") { nil } %>
+  password: <%= ENV.fetch("POSTGRES_PASSWORD") { nil } %>
 
 development:
   <<: *default
-  database: maybe_development
+  database: <%= ENV.fetch("POSTGRES_DB") { "maybe_development" } %>
 
-  # The specified database role being used to connect to PostgreSQL.
-  # To create additional roles in PostgreSQL see `$ createuser --help`.
-  # When left blank, PostgreSQL will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: maybe
-
-  # The password associated with the PostgreSQL role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: maybe_test
+  database: <%= ENV.fetch("POSTGRES_DB") { "maybe_test" } %>
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
-  database: maybe_production
-  username: maybe
-  password: <%= ENV["MAYBE_DATABASE_PASSWORD"] %>
+  database: <%= ENV.fetch("POSTGRES_DB") { "maybe_production" } %>


### PR DESCRIPTION
This is a barebones configuration for Docker Compose.

1. `docker compose build`
2. `docker compose up -d`

Application will be available on `http://localhost:3000`.

Actual production deployments will require a reverse proxy in front of the `app` container.