### PR TITLE
Add modal for new transactions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Authentication, Invitable, SelfHostable
+  include Authentication, Invitable, SelfHostable, TurboStreamsRedirect
   include Pagy::Backend
 
   before_action :sync_accounts

--- a/app/controllers/concerns/turbo_streams_redirect.rb
+++ b/app/controllers/concerns/turbo_streams_redirect.rb
@@ -1,0 +1,28 @@
+module TurboStreamsRedirect
+  extend ActiveSupport::Concern
+
+  def redirect_to(options = {}, response_options = {})
+    turbo_frame = response_options.delete(:turbo_frame)
+    turbo_action = response_options.delete(:turbo_action)
+    location = url_for(options)
+
+    if request.format.turbo_stream? && turbo_frame.present?
+      alert, notice, flash_override = response_options.values_at(:alert, :notice, :flash)
+      flash_to_merge = flash_override || {}
+      flash_to_merge[:alert] = alert if alert.present?
+      flash_to_merge[:notice] = notice if notice.present?
+      flash.merge!(flash_to_merge)
+
+      case Rack::Utils.status_code(response_options.fetch(:status, :created))
+      when 300..399 then response_options[:status] = :created
+      end
+
+      render "turbo/streams/redirect", **response_options.with_defaults(
+        locals: { location: location, turbo_frame: turbo_frame, turbo_action: turbo_action },
+        location: location,
+      )
+    else
+      super
+    end
+  end
+end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -59,6 +59,8 @@ class TransactionsController < ApplicationController
     account = Current.family.accounts.find(params[:transaction][:account_id])
 
     @transaction = account.transactions.build(transaction_params)
+    @transaction.amount = @transaction.amount.abs
+    @transaction.amount = -@transaction.amount if params[:transaction][:kind] == "income"
 
     if @transaction.save
       @transaction.account.sync_later

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -50,6 +50,7 @@ class TransactionsController < ApplicationController
 
   def new
     @transaction = Transaction.new
+    @transaction.account = Current.family.accounts.find(params[:account_id]) if params[:account_id]
   end
 
   def edit

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -15,7 +15,6 @@ class TransactionsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.turbo_stream
     end
   end
 
@@ -61,13 +60,11 @@ class TransactionsController < ApplicationController
 
     @transaction = account.transactions.build(transaction_params)
 
-    respond_to do |format|
-      if @transaction.save
-        @transaction.account.sync_later
-        format.html { redirect_to transactions_url, notice: t(".success") }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-      end
+    if @transaction.save
+      @transaction.account.sync_later
+      redirect_to transactions_url, notice: t(".success"), turbo_frame: "_top"
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -22,6 +22,22 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     RUBY_EVAL
   end
 
+  def radio_tab_field(method, tag_value, options = {}, &block)
+    tab_class = "
+      px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center border border-transparent
+      has-[:checked]:bg-white has-[:checked]:border has-[:checked]:border-alpha-black-25 has-[:checked]:shadow-xs
+      has-[:disabled]:cursor-not-allowed
+    "
+
+    content = @template.capture(&block) if block_given?
+    content ||= tag_value.to_s.humanize
+
+    label("#{method}_#{tag_value}".to_sym, class: tab_class) do
+      radio_button(method, tag_value, options.except(:label).merge(class: "hidden")) +
+      content
+    end
+  end
+
   # See `Monetizable` concern, which adds a _money suffix to the attribute name
   # For a monetized field, the setter will always be the attribute name without the _money suffix
   def money_field(method, options = {})

--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -30,7 +30,11 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
     "
 
     content = @template.capture(&block) if block_given?
-    content ||= tag_value.to_s.humanize
+    unless content
+      label_text = @template.tag.span(options[:label] || tag_value.to_s.humanize)
+      icon = options[:icon] ? @template.lucide_icon(options[:icon], class: "w-4 h-4") : ""
+      content = @template.safe_join([ icon, label_text ])
+    end
 
     label("#{method}_#{tag_value}".to_sym, class: tab_class) do
       radio_button(method, tag_value, options.except(:label).merge(class: "hidden")) +

--- a/app/views/accounts/_transactions.html.erb
+++ b/app/views/accounts/_transactions.html.erb
@@ -2,7 +2,7 @@
 <div class="bg-white space-y-4 p-5 border border-alpha-black-25 rounded-xl shadow-xs">
   <div class="flex justify-between items-center">
     <h3 class="font-medium text-lg">Transactions</h3>
