### PR TITLE
Fix account page on fresh install

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,20 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   normalizes :email, with: ->(email) { email.strip.downcase }
 
+  normalizes :first_name, :last_name, with: ->(value) { value.strip.presence }
+
   enum :role, { member: "member", admin: "admin" }, validate: true
 
   generates_token_for :password_reset, expires_in: 15.minutes do
     password_salt&.last(10)
+  end
+
+  def display_name
+    [ first_name, last_name ].compact.join(" ").presence || email
+  end
+
+  def initial
+    (display_name&.first || email.first).upcase
   end
 
   def acknowledge_upgrade_prompt(commit_sha)

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -4,14 +4,16 @@
   <% end %>
   <div id="user-menu" data-controller="menu">
     <button data-menu-target="button">
-      <div class="text-white w-9 h-9 bg-gray-400 rounded-full flex items-center justify-center text-lg uppercase"><%= Current.user.email.first %></div>
+      <div class="text-white w-9 h-9 bg-gray-400 rounded-full flex items-center justify-center text-lg uppercase"><%= Current.user.initial %></div>
     </button>
     <div data-menu-target="content" class="hidden absolute w-[240px] z-10 top-10 left-[255px] top-[72px] bg-white rounded-sm shadow-xs border border-alpha-black-25">
       <div class="p-3 flex items-center gap-3">
-        <div class="text-white shrink-0 w-9 h-9 bg-gray-400 rounded-full flex items-center justify-center text-lg uppercase"><%= Current.user.email.first %></div>
+        <div class="text-white shrink-0 w-9 h-9 bg-gray-400 rounded-full flex items-center justify-center text-lg uppercase"><%= Current.user.initial %></div>
         <div>
-          <span class="text-gray-900 font-medium text-sm"><%= Current.user.first_name %> <%= Current.user.last_name %></span>
-          <span class="text-gray-500 text-sm"><%= Current.user.email %></span>
+          <span class="text-gray-900 font-medium text-sm"><%= Current.user.display_name %></span>
+          <% if Current.user.display_name != Current.user.email %>
+            <span class="text-gray-500 text-sm"><%= Current.user.email %></span>
+          <% end %>
         </div>
       </div>
       <div class="border-t border-b border-alpha-black-100 p-1">

--- a/app/views/settings/profiles/show.html.erb
+++ b/app/views/settings/profiles/show.html.erb
@@ -39,9 +39,9 @@
           </div>
           <div class="flex gap-2 items-center bg-white p-4 border border-alpha-black-25 rounded-lg">
             <div class="mr-1 flex justify-center items-center bg-gray-50 w-8 h-8 rounded-full border border-alpha-black-25">
-              <p class="uppercase text-xs text-gray-500"><%= Current.user.first_name.first %></p>
+              <p class="uppercase text-xs text-gray-500"><%= Current.user.initial %></p>
             </div>
-            <p class="text-gray-900 font-medium text-sm"><%= Current.user.first_name %> <%= Current.user.last_name %></p>
+            <p class="text-gray-900 font-medium text-sm"><%= Current.user.display_name %></p>
             <div class="rounded-md bg-gray-100 px-1.5 py-0.5">
               <p class="uppercase text-gray-500 font-medium text-xs"><%= Current.user.role %></p>
             </div>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -37,10 +37,37 @@ class UserTest < ActiveSupport::TestCase
     assert_not duplicate_user.valid?
   end
 
-  test "email addresses are be saved as lower-case" do
-    mixed_case_email = "Foo@ExAMPle.CoM"
-    @user.email = mixed_case_email
-    @user.save
-    assert_equal mixed_case_email.downcase, @user.reload.email
+  test "email address is normalized" do
+    @user.update!(email: " User@ExAMPle.CoM ")
+    assert_equal "user@example.com", @user.reload.email
+  end
+
+  test "display name" do
+    user = User.new(email: "user@example.com")
+    assert_equal "user@example.com", user.display_name
+    user.first_name = "Bob"
+    assert_equal "Bob", user.display_name
+    user.last_name = "Dylan"
+    assert_equal "Bob Dylan", user.display_name
+  end
+
+  test "initial" do
+    user = User.new(email: "user@example.com")
+    assert_equal "U", user.initial
+    user.first_name = "Bob"
+    assert_equal "B", user.initial
+    user.first_name = nil
+    user.last_name = "Dylan"
+    assert_equal "D", user.initial
+  end
+
+  test "names are normalized" do
+    @user.update!(first_name: "", last_name: "")
+    assert_nil @user.first_name
+    assert_nil @user.last_name
+
+    @user.update!(first_name: " Bob ", last_name: " Dylan ")
+    assert_equal "Bob", @user.first_name
+    assert_equal "Dylan", @user.last_name
   end
 end


### PR DESCRIPTION
### What

- [x] Fix `/settings/profile` on a fresh install
- [x] Consolidate logic around displaying name on the UI
- [x] Consolidate logic around user initial on the UI

### Why

I did a fresh install on Render (it worked great!) and I got an error when I tried accessing the Account page.

![CleanShot 2024-04-26 at 14 26 31@2x](https://github.com/maybe-finance/maybe/assets/399663/997f59f7-a77c-450b-be52-24a1c2df57b2)
