### PR TITLE
Clean up i18n translations

### DIFF
--- a/app/views/accounts/_account_valuation_list.html.erb
+++ b/app/views/accounts/_account_valuation_list.html.erb
@@ -40,9 +40,9 @@
           <% end %>
           <%= link_to valuation_path(valuation.original),
               data: { turbo_method: :delete,
-                      turbo_confirm: { title: t("custom_turbo_confirm.history.title"),
-                                       body: t("custom_turbo_confirm.history.body_html"),
-                                       accept: t("custom_turbo_confirm.history.accept") } },
+                      turbo_confirm: { title: t(".confirm_title"),
+                                       body: t(".confirm_body_html"),
+                                       accept: t(".confirm_accept") } },
               class: "text-red-600 flex gap-1 items-center hover:bg-gray-50 rounded-md p-2" do %>
             <%= lucide_icon("trash-2", class: "w-5 h-5 shrink-0") %>
             <span class="text-sm">Delete entry</span>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -26,9 +26,9 @@
                 class: "block w-full py-2 text-red-600 hover:text-red-800 flex items-center",
                 data: {
                   turbo_confirm: {
-                    title: t("custom_turbo_confirm.account_destroy.title"),
-                    body: t("custom_turbo_confirm.account_destroy.body_html"),
-                    accept: t("custom_turbo_confirm.account_destroy.accept", name: @account.name)
+                    title: t(".confirm_title"),
+                    body: t(".confirm_body_html"),
+                    accept: t(".confirm_accept", name: @account.name)
                   }
                 } do %>
               <%= lucide_icon("trash-2", class: "w-5 h-5 mr-2") %> Delete account

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
       </main>
     </div>
     <%= turbo_frame_tag "modal" %>
-    <%= render "shared/custom_confirm_modal" %>
+    <%= render "shared/confirm_modal" %>
     <%= render "shared/upgrade_notification" %>
     <% if self_hosted? %>
       <div class="flex items-center py-0.5 px-0.5 gap-1 fixed bottom-2 right-2 shadow-xs border border-alpha-black-50 rounded-md bg-white">

--- a/app/views/shared/_confirm_modal.html.erb
+++ b/app/views/shared/_confirm_modal.html.erb
@@ -2,15 +2,15 @@
   <form method="dialog" class="p-4">
     <div class="flex flex-col mb-4">
       <div class="flex justify-between mb-2 gap-4">
-        <h3 id="turbo-confirm-title" class="font-medium text-md"><%= t("custom_turbo_confirm.default.title") %></h3>
+        <h3 id="turbo-confirm-title" class="font-medium text-md"><%= t(".title") %></h3>
         <button value="cancel">
           <%= lucide_icon("x", class: "w-5 h-5 shrink-0 text-gray-500") %>
         </button>
       </div>
       <div id="turbo-confirm-body" class="text-gray-500 text-sm">
-        <%= t("custom_turbo_confirm.default.body_html") %>
+        <%= t(".body_html") %>
       </div>
     </div>
-    <button id="turbo-confirm-accept" class="w-full text-red-600 rounded-xl text-center p-[10px] border" value="confirm"><%= t("custom_turbo_confirm.default.accept") %></button>
+    <button id="turbo-confirm-accept" class="w-full text-red-600 rounded-xl text-center p-[10px] border" value="confirm"><%= t(".accept") %></button>
   </form>
 </dialog>

--- a/config/locales/views/account/en.yml
+++ b/config/locales/views/account/en.yml
@@ -1,15 +1,13 @@
 ---
 en:
   accounts:
-    show:
-      confirm_title: Delete account?
-      confirm_accept: Delete "%{name}"
-      confirm_body_html:
-        "<p>By deleting this account, you will erase its value history, affecting
-        various aspects of your overall account. This action will have a direct impact
-        on your net worth calculations and the account graphs.</p><br /> <p>After
-        deletion, there is no way you'll be able to restore the account information
-        because you'll need to add it as a new account.</p>"
+    account_valuation_list:
+      confirm_accept: Delete entry
+      confirm_body_html: "<p>Deleting this entry will remove it from the account’s
+        history which will impact different parts of your account. This includes the
+        net worth and account graphs.</p></br><p>The only way you’ll be able to add
+        this entry back is by re-entering it manually via a new entry</p>"
+      confirm_title: Delete Entry?
     create:
       success: New account created successfully
     destroy:
@@ -25,17 +23,17 @@ en:
         placeholder: Example account name
       select_accountable_type: What would you like to add?
       title: Add an account
+    show:
+      confirm_accept: Delete "%{name}"
+      confirm_body_html: "<p>By deleting this account, you will erase its value history,
+        affecting various aspects of your overall account. This action will have a
+        direct impact on your net worth calculations and the account graphs.</p><br
+        /> <p>After deletion, there is no way you'll be able to restore the account
+        information because you'll need to add it as a new account.</p>"
+      confirm_title: Delete account?
     summary:
       new: New account
     sync:
       success: Account sync started
     update:
       success: Account updated successfully
-    account_valuation_list:
-      confirm_title: Delete Entry?
-      confirm_accept: Delete entry
-      confirm_body_html:
-        "<p>Deleting this entry will remove it from the account’s history
-        which will impact different parts of your account. This includes the net worth
-        and account graphs.</p></br><p>The only way you’ll be able to add this entry
-        back is by re-entering it manually via a new entry</p>"

--- a/config/locales/views/account/en.yml
+++ b/config/locales/views/account/en.yml
@@ -1,6 +1,15 @@
 ---
 en:
   accounts:
+    show:
+      confirm_title: Delete account?
+      confirm_accept: Delete "%{name}"
+      confirm_body_html:
+        "<p>By deleting this account, you will erase its value history, affecting
+        various aspects of your overall account. This action will have a direct impact
+        on your net worth calculations and the account graphs.</p><br /> <p>After
+        deletion, there is no way you'll be able to restore the account information
+        because you'll need to add it as a new account.</p>"
     create:
       success: New account created successfully
     destroy:
@@ -22,3 +31,11 @@ en:
       success: Account sync started
     update:
       success: Account updated successfully
+    account_valuation_list:
+      confirm_title: Delete Entry?
+      confirm_accept: Delete entry
+      confirm_body_html:
+        "<p>Deleting this entry will remove it from the account’s history
+        which will impact different parts of your account. This includes the net worth
+        and account graphs.</p></br><p>The only way you’ll be able to add this entry
+        back is by re-entering it manually via a new entry</p>"

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -1,26 +1,10 @@
 ---
 en:
-  custom_turbo_confirm:
-    account_destroy:
-      accept: Delete "%{name}"
-      body_html: "<p>By deleting this account, you will erase its value history, affecting
-        various aspects of your overall account. This action will have a direct impact
-        on your net worth calculations and the account graphs.</p><br /> <p>After
-        deletion, there is no way you'll be able to restore the account information
-        because you'll need to add it as a new account.</p>"
-      title: Delete account?
-    default:
+  shared:
+    confirm_modal:
       accept: Confirm
       body_html: "<p>You will not be able to undo this decision</p>"
       title: Are you sure?
-    history:
-      accept: Delete entry
-      body_html: "<p>Deleting this entry will remove it from the account’s history
-        which will impact different parts of your account. This includes the net worth
-        and account graphs.</p></br><p>The only way you’ll be able to add this entry
-        back is by re-entering it manually via a new entry</p>"
-      title: Delete Entry?
-  shared:
     notification:
       dismiss: Dismiss
     upgrade_notification:


### PR DESCRIPTION
My original reason for opening this was to fix the following error when running `i18n-tasks add-missing`:

```
(base) maybe $ i18n-tasks add-missing
/Users/zachgoll/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/i18n-1.14.4/lib/i18n/backend/base.rb:65:in `translate': reserved key :default used in "Value. Interpolates: %{value}, %{human_key}, %{key}, %{default}, %{value_or_human_key}, %{value_or_default_or_human_key}" (I18n::ReservedInterpolationKey)

          raise ReservedInterpolationKey.new($1.to_sym, entry)
```

It looks like this is an upstream issue [as pointed out here.](https://github.com/glebm/i18n-tasks/issues/552)

Given it's not critical to the project, I decided against any temporary workarounds.  Instead, we'll just manually fill in translations until the upstream fix is implemented.