### PR TITLE
Fix modal height in Safari

### DIFF
--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (content:) -%>
 <%= turbo_frame_tag "modal" do %>
   <dialog class="bg-white border border-alpha-black-25 rounded-2xl max-h-[648px] max-w-[580px] w-full shadow-xs h-fit" data-controller="modal" data-action="click->modal#clickOutside">
-    <div class="flex flex-col h-full">
+    <div class="flex flex-col">
       <%= content %>
     </div>
   </dialog>


### PR DESCRIPTION
Fixes the modal (used for e.g. transaction or account creation) being broken in Safari (where it's only shown as a thin line in the middle of the screen)

I've verified that it still works as expected in Chrome after this fix.

Screenshot of the issue this fixes:
 <img width="1261" alt="Screenshot 2024-04-18 at 20 54 12" src="https://github.com/maybe-finance/maybe/assets/113784/34030f0d-561c-4de3-8f0f-432d99b2ca7e">