-    <%= link_to new_transaction_path, class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg" do %>
+    <%= link_to new_transaction_path(account_id: @account), class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg", data: { turbo_frame: "modal" } do %>
       <%= lucide_icon("plus", class: "w-5 h-5 text-gray-900") %>
       <span class="text-sm">New transaction</span>
     <% end %>

--- a/app/views/accounts/_transactions.html.erb
+++ b/app/views/accounts/_transactions.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (transactions:)%>
+<%# locals: (account:, transactions:)%>
 <div class="bg-white space-y-4 p-5 border border-alpha-black-25 rounded-xl shadow-xs">
   <div class="flex justify-between items-center">
     <h3 class="font-medium text-lg">Transactions</h3>
-    <%= link_to new_transaction_path(account_id: @account), class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg", data: { turbo_frame: "modal" } do %>
+    <%= link_to new_transaction_path(account_id: account), class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg", data: { turbo_frame: "modal" } do %>
       <%= lucide_icon("plus", class: "w-5 h-5 text-gray-900") %>
       <span class="text-sm">New transaction</span>
     <% end %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -71,7 +71,7 @@
         <%= render partial: "accounts/account_history", locals: { account: @account, valuations: @valuation_series } %>
       </div>
       <div data-tabs-target="tab" id="account-transactions-tab" class="hidden">
-        <%= render partial: "accounts/transactions", locals: { transactions: @account.transactions.order(date: :desc) } %>
+        <%= render partial: "accounts/transactions", locals: { account: @account, transactions: @account.transactions.order(date: :desc) } %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (content:) -%>
 <%= turbo_frame_tag "modal" do %>
-  <dialog class="bg-white border border-alpha-black-25 rounded-2xl max-h-[556px] max-w-[580px] w-full shadow-xs h-full" data-controller="modal" data-action="click->modal#clickOutside">
+  <dialog class="bg-white border border-alpha-black-25 rounded-2xl max-h-[80vh] max-w-[580px] w-full shadow-xs" data-controller="modal" data-action="click->modal#clickOutside">
     <div class="flex flex-col h-full">
       <%= content %>
     </div>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -22,7 +22,7 @@
 
   <%= f.money_field :amount_money, label: "Amount", required: true %>
 
-  <%= f.collection_select :category_id, Current.family.transaction.categories, :id, :name, { prompt: "Select an category", label: "Category" }, required: true %>
+  <%= f.collection_select :category_id, Current.family.transaction_categories.all, :id, :name, { prompt: "Select an category", label: "Category" }, required: true %>
 
   <%= f.date_field :date, label: "Date", required: true %>
 

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,7 +1,47 @@
 <%= form_with model: @transaction do |f| %>
-  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account" } %>
-  <%= f.date_field :date, label: "Date" %>
-  <%= f.text_field :name, label: "Name", placeholder: "Groceries" %>
-  <%= f.money_field :amount_money, label: "Amount" %>
-  <%= f.submit %>
+  <div class="bg-gray-50 rounded-lg p-1 flex gap-1 text-sm text-gray-900 font-medium">
+    <%= f.radio_button :kind, "expense", class: "peer/expense hidden", checked: true %>
+    <%=
+      f.label(
+        :kind_expense,
+        class: "
+          px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center border border-transparent
+          peer-checked/expense:bg-white peer-checked/expense:border peer-checked/expense:border-alpha-black-25 peer-checked/expense:shadow-xs
+        "
+      ) do
+    %>
+      <%= lucide_icon "minus-circle", class: "w-4 h-4" %>
+      <span>Expense</span>
+    <% end %>
+    <%= f.radio_button :kind, "income", class: "peer/income hidden" %>
+    <%=
+      f.label(
+        :kind_income,
+        class: "
+          px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center border border-transparent
+          peer-checked/income:bg-white peer-checked/income:border peer-checked/income:border-alpha-black-25 peer-checked/income:shadow-xs
+        "
+      ) do
+    %>
+      <%= lucide_icon "plus-circle", class: "w-4 h-4" %>
+      <span>Income</span>
+    <% end %>
+    <button disabled class="px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center cursor-not-allowed">
+      <%= lucide_icon "arrow-right-left", class: "w-4 h-4" %>
+      <span>Transfer</span>
+    </button>
+  </div>
+
+  <%= f.text_field :name, label: "Description", placeholder: "Describe transaction...", required: true %>
+
+  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account" }, required: true %>
+
+  <%= f.money_field :amount_money, label: "Amount", required: true %>
+
+  <% sorted_categories = Current.family.transaction_categories.sort_by { |category| category.id == transaction.category_id ? 0 : 1 } %>
+  <%= f.collection_select :category_id, sorted_categories, :id, :name, { prompt: "Select an category", label: "Category" }, required: true %>
+
+  <%= f.date_field :date, label: "Date", required: true %>
+
+  <%= f.submit "Add transaction" %>
 <% end %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -2,29 +2,29 @@
   <div class="bg-gray-50 rounded-lg p-1 flex gap-1 text-sm text-gray-900 font-medium">
     <%= f.radio_tab_field :kind, :expense, checked: true do %>
       <%= lucide_icon "minus-circle", class: "w-4 h-4" %>
