### PR TITLE
implement new-transaction modal

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -50,6 +50,10 @@ class TransactionsController < ApplicationController
 
   def new
     @transaction = Transaction.new
+
+    if params[:account_id].present?
+      @transaction.account_id = params[:account_id]
+    end
   end
 
   def edit

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,10 +1,15 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="modal"
 export default class extends Controller {
   connect() {
-    if (this.element.open) return
-    else this.element.showModal()
+    this.element.addEventListener("turbo:submit-end", (event) => {
+      if (event.detail.success) {
+        this.element.close();
+      }
+    });
+    if (this.element.open) return;
+    else this.element.showModal();
   }
 
   // Hide the dialog when the user clicks outside of it

--- a/app/views/accounts/_transactions.html.erb
+++ b/app/views/accounts/_transactions.html.erb
@@ -2,7 +2,7 @@
 <div class="bg-white space-y-4 p-5 border border-alpha-black-25 rounded-xl shadow-xs">
   <div class="flex justify-between items-center">
     <h3 class="font-medium text-lg">Transactions</h3>
-    <%= link_to new_transaction_path, class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg" do %>
+    <%= link_to new_transaction_path, class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg", title: t(".new_transaction"), data: { turbo_frame: "modal" } do %>
       <%= lucide_icon("plus", class: "w-5 h-5 text-gray-900") %>
       <span class="text-sm">New transaction</span>
     <% end %>

--- a/app/views/accounts/_transactions.html.erb
+++ b/app/views/accounts/_transactions.html.erb
@@ -2,7 +2,7 @@
 <div class="bg-white space-y-4 p-5 border border-alpha-black-25 rounded-xl shadow-xs">
   <div class="flex justify-between items-center">
     <h3 class="font-medium text-lg">Transactions</h3>
-    <%= link_to new_transaction_path, class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg", title: t(".new_transaction"), data: { turbo_frame: "modal" } do %>
+    <%= link_to new_transaction_path(account_id: @account), class: "flex gap-1 font-medium items-center bg-gray-50 text-gray-900 p-2 rounded-lg", title: t(".new_transaction"), data: { turbo_frame: "modal", id: @account[:account_id] } do %>
       <%= lucide_icon("plus", class: "w-5 h-5 text-gray-900") %>
       <span class="text-sm">New transaction</span>
     <% end %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,7 +1,15 @@
 <%= form_with model: @transaction do |f| %>
+  <div class="flex gap-2 items-center">
+    <%= f.radio_button :type, 'published', checked: true %> Expense
+    <%= f.radio_button :type, 'draft' %> Income
+    <%= f.radio_button :type, 'archived', class: "cursor-not-allowed", disabled: true %> Transfer
+  </div>
   <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account" } %>
   <%= f.date_field :date, label: "Date" %>
   <%= f.text_field :name, label: "Name", placeholder: "Groceries" %>
+  <%= f.collection_select :category_id, Current.family.transaction_categories, :id, :name, { prompt: "Select a category", label: "Category" } %>
+  <%= f.text_field :notes, label: "Notes" %>
   <%= f.money_field :amount_money, label: "Amount" %>
   <%= f.submit %>
 <% end %>
+ 

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -3,7 +3,7 @@
     <h1 class="text-xl">Transactions</h1>
     <div class="flex items-center gap-5">
       <div class="flex items-center gap-2">
-        <%= link_to new_transaction_path, class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2" do %>
+        <%= link_to new_transaction_path, class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2", title: t(".new_transaction"), data: { turbo_frame: "modal" } do %>
           <%= lucide_icon("plus", class: "w-5 h-5") %>
           <p>New transaction</p>
         <% end %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -9,7 +9,7 @@
     <%= f.radio_button :type, 'income' %> Income
     <%= f.radio_button :type, 'transfer', class: "cursor-not-allowed", disabled: true %> Transfer
   </div>
-  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account" } %>
+  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account"} %>
   <%= f.date_field :date, label: "Date" %>
   <%= f.text_field :name, label: "Name", placeholder: "Groceries" %>
   <%= f.collection_select :category_id, Current.family.transaction_categories, :id, :name, { prompt: "Select a category", label: "Category" } %>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,7 +1,23 @@
-<div class="mx-auto md:w-2/3 w-full">
-  <h1 class="font-bold text-4xl mb-4">New transaction</h1>
-  <%= render "form", transaction: @transaction %>
-</div>
-<div class="flex justify-center">
-  <%= link_to "Back to transactions", transactions_path, class: "mt-8 underline text-lg font-bold" %>
-</div>
+<h1 class="text-3xl font-semibold font-display"><%= t(".title") %></h1>
+<%= modal do %>
+  <div class="flex flex-col min-h-[530px]" data-controller="list-keyboard-navigation">
+  <div class="p-4">
+  <h1 class="text-2xl">New Transaction </h1>
+    <%= form_with model: @transaction do |f| %>
+  <div class="flex gap-2 items-center">
+    <%= f.radio_button :type, 'expense', checked: true %> Expense
+    <%= f.radio_button :type, 'income' %> Income
+    <%= f.radio_button :type, 'transfer', class: "cursor-not-allowed", disabled: true %> Transfer
+  </div>
+  <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account" } %>
+  <%= f.date_field :date, label: "Date" %>
+  <%= f.text_field :name, label: "Name", placeholder: "Groceries" %>
+  <%= f.collection_select :category_id, Current.family.transaction_categories, :id, :name, { prompt: "Select a category", label: "Category" } %>
+  <%= f.text_field :notes, label: "Notes" %>
+  <%= f.money_field :amount_money, label: "Amount" %>
+  <%= f.submit %>
+<% end %>
+ 
+  </div>
+</div> 
+<% end %> 

--- a/config/locales/views/layout/en.yml
+++ b/config/locales/views/layout/en.yml
@@ -6,6 +6,7 @@ en:
       dashboard: Dashboard
       new_account: New account
       transactions: Transactions
+      new_transaction: New Transaction
     auth:
       or: or
       privacy_policy: Privacy Policy


### PR DESCRIPTION
/claim #629

/closes #629 

This PR replaces the current `/new` route for transaction and adds a modal for the new-transaction flow.

This is purely inspired from the existing `account` creation flow.

## Implementation Details.

* Update the route with modal
* Implement the form fields along with the category
* Handle redirection after save with all the turbo-streams
* Auto-close the modal after the event is success.


## Video


https://github.com/maybe-finance/maybe/assets/59088937/2434d75d-c0c9-496b-b3b5-6518d941e3ba

