### PR TITLE
Allow 2 decimals when adding a balance

### DIFF
--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -36,7 +36,8 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     default_options = {
       class: "form-field__input",
       value: money&.amount,
-      placeholder: Money.new(0, money&.currency || Money.default_currency).format
+      placeholder: Money.new(0, money&.currency || Money.default_currency).format,
+      step: "0.01" # Not all currencies have 2 decimal places
     }
 
     merged_options = default_options.merge(options)


### PR DESCRIPTION
Fixes #613 

This should fix money fields throughout the app.

One thing I'm not sure of is that not all currencies allow decimals, so this should maybe be dynamic based on the currency this input is in? Maybe that's a property on that `Money.new(0, money&.currency || Money.default_currency)` line too?