### PR TITLE
add basic support for deleting account

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -16,7 +16,7 @@ module Authentication
   private
 
   def authenticate_user!
-    if user = User.find_by(id: session[:user_id])
+    if user = User.find_by(id: session[:user_id], marked_for_deletion: false)
       Current.user = user
     else
       redirect_to new_session_url

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -9,7 +9,7 @@ class PasswordResetsController < ApplicationController
   end
 
   def create
-    if (user = User.find_by(email: params[:email]))
+    if (user = User.find_by(email: params[:email], marked_for_deletion: false))
       PasswordMailer.with(
         user: user,
         token: user.generate_token_for(:password_reset)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,7 +7,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.authenticate_by(email: params[:email], password: params[:password])
+    if user = User.authenticate_by(email: params[:email], password: params[:password], marked_for_deletion: false)
       login user
       redirect_to root_path
     else

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -19,6 +19,7 @@ class Settings::ProfilesController < ApplicationController
   
   def destroy
     begin
+      Rails.logger.info "DESTROYING"
       delete_user
       logout
       redirect_to new_registration_path, notice: t(".success")

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -19,7 +19,6 @@ class Settings::ProfilesController < ApplicationController
   
   def destroy
     begin
-      Rails.logger.info "DESTROYING"
       delete_user
       logout
       redirect_to new_registration_path, notice: t(".success")

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -16,11 +16,42 @@ class Settings::ProfilesController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+  
+  def destroy
+    begin
+      delete_user
+      logout
+      redirect_to new_session_path, notice: t(".success")
+    rescue ActiveRecord::RecordNotDestroyed => e
+      Rails.logger.error "Error deleting account: #{e.message}"
+      return redirect_to settings_profile_path, alert: t(".account_deletion_failed")
+    rescue StandardError => e
+      Rails.logger.error "An unexpected error occurred: #{e.message}"
+      redirect_to settings_profile_path, alert: t(".account_deletion_failed")
+    end
+  end
 
   private
 
   def user_params
     params.require(:user).permit(:first_name, :last_name,
                                  family_attributes: [ :name, :id ])
+  end
+
+  def delete_user
+    # raise StandardError.new "Unexpected error"
+    if Current.user.isMember
+      Rails.logger.info "Is member"
+      other_family_users = User.where(family_id: Current.user.family_id).where.not(id: Current.user.id).count
+      ActiveRecord::Base.transaction do
+        if other_family_users == 0
+          # this is true for our demo user but should not normally happen
+          Current.family.destroy # this takes care of deleting all related accounts
+        end
+        Current.user.destroy
+      end
+    ## TODO: work on other edge cases involving admin and others
+    ## TODO: handle errors properly if the transaction fails
+    end
   end
 end

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -16,7 +16,7 @@ class Settings::ProfilesController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
-  
+
   def destroy
     begin
       if Current.user.admin?

--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -44,7 +44,7 @@ class Settings::ProfilesController < ApplicationController
 
   def mark_user_for_deletion_and_logout
     Current.user.update!(marked_for_deletion: true)
-    DeleteUserJob.perform_later(Current.user)
+    Current.user.purge_data_later
     logout
   end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -29,9 +29,13 @@ Turbo.setConfirmMethod((message) => {
     }
 
     if (reject) {
-      document.getElementById("turbo-confirm-reject").innerHTML = reject;
-    } else {
-      document.getElementById("turbo-confirm-reject").remove()
+      const button = document.createElement("button")
+      button.setAttribute("id", "turbo-confirm-reject")
+      button.setAttribute("class", "w-full text-red-600 rounded-xl text-center p-[10px] border mt-2")
+      button.setAttribute("value", "reject")
+      button.innerHTML = reject
+
+      document.getElementById("turbo-confirm-dialog-form").appendChild(button)
     }
 
   } catch (e) {

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -29,13 +29,8 @@ Turbo.setConfirmMethod((message) => {
     }
 
     if (reject) {
-      const button = document.createElement("button")
-      button.setAttribute("id", "turbo-confirm-reject")
-      button.setAttribute("class", "w-full text-red-600 rounded-xl text-center p-[10px] border mt-2")
-      button.setAttribute("value", "reject")
-      button.innerHTML = reject
-
-      document.getElementById("turbo-confirm-dialog-form").appendChild(button)
+      const className = document.getElementById("turbo-confirm-reject").className.replace("hidden", "")
+      document.getElementById("turbo-confirm-reject").className = className
     }
 
   } catch (e) {

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -10,7 +10,7 @@ Turbo.setConfirmMethod((message) => {
   const dialog = document.getElementById("turbo-confirm");
 
   try {
-    const { title, body, accept } = JSON.parse(message);
+    const { title, body, accept, reject, acceptClass } = JSON.parse(message);
 
     if (title) {
       document.getElementById("turbo-confirm-title").innerHTML = title;
@@ -20,9 +20,20 @@ Turbo.setConfirmMethod((message) => {
       document.getElementById("turbo-confirm-body").innerHTML = body;
     }
 
+    if (acceptClass) {
+      document.getElementById("turbo-confirm-accept").className += acceptClass
+    }
+
     if (accept) {
       document.getElementById("turbo-confirm-accept").innerHTML = accept;
     }
+
+    if (reject) {
+      document.getElementById("turbo-confirm-reject").innerHTML = reject;
+    } else {
+      document.getElementById("turbo-confirm-reject").remove()
+    }
+
   } catch (e) {
     document.getElementById("turbo-confirm-title").innerText = message;
   }

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -1,0 +1,39 @@
+class DeleteUserJob < ApplicationJob
+  queue_as :default
+
+  def perform(user_attributes)
+    user = User.new(user_attributes)
+    family = Family.find(user.family_id)
+
+    if user.role == "member"
+      Rails.logger.info "Is member"
+      other_family_users = User.where(family_id: user.family_id).where.not(id: user.id).count
+
+      ActiveRecord::Base.transaction do
+        # this is true for our demo user but should not normally happen
+        if other_family_users == 0
+          if family != nil
+            Rails.logger.info "about to destroy family #{family.id}"
+            family.destroy
+          end
+        end
+      end
+    elsif user.role == "admin"
+      Rails.logger.info "Handling accound deletion for an admin User #{user.id}"
+      other_admins = User.where(family_id: user.family_id, role: "admin").where.not(id: user.id).count
+
+      Rails.logger.info "Other admins count #{other_admins}"
+      if other_admins == 0
+        ActiveRecord::Base.transaction do
+          
+          if family != nil
+            family.destroy
+          end
+          # since other users are now invalid because of the orphaned family -> delete users as well
+          users = User.where(family_id: user.family_id)
+          users.destroy_all
+        end
+      end
+    end
+  end
+end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -1,34 +1,18 @@
 class DeleteUserJob < ApplicationJob
   queue_as :default
 
-  def perform(user_attributes)
-    user = User.new(user_attributes)
+  def perform(user)
     family = Family.find(user.family_id)
 
-    if user.isMember
-      other_family_users = User.where(family_id: user.family_id).where.not(id: user.id).count
-
-      ActiveRecord::Base.transaction do
-        # this is true for our demo user but should not normally happen
-        if other_family_users == 0
-          if family != nil
-            family.destroy
-          end
-        end
-      end
-    elsif user.isAdmin
-      other_admins = User.where(family_id: user.family_id, role: "admin").where.not(id: user.id).count
+    if user.member?
+      user.destroy
+    elsif user.admin?
+      other_admins = User.family.admins.where.not(id: user.id).count
 
       if other_admins == 0
-        ActiveRecord::Base.transaction do
-          
-          if family != nil
-            family.destroy
-          end
-          # since other users are now invalid because of the orphaned family -> delete users as well
-          users = User.where(family_id: user.family_id)
-          users.destroy_all
-        end
+        User.family.destroy # this destroys related users and accounts
+      else
+        user.destroy
       end
     end
   end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -2,15 +2,13 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    family = Family.find(user.family_id)
-
     if user.member?
       user.destroy
     elsif user.admin?
-      other_admins = User.family.admins.where.not(id: user.id).count
+      other_admins = user.family.admins.where.not(id: user.id).count
 
       if other_admins == 0
-        User.family.destroy # this destroys related users and accounts
+        user.family.destroy # this destroys related users and accounts
       else
         user.destroy
       end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -5,24 +5,22 @@ class DeleteUserJob < ApplicationJob
     user = User.new(user_attributes)
     family = Family.find(user.family_id)
 
+    puts user_attributes
+
     if user.role == "member"
-      Rails.logger.info "Is member"
       other_family_users = User.where(family_id: user.family_id).where.not(id: user.id).count
 
       ActiveRecord::Base.transaction do
         # this is true for our demo user but should not normally happen
         if other_family_users == 0
           if family != nil
-            Rails.logger.info "about to destroy family #{family.id}"
             family.destroy
           end
         end
       end
     elsif user.role == "admin"
-      Rails.logger.info "Handling accound deletion for an admin User #{user.id}"
       other_admins = User.where(family_id: user.family_id, role: "admin").where.not(id: user.id).count
 
-      Rails.logger.info "Other admins count #{other_admins}"
       if other_admins == 0
         ActiveRecord::Base.transaction do
           

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -2,18 +2,23 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    if user.member?
-      user.destroy
-    elsif user.admin?
-      other_admins = user.family.admins.where.not(id: user.id).count
-
-      if other_admins == 0
-        if user.family.members.count == 0
-          user.family.destroy
-        end
-      else
+    ActiveRecord::Base.transaction do
+      if user.member?
         user.destroy
+      elsif user.admin?
+        other_admins = user.family.admins.where.not(id: user.id).count
+
+        if other_admins == 0
+          if user.family.members.count == 0
+            user.family.destroy
+          end
+        else
+          user.destroy
+        end
       end
     end
+  rescue => e
+    Rails.logger.error "An error occurred during DeleteUserJob: #{e.message} for the user #{user.id}"
+    raise e #just propagating
   end
 end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -2,23 +2,6 @@ class DeleteUserJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    ActiveRecord::Base.transaction do
-      if user.member?
-        user.destroy
-      elsif user.admin?
-        other_admins = user.family.admins.where.not(id: user.id).count
-
-        if other_admins == 0
-          if user.family.members.count == 0
-            user.family.destroy
-          end
-        else
-          user.destroy
-        end
-      end
-    end
-  rescue => e
-    Rails.logger.error "An error occurred during DeleteUserJob: #{e.message} for the user #{user.id}"
-    raise e # just propagating
+    user.purge_data
   end
 end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -19,6 +19,6 @@ class DeleteUserJob < ApplicationJob
     end
   rescue => e
     Rails.logger.error "An error occurred during DeleteUserJob: #{e.message} for the user #{user.id}"
-    raise e #just propagating
+    raise e # just propagating
   end
 end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -5,8 +5,6 @@ class DeleteUserJob < ApplicationJob
     user = User.new(user_attributes)
     family = Family.find(user.family_id)
 
-    puts user_attributes
-
     if user.role == "member"
       other_family_users = User.where(family_id: user.family_id).where.not(id: user.id).count
 

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -8,7 +8,9 @@ class DeleteUserJob < ApplicationJob
       other_admins = user.family.admins.where.not(id: user.id).count
 
       if other_admins == 0
-        user.family.destroy # this destroys related users and accounts
+        if user.family.members.count == 0
+          user.family.destroy
+        end
       else
         user.destroy
       end

--- a/app/jobs/delete_user_job.rb
+++ b/app/jobs/delete_user_job.rb
@@ -5,7 +5,7 @@ class DeleteUserJob < ApplicationJob
     user = User.new(user_attributes)
     family = Family.find(user.family_id)
 
-    if user.role == "member"
+    if user.isMember
       other_family_users = User.where(family_id: user.family_id).where.not(id: user.id).count
 
       ActiveRecord::Base.transaction do
@@ -16,7 +16,7 @@ class DeleteUserJob < ApplicationJob
           end
         end
       end
-    elsif user.role == "admin"
+    elsif user.isAdmin
       other_admins = User.where(family_id: user.family_id, role: "admin").where.not(id: user.id).count
 
       if other_admins == 0

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -4,6 +4,14 @@ class Family < ApplicationRecord
   has_many :transactions, through: :accounts
   has_many :transaction_categories, dependent: :destroy, class_name: "Transaction::Category"
 
+  def admins
+    users.where(users: { role: "admin" })
+  end
+
+  def members
+    users.where(users: { role: "member" })
+  end
+
   def snapshot(period = Period.all)
     query = accounts.active.joins(:balances)
       .where("account_balances.currency = ?", self.currency)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -5,11 +5,11 @@ class Family < ApplicationRecord
   has_many :transaction_categories, dependent: :destroy, class_name: "Transaction::Category"
 
   def admins
-    users.where(users: { role: "admin" })
+    users.where(users: { role: "admin", marked_for_deletion: false })
   end
 
   def members
-    users.where(users: { role: "member" })
+    users.where(users: { role: "member", marked_for_deletion: false })
   end
 
   def snapshot(period = Period.all)

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -5,11 +5,15 @@ class Family < ApplicationRecord
   has_many :transaction_categories, dependent: :destroy, class_name: "Transaction::Category"
 
   def admins
-    users.where(users: { role: "admin", marked_for_deletion: false })
+    users.where(users: { role: "admin" })
   end
 
   def members
-    users.where(users: { role: "member", marked_for_deletion: false })
+    users.where(users: { role: "member" })
+  end
+
+  def can_be_destroyed_by?(user)
+    users.count == 1 && user.admin?
   end
 
   def snapshot(period = Period.all)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,7 @@ class User < ApplicationRecord
       destroy!
     end
   end
-  
+
   def display_name
     [ first_name, last_name ].compact.join(" ").presence || email
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,14 +13,6 @@ class User < ApplicationRecord
     password_salt&.last(10)
   end
 
-  def isAdmin
-    role.downcase === "admin"
-  end
-
-  def isMember
-    role.downcase === "member"
-  end
-
   def acknowledge_upgrade_prompt(commit_sha)
     update!(last_prompted_upgrade_commit_sha: commit_sha)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,14 @@ class User < ApplicationRecord
     password_salt&.last(10)
   end
 
+  def isAdmin
+    role.downcase === "admin"
+  end
+
+  def isMember
+    role.downcase === "member"
+  end
+
   def acknowledge_upgrade_prompt(commit_sha)
     update!(last_prompted_upgrade_commit_sha: commit_sha)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,18 @@ class User < ApplicationRecord
     password_salt&.last(10)
   end
 
+  def purge_data_later
+    DeleteUserJob.perform_later(self)
+  end
+
+  def purge_data
+    if family.can_be_destroyed_by?(self)
+      family.destroy!
+    else
+      destroy!
+    end
+  end
+
   def acknowledge_upgrade_prompt(commit_sha)
     update!(last_prompted_upgrade_commit_sha: commit_sha)
   end

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -73,7 +73,7 @@
                 acceptClass: ' text-white bg-red-500'
               }
             } do %>
-          <%= lucide_icon("trash-2", class: "w-5 h-5 mr-2") %> <%= t(".delete_account") %>
+            <%= t(".delete_account") %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -70,7 +70,7 @@
                 body: t(".confirm_delete_body_html"),
                 accept: t(".delete_account"),
                 reject: t(".cancel"),
-                acceptClass: ' text-white bg-red-500'
+                acceptClass: " text-white bg-red-500"
               }
             } do %>
             <%= t(".delete_account") %>

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -61,9 +61,20 @@
           <h3 class="font-medium text-gray-900"><%= t(".delete_account") %></h3>
           <p class="text-gray-500 text-sm"><%= t(".delete_account_warning") %></p>
         </div>
-        <button disabled class="bg-red-500 text-white text-sm font-medium rounded-lg px-3 py-2 cursor-not-allowed">
-          <%= t(".delete_account") %>
-        </button>
+        <%= button_to settings_profile_path,
+            method: :delete,
+            class: "block bg-red-500 text-white hover:opacity-9 text-sm font-medium rounded-lg px-3 py-2 flex items-center",
+            data: {
+              turbo_confirm: {
+                title: t(".confirm_delete_title"),
+                body: t(".confirm_delete_body_html"),
+                accept: t(".delete_account"),
+                reject: t(".cancel"),
+                acceptClass: ' text-white bg-red-500'
+              }
+            } do %>
+          <%= lucide_icon("trash-2", class: "w-5 h-5 mr-2") %> <%= t(".delete_account") %>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/shared/_confirm_modal.html.erb
+++ b/app/views/shared/_confirm_modal.html.erb
@@ -12,5 +12,6 @@
       </div>
     </div>
     <button id="turbo-confirm-accept" class="w-full text-red-600 rounded-xl text-center p-[10px] border" value="confirm"><%= t(".accept") %></button>
+    <button id="turbo-confirm-reject" class="w-full text-black rounded-xl text-center p-[10px] border mt-2 hidden" value="reject"><%= t(".cancel") %></button>
   </form>
 </dialog>

--- a/app/views/shared/_confirm_modal.html.erb
+++ b/app/views/shared/_confirm_modal.html.erb
@@ -1,5 +1,5 @@
 <dialog id="turbo-confirm" class="max-w-[420px] w-full rounded-xl">
-  <form method="dialog" class="p-4" id="turbo-confirm-dialog-form">
+  <form method="dialog" class="p-4">
     <div class="flex flex-col mb-4">
       <div class="flex justify-between mb-2 gap-4">
         <h3 id="turbo-confirm-title" class="font-medium text-md"><%= t(".title") %></h3>

--- a/app/views/shared/_confirm_modal.html.erb
+++ b/app/views/shared/_confirm_modal.html.erb
@@ -1,5 +1,5 @@
 <dialog id="turbo-confirm" class="max-w-[420px] w-full rounded-xl">
-  <form method="dialog" class="p-4">
+  <form method="dialog" class="p-4" id="turbo-confirm-dialog-form">
     <div class="flex flex-col mb-4">
       <div class="flex justify-between mb-2 gap-4">
         <h3 id="turbo-confirm-title" class="font-medium text-md"><%= t(".title") %></h3>
@@ -12,6 +12,5 @@
       </div>
     </div>
     <button id="turbo-confirm-accept" class="w-full text-red-600 rounded-xl text-center p-[10px] border" value="confirm"><%= t(".accept") %></button>
-    <button id="turbo-confirm-reject" class="w-full text-red-600 rounded-xl text-center p-[10px] border mt-2" value="reject"><%= t(".reject") %></button>
   </form>
 </dialog>

--- a/app/views/shared/_confirm_modal.html.erb
+++ b/app/views/shared/_confirm_modal.html.erb
@@ -12,5 +12,6 @@
       </div>
     </div>
     <button id="turbo-confirm-accept" class="w-full text-red-600 rounded-xl text-center p-[10px] border" value="confirm"><%= t(".accept") %></button>
+    <button id="turbo-confirm-reject" class="w-full text-red-600 rounded-xl text-center p-[10px] border mt-2" value="reject"><%= t(".reject") %></button>
   </form>
 </dialog>

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -79,6 +79,8 @@ en:
       destroy:
         account_deletion_failed: Sorry, there was an error deleting your account.
           Try again later or contact support.
+        cannot_delete_admin_account_warning: Sorry, your account cannot be deleted
+          while other members are present. Please delete all members first.
         success: Account deleted successfully.
       show:
         add_member: Add Member

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -76,11 +76,16 @@ en:
       update:
         success: Preferences updated successfully.
     profiles:
+      destroy:
+        account_deletion_failed: Sorry, there was an error deleting your account.
+          Try again later or contact support.
+        success: Account deleted successfully.
       show:
         add_member: Add Member
         cancel: Cancel
+        confirm_delete_body_html: "<p>Are you sure you want to permanently delete
+          your account? This action is irreversible.</p>"
         confirm_delete_title: Delete account?
-        confirm_delete_body_html: "<p>Are you sure you want to permanently delete your account? This action is irreversible.</p>"
         danger_zone_title: Danger Zone
         delete_account: Delete Account
         delete_account_warning: Deleting your account will permanently remove all
@@ -98,6 +103,3 @@ en:
         save: Save
       update:
         success: Profile updated successfully.
-      destroy:
-        success: Account deleted successfully.
-        account_deletion_failed: Sorry, there was an error deleting your account. Try again later or contact support.

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -78,6 +78,9 @@ en:
     profiles:
       show:
         add_member: Add Member
+        cancel: Cancel
+        confirm_delete_title: Delete account?
+        confirm_delete_body_html: "<p>Are you sure you want to permanently delete your account? This action is irreversible.</p>"
         danger_zone_title: Danger Zone
         delete_account: Delete Account
         delete_account_warning: Deleting your account will permanently remove all
@@ -95,3 +98,6 @@ en:
         save: Save
       update:
         success: Profile updated successfully.
+      destroy:
+        success: Account deleted successfully.
+        account_deletion_failed: Sorry, there was an error deleting your account. Try again later or contact support.

--- a/config/locales/views/shared/en.yml
+++ b/config/locales/views/shared/en.yml
@@ -4,6 +4,7 @@ en:
     confirm_modal:
       accept: Confirm
       body_html: "<p>You will not be able to undo this decision</p>"
+      cancel: Cancel
       title: Are you sure?
     notification:
       dismiss: Dismiss

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   resource :password
 
   namespace :settings do
-    resource :profile, only: %i[show update]
+    resource :profile, only: %i[show update destroy]
     resource :preferences, only: %i[show update]
     resource :notifications, only: %i[show update]
     resource :billing, only: %i[show update]

--- a/db/migrate/20240427171242_add_marked_for_deletion_to_user.rb
+++ b/db/migrate/20240427171242_add_marked_for_deletion_to_user.rb
@@ -1,0 +1,5 @@
+class AddMarkedForDeletionToUser < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :marked_for_deletion, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_04_25_000110) do
+ActiveRecord::Schema[7.2].define(version: 2024_04_27_171242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -246,6 +246,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_04_25_000110) do
     t.string "last_prompted_upgrade_commit_sha"
     t.string "last_alerted_upgrade_commit_sha"
     t.enum "role", default: "member", null: false, enum_type: "user_role"
+    t.boolean "marked_for_deletion", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["family_id"], name: "index_users_on_family_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_04_26_191312) do
+ActiveRecord::Schema[7.2].define(version: 2024_04_27_171242) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/lib/tasks/demo_data.rake
+++ b/lib/tasks/demo_data.rake
@@ -13,7 +13,7 @@ namespace :demo_data do
       u.family = family
       u.first_name = "User"
       u.last_name = "Demo"
-      u.marked_for_deletion = false #if existing user found
+      u.marked_for_deletion = false # if existing user found
     end
 
     puts "Reset user: #{user.email} with family: #{family.name}"

--- a/lib/tasks/demo_data.rake
+++ b/lib/tasks/demo_data.rake
@@ -13,6 +13,7 @@ namespace :demo_data do
       u.family = family
       u.first_name = "User"
       u.last_name = "Demo"
+      u.marked_for_deletion = false #if existing user found
     end
 
     puts "Reset user: #{user.email} with family: #{family.name}"

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -28,10 +28,8 @@ class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "cannot delete admin while other members are present" do
-    other_admin = users(:other_family_admin)
-    User.where.not(id: other_admin.id).destroy_all # just delete other admin so this is last
-
-    sign_in @admin = other_admin
+    sign_in @admin = users(:other_family_admin)
+    User.where.not(id: @admin.id).destroy_all # just delete other admin so this is last
 
     delete settings_profile_url
     assert_response :redirect

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -2,21 +2,27 @@ require "test_helper"
 
 class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in @user = users(:family_admin)
+    sign_in @user = users(:family_member)
   end
   test "get" do
     get settings_profile_url
     assert_response :success
   end
 
-  test "destroy" do
+  test "cannot delete admin while other members are present" do
+    sign_in @admin = users(:family_admin)
+
     delete settings_profile_url
     assert_response :redirect
 
-    assert_raises(ActiveRecord::RecordNotFound) do
-      User.find(@user.id)
-    end
+    assert User.find(@admin.id).marked_for_deletion == false
+  end
 
-    assert_enqueued_with(job: DeleteUserJob, args: [@user.attributes])
+  test "deleting a user will mark the user for deletion and queue a deletion job" do
+    delete settings_profile_url
+    assert_response :redirect
+
+    assert User.find(@user.id).marked_for_deletion
+    assert_enqueued_with(job: DeleteUserJob, args: [@user])
   end
 end

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -8,4 +8,15 @@ class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
     get settings_profile_url
     assert_response :success
   end
+
+  test "destroy" do
+    delete settings_profile_url
+    assert_response :redirect
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      User.find(@user.id)
+    end
+
+    assert_enqueued_with(job: DeleteUserJob, args: [@user.attributes])
+  end
 end

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -30,7 +30,7 @@ class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
   test "cannot delete admin while other members are present" do
     other_admin = users(:other_family_admin)
     User.where.not(id: other_admin.id).destroy_all # just delete other admin so this is last
-    
+
     sign_in @admin = other_admin
 
     delete settings_profile_url

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -23,6 +23,6 @@ class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :redirect
 
     assert User.find(@user.id).marked_for_deletion
-    assert_enqueued_with(job: DeleteUserJob, args: [@user])
+    assert_enqueued_with(job: DeleteUserJob, args: [ @user ])
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -6,6 +6,14 @@ family_admin:
   password_digest: <%= BCrypt::Password.create('password') %>
   role: admin
 
+other_family_admin:
+  family: dylan_family
+  first_name: Duran
+  last_name: Dylan
+  email: bob2@bobdylan.com
+  password_digest: <%= BCrypt::Password.create('password') %>
+  role: admin
+
 family_member:
   family: dylan_family
   first_name: Jakob

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,6 +4,7 @@ family_admin:
   last_name: Dylan
   email: bob@bobdylan.com
   password_digest: <%= BCrypt::Password.create('password') %>
+  role: admin
 
 family_member:
   family: dylan_family

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -8,8 +8,34 @@ class DeleteUserJobTest < ActiveJob::TestCase
   end
 
   test "can be enqueued with user attributes" do
+    assert_enqueued_with(job: DeleteUserJob, args: [@user_member.attributes]) do
+      DeleteUserJob.perform_later(@user_member.attributes)
+    end
+  end
+
+  test "can be enqueued with admin user attributes" do
     assert_enqueued_with(job: DeleteUserJob, args: [@user_admin.attributes]) do
       DeleteUserJob.perform_later(@user_admin.attributes)
     end
+  end
+
+  test "deleting a member with an admin will not delete the family" do
+    DeleteUserJob.perform_now(@user_member.attributes)
+    Family.find(@user_member.family_id)
+  end
+
+  test "family, related accounts and other members are deleted for the last remaining admin" do
+    DeleteUserJob.perform_now(@user_admin.attributes)
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      puts Family.find(@user_admin.family_id)
+    end
+
+    assert_raises(ActiveRecord::RecordNotFound) do
+      puts Family.find(@user_admin.family_id).accounts
+    end
+
+    assert_equal Account.where(family_id: @user_admin.family_id).count, 0
+    assert_equal User.where(family_id: @user_admin.family_id).count, 0
   end
 end

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -33,10 +33,6 @@ class DeleteUserJobTest < ActiveJob::TestCase
       Family.find(@user_admin.family_id)
     end
 
-    assert_raises(ActiveRecord::RecordNotFound) do
-      Family.find(@user_admin.family_id).accounts
-    end
-
     assert_equal Account.where(family_id: @user_admin.family_id).count, 0
     assert_equal User.where(family_id: @user_admin.family_id).count, 0
   end

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -27,6 +27,7 @@ class DeleteUserJobTest < ActiveJob::TestCase
   end
 
   test "family, related accounts and other members are deleted for the last remaining admin" do
+    User.where(id: @user_member.id).destroy_all # just making sure the user has been deleted
     DeleteUserJob.perform_now(@user_admin)
 
     assert_raises(ActiveRecord::RecordNotFound) do

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -1,20 +1,19 @@
 require "test_helper"
 
 class DeleteUserJobTest < ActiveJob::TestCase
-
   setup do
     @user_admin = users(:family_admin)
     @user_member = users(:family_member)
   end
 
   test "can be enqueued with user" do
-    assert_enqueued_with(job: DeleteUserJob, args: [@user_member]) do
+    assert_enqueued_with(job: DeleteUserJob, args: [ @user_member ]) do
       DeleteUserJob.perform_later(@user_member)
     end
   end
 
   test "can be enqueued with admin user" do
-    assert_enqueued_with(job: DeleteUserJob, args: [@user_admin]) do
+    assert_enqueued_with(job: DeleteUserJob, args: [ @user_admin ]) do
       DeleteUserJob.perform_later(@user_admin)
     end
   end

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -1,7 +1,15 @@
 require "test_helper"
 
 class DeleteUserJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  setup do
+    @user_admin = users(:family_admin)
+    @user_member = users(:family_member)
+  end
+
+  test "can be enqueued with user attributes" do
+    assert_enqueued_with(job: DeleteUserJob, args: [@user_admin.attributes]) do
+      DeleteUserJob.perform_later(@user_admin.attributes)
+    end
+  end
 end

--- a/test/jobs/delete_user_job_test.rb
+++ b/test/jobs/delete_user_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DeleteUserJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
fixes #675 
/claim #675

### DEMO 1 - admin is not allowed to delete account until there are no members
https://github.com/maybe-finance/maybe/assets/119384208/3cf8f17c-460e-49b1-a0f8-030ecc297d28

### DEMO 2 - admin account deletion after all members are deleted

https://github.com/maybe-finance/maybe/assets/119384208/86202816-9012-472e-bd7e-941cd63244b5



This draft PR demonstrates a naive implementation of user account deletion that I'll build on over the next few hours.
This implementation deletes the user and attempts to delete other related data in the same request "cycle".

The problem identified while deleting the demo account is that the delete operation can really take a long time depending on the number of accounts associated with the user's family. I have thus decided to do the cleanup in a background job.

**UI Requirements**
- [X]  User must confirm deletion via a dialog
- [X]  After deletion, user is redirected to the sign up page with success notification
- [X]  Deletions should be atomic. A delete action should never result in invalid states or partially deleted data.
- [X]  i18n translations provided for en.yml

BACKEND Requirements
- [X]  Appropriate tests written
- [X] Introduce background worker to do cleanup according to logic relating to Family, Accounts, admin and member User types
- [X] Write tests for endpoint and background worker
- [ ] Final review and testing


