### PR TITLE
Add transaction destroy balance sync test

### DIFF
--- a/app/models/account/balance/calculator.rb
+++ b/app/models/account/balance/calculator.rb
@@ -100,7 +100,8 @@ class Account::Balance::Calculator
           oldest_valuation = normalized_valuations.find { |v| v["date"] == oldest_valuation_date }
           oldest_valuation["value"].to_d
         else
-          net_transaction_flows = normalized_transactions.sum { |t| t["amount"].to_d }
+          prior_transactions = normalize_entries_to_account_currency(@account.transactions.where("date < ?", @calc_start_date).select(:date, :amount, :currency), :amount)
+          net_transaction_flows = prior_transactions.sum { |t| t["amount"].to_d }
           net_transaction_flows *= -1 if @account.classification == "liability"
           @account.balance.to_d + net_transaction_flows
         end

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -98,4 +98,17 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to transactions_url
   end
+
+  test "should sync account after destroy" do
+    account = @transaction.account
+    date = @transaction.date
+    amount = @transaction.amount
+
+    account.sync
+
+    assert_difference("account.balance_on(date)", amount) do
+      delete transaction_url(@transaction)
+      perform_enqueued_jobs
+    end
+  end
 end


### PR DESCRIPTION
I think I may have found a bug in the `Account::Balance::Calculator::implied_start_balance` method while working on #584. This PR contains a fix and a test that passes after the fix has been implemented. Feel free to close this if I got things wrong 😄 

At the moment, to get the start balance in a situation where there aren't any valuations, we sum amounts of transactions occurring  _after_ the `calc_start_date`. Shouldn't that be the other way round?

For example, I would expect that if we're computing balances between 2024-04-01 and today (and we don't have any valuations entries), the balance on the first day (2024-04-01) should be equal to `@account.balance + sum(transactions before 2024-04-01)`, with `@account.balance` being the "initial" balance of the account (set when the account was created).

There are now a bunch of other tests failing that depend on the `implied_start_balance` method, I will fix those after I have received confirmation that this really is a bug.