### PR TITLE
Use `placeholder-shown:` for reduced opacity

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -42,8 +42,9 @@
   }
 
   .form-field__input {
-    @apply p-3 w-full bg-transparent border-none opacity-50;
+    @apply p-3 w-full bg-transparent border-none opacity-100;
     @apply focus:outline-none focus:ring-0 focus:opacity-100;
+    @apply placeholder-shown:opacity-50;
   }
 
   .form-field__submit {


### PR DESCRIPTION
Placeholders:

<img width="636" alt="image" src="https://github.com/maybe-finance/maybe/assets/144075/cf1a56c2-5246-4566-808c-1f0c7660ae28">

Actual values (even when out of focus):

<img width="643" alt="image" src="https://github.com/maybe-finance/maybe/assets/144075/2e74997e-1bbf-441a-98d0-e7a909ec95be">

On main, the _Wells Fargo_ & _420_ value would've been at 50% opacity when you moved focus out of these inputs. That felt broken.