-      <span>Expense</span>
+      <span><%= t(".expense") %></span>
     <% end %>
 
     <%= f.radio_tab_field :kind, :income do %>
       <%= lucide_icon "plus-circle", class: "w-4 h-4" %>
-      <span>Income</span>
+      <span><%= t(".income") %></span>
     <% end %>
 
     <%= f.radio_tab_field :kind, :transfer, disabled: true do %>
       <%= lucide_icon "arrow-right-left", class: "w-4 h-4" %>
-      <span>Transfer</span>
+      <span><%= t(".transfer") %></span>
     <% end %>
   </div>
 
-  <%= f.text_field :name, label: "Description", placeholder: "Describe transaction...", required: true %>
+  <%= f.text_field :name, label: t(".description.label"), placeholder: t(".description.placeholder"), required: true %>
 
-  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account" }, required: true %>
+  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: t(".account.prompt"), label: t(".account.label") }, required: true %>
 
-  <%= f.money_field :amount_money, label: "Amount", required: true %>
+  <%= f.money_field :amount_money, label: t(".amount.label"), required: true %>
 
-  <%= f.collection_select :category_id, Current.family.transaction_categories.all, :id, :name, { prompt: "Select an category", label: "Category" }, required: true %>
+  <%= f.collection_select :category_id, Current.family.transaction_categories.all, :id, :name, { prompt: t(".category.prompt"), label: t(".category.label")}, required: true %>
 
-  <%= f.date_field :date, label: "Date", required: true %>
+  <%= f.date_field :date, label: t(".date.label"), required: true %>
 
-  <%= f.submit "Add transaction" %>
+  <%= f.submit t(".submit") %>
 <% end %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,30 +1,14 @@
 <%= form_with model: @transaction do |f| %>
-  <div class="bg-gray-50 rounded-lg p-1 flex gap-1 text-sm text-gray-900 font-medium">
-    <%= f.radio_tab_field :kind, :expense, checked: true do %>
-      <%= lucide_icon "minus-circle", class: "w-4 h-4" %>
-      <span><%= t(".expense") %></span>
-    <% end %>
-
-    <%= f.radio_tab_field :kind, :income do %>
-      <%= lucide_icon "plus-circle", class: "w-4 h-4" %>
-      <span><%= t(".income") %></span>
-    <% end %>
-
-    <%= f.radio_tab_field :kind, :transfer, disabled: true do %>
-      <%= lucide_icon "arrow-right-left", class: "w-4 h-4" %>
-      <span><%= t(".transfer") %></span>
-    <% end %>
-  </div>
+  <fieldset class="bg-gray-50 rounded-lg p-1 flex gap-1 text-sm text-gray-900 font-medium">
+    <%= f.radio_tab_field :kind, :expense, checked: true, label: t(".expense"), icon: "minus-circle" %>
+    <%= f.radio_tab_field :kind, :income, label: t(".income"), icon: "plus-circle" %>
+    <%= f.radio_tab_field :kind, :transfer, disabled: true, label: t(".transfer"), icon: "arrow-right-left" %>
+  </fieldset>
 
   <%= f.text_field :name, label: t(".description.label"), placeholder: t(".description.placeholder"), required: true %>
-
   <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: t(".account.prompt"), label: t(".account.label") }, required: true %>
-
   <%= f.money_field :amount_money, label: t(".amount.label"), required: true %>
-
   <%= f.collection_select :category_id, Current.family.transaction_categories.all, :id, :name, { prompt: t(".category.prompt"), label: t(".category.label")}, required: true %>
-
   <%= f.date_field :date, label: t(".date.label"), required: true %>
-
   <%= f.submit t(".submit") %>
 <% end %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -22,8 +22,7 @@
 
   <%= f.money_field :amount_money, label: "Amount", required: true %>
 
-  <% sorted_categories = Current.family.transaction_categories.sort_by { |category| category.id == transaction.category_id ? 0 : 1 } %>
-  <%= f.collection_select :category_id, sorted_categories, :id, :name, { prompt: "Select an category", label: "Category" }, required: true %>
+  <%= f.collection_select :category_id, Current.family.transaction.categories, :id, :name, { prompt: "Select an category", label: "Category" }, required: true %>
 
   <%= f.date_field :date, label: "Date", required: true %>
 

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,35 +1,19 @@
 <%= form_with model: @transaction do |f| %>
   <div class="bg-gray-50 rounded-lg p-1 flex gap-1 text-sm text-gray-900 font-medium">
-    <%= f.radio_button :kind, "expense", class: "peer/expense hidden", checked: true %>
-    <%=
-      f.label(
-        :kind_expense,
-        class: "
-          px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center border border-transparent
-          peer-checked/expense:bg-white peer-checked/expense:border peer-checked/expense:border-alpha-black-25 peer-checked/expense:shadow-xs
-        "
-      ) do
-    %>
+    <%= f.radio_tab_field :kind, :expense, checked: true do %>
       <%= lucide_icon "minus-circle", class: "w-4 h-4" %>
       <span>Expense</span>
     <% end %>
-    <%= f.radio_button :kind, "income", class: "peer/income hidden" %>
-    <%=
-      f.label(
-        :kind_income,
-        class: "
-          px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center border border-transparent
-          peer-checked/income:bg-white peer-checked/income:border peer-checked/income:border-alpha-black-25 peer-checked/income:shadow-xs
-        "
-      ) do
-    %>
+
+    <%= f.radio_tab_field :kind, :income do %>
       <%= lucide_icon "plus-circle", class: "w-4 h-4" %>
       <span>Income</span>
     <% end %>
-    <button disabled class="px-2 py-1 rounded-md flex-1 flex justify-center items-center gap-2 text-center cursor-not-allowed">
+
+    <%= f.radio_tab_field :kind, :transfer, disabled: true do %>
       <%= lucide_icon "arrow-right-left", class: "w-4 h-4" %>
       <span>Transfer</span>
-    </button>
+    <% end %>
   </div>
 
   <%= f.text_field :name, label: "Description", placeholder: "Describe transaction...", required: true %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-xl">Transactions</h1>
     <div class="flex items-center gap-5">
       <div class="flex items-center gap-2">
-        <%= link_to new_transaction_path, class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2" do %>
+        <%= link_to new_transaction_path, class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2", data: { turbo_frame: "modal" } do %>
           <%= lucide_icon("plus", class: "w-5 h-5") %>
           <p>New transaction</p>
         <% end %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,7 +1,7 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl mb-4">New transaction</h1>
-  <%= render "form", transaction: @transaction %>
-</div>
-<div class="flex justify-center">
-  <%= link_to "Back to transactions", transactions_path, class: "mt-8 underline text-lg font-bold" %>
-</div>
+<%= modal do %>
+  <div class="flex flex-col min-h-[530px] p-4">
+    <h1 class="text-gray-800 font-medium">New transaction</h1>
+
+    <%= render "form", transaction: @transaction %>
+  </div>
+<% end %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,7 +1,7 @@
 <%= modal do %>
   <div class="flex flex-col min-h-[530px] p-4">
     <div class="flex justify-between">
-      <h1 class="text-gray-800 font-medium">New transaction</h1>
+      <h1 class="text-gray-800 font-medium"><%= t(".title") %></h1>
       <%= lucide_icon "x", class: "w-5 h-5 text-gray-500", data: { action: "click->modal#close" } %>
     </div>
 

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,6 +1,9 @@
 <%= modal do %>
   <div class="flex flex-col min-h-[530px] p-4">
