### PR TITLE
Enhance currency selector to list 'All Others' after 'Popular'

### DIFF
--- a/config/locales/views/account/en.yml
+++ b/config/locales/views/account/en.yml
@@ -6,6 +6,9 @@ en:
     index:
       new_account: New account
     new:
+      currency:
+        all_others: All Others
+        popular: Popular
       name:
         label: Account name
         placeholder: Example account name

--- a/lib/money/currency.rb
+++ b/lib/money/currency.rb
@@ -26,6 +26,10 @@ class Money::Currency
             @all ||= YAML.load_file(CURRENCIES_FILE_PATH)
         end
 
+        def all_instances
+            all.values.map { |currency_data| new(currency_data["iso_code"]) }
+        end
+
         def popular
             all.values.sort_by { |currency| currency["priority"] }.first(12).map { |currency_data| new(currency_data["iso_code"]) }
         end


### PR DESCRIPTION
This PR enhances the currency selector by ensuring that not only popular currencies are displayed, but it also categorizes other available currencies within optgroups.

<img width="1406" alt="money currency selector w/ optgroups" src="https://github.com/maybe-finance/maybe/assets/6089872/9e87d6ee-269d-4f70-bd42-e48f050d5664">