-    <h1 class="text-gray-800 font-medium">New transaction</h1>
+    <div class="flex justify-between">
+      <h1 class="text-gray-800 font-medium">New transaction</h1>
+      <%= lucide_icon "x", class: "w-5 h-5 text-gray-500", data: { action: "click->modal#close" } %>
+    </div>
 
     <%= render "form", transaction: @transaction %>
   </div>

--- a/app/views/turbo/streams/redirect.turbo_stream.erb
+++ b/app/views/turbo/streams/redirect.turbo_stream.erb
@@ -1,0 +1,11 @@
+<%= turbo_stream.append_all "head" do %>
+  <%= javascript_tag nonce: true, data: { turbo_cache: false } do %>
+    window.Turbo.visit("<%= escape_javascript response.location %>", {
+      frame: "<%= escape_javascript turbo_frame %>",
+      <% if turbo_action.present? %>
+      action: "<%= escape_javascript turbo_action %>",
+      <% end %>
+    })
+    document.currentScript.remove()
+  <% end %>
+<% end %>

--- a/app/views/turbo/streams/redirect.turbo_stream.erb
+++ b/app/views/turbo/streams/redirect.turbo_stream.erb
@@ -1,5 +1,5 @@
 <%= turbo_stream.append_all "head" do %>
-  <%= javascript_tag nonce: true, data: { turbo_cache: false } do %>
+  <script data-turbo-cache="false">
     window.Turbo.visit("<%= escape_javascript response.location %>", {
       frame: "<%= escape_javascript turbo_frame %>",
       <% if turbo_action.present? %>
@@ -7,5 +7,5 @@
       <% end %>
     })
     document.currentScript.remove()
-  <% end %>
+  </script>
 <% end %>

--- a/config/locales/views/transaction/en.yml
+++ b/config/locales/views/transaction/en.yml
@@ -1,6 +1,26 @@
 ---
 en:
   transactions:
+    new:
+      title: New Transaction
+    form:
+      expense: Expense
+      income: Income
+      transfer: Transfer
+      description:
+        label: Description
+        placeholder: Describe transaction...
+      account:
+        prompt: Select an Account
+        label: Account
+      amount:
+        label: Amount
+      category:
+        prompt: Select a Category
+        label: Category
+      date:
+        label: Date
+      submit: Add transaction
     categories:
       create:
         error: Error creating transaction category

--- a/config/locales/views/transaction/en.yml
+++ b/config/locales/views/transaction/en.yml
@@ -1,26 +1,6 @@
 ---
 en:
   transactions:
-    new:
-      title: New Transaction
-    form:
-      expense: Expense
-      income: Income
-      transfer: Transfer
-      description:
-        label: Description
-        placeholder: Describe transaction...
-      account:
-        prompt: Select an Account
-        label: Account
-      amount:
-        label: Amount
-      category:
-        prompt: Select a Category
-        label: Category
-      date:
-        label: Date
-      submit: Add transaction
     categories:
       create:
         error: Error creating transaction category
@@ -34,5 +14,25 @@ en:
       success: New transaction created successfully
     destroy:
       success: Transaction deleted successfully
+    form:
+      account:
+        label: Account
+        prompt: Select an Account
+      amount:
+        label: Amount
+      category:
+        label: Category
+        prompt: Select a Category
+      date:
+        label: Date
+      description:
+        label: Description
+        placeholder: Describe transaction...
+      expense: Expense
+      income: Income
+      submit: Add transaction
+      transfer: Transfer
+    new:
+      title: New Transaction
     update:
       success: Transaction updated successfully


### PR DESCRIPTION
This change adds the new transaction modal.

https://github.com/maybe-finance/maybe/assets/1793797/8643056f-b81d-4ccf-baa4-f3d21610ce8e

All fields are required:
<img width="1512" alt="Required fields" src="https://github.com/maybe-finance/maybe/assets/1793797/d61ae906-ab09-4b7e-94f7-03cfa93a72a0">

As part of this I've added a new `TurboStreamsRedirect` concern to the ApplicationController. This concern adds the ability to specify a turbo_frame on redirect_to, which allows us to decide from the server when to escape out of the modal by setting the turbo_frame of the redirect to `_top`.

/claim #629
Resolves #629 