### PR TITLE
Deps cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,17 +75,3 @@ GITHUB_REPO_BRANCH=main
 # S3_SECRET_ACCESS_KEY=
 # S3_REGION= # defaults to `us-east-1` if not set
 # S3_BUCKET=
-
-# Google Cloud Storage
-# =====================
-# Save your JSON keyfile as `gcp-storage-keyfile.json` in the root of the project
-# ACTIVE_STORAGE_SERVICE=google
-# GCS_PROJECT=
-# GCS_BUCKET=
-
-# Microsoft Azure Storage
-# ========================
-# ACTIVE_STORAGE_SERVICE=azure
-# AZURE_STORAGE_ACCOUNT_NAME=
-# AZURE_STORAGE_ACCESS_KEY=
-# AZURE_STORAGE_CONTAINER=

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "rails", github: "rails/rails", branch: "main"
 
 # Drivers
 gem "pg", "~> 1.5"
-gem "redis", ">= 4.0.1"
 
 # Deployment
 gem "puma", ">= 5.0"
@@ -33,37 +32,35 @@ gem "ransack"
 gem "stackprof"
 gem "sentry-ruby"
 gem "sentry-rails"
-gem "rails-settings-cached"
-gem "octokit"
 
 # Active Storage
 gem "aws-sdk-s3", require: false
-gem "azure-storage-blob", "~> 2.0", require: false
-gem "google-cloud-storage", "~> 1.11", require: false
 gem "image_processing", ">= 1.2"
 
 # Other
-gem "bcrypt", "~> 3.1.7"
-gem "inline_svg"
-gem "tzinfo-data", platforms: %i[ windows jruby ]
+gem "bcrypt", "~> 3.1"
 gem "faraday"
+gem "faraday-retry"
+gem "inline_svg"
+gem "octokit"
 gem "pagy"
+gem "rails-settings-cached"
+gem "tzinfo-data", platforms: %i[ windows jruby ]
 
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ]
   gem "brakeman", require: false
   gem "rubocop-rails-omakase", require: false
   gem "dotenv-rails"
-  gem "letter_opener"
   gem "i18n-tasks"
   gem "erb_lint"
-  gem "byebug"
 end
 
 group :development do
-  gem "web-console"
   gem "hotwire-livereload"
+  gem "letter_opener"
   gem "ruby-lsp-rails"
+  gem "web-console"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: a94938f10ce0f34c765028e518caed6527a31d11
+  revision: 2c79c87a1906498845542607d1293fc10acafb90
   branch: main
   specs:
     actioncable (7.2.0.alpha)
@@ -95,7 +95,7 @@ GIT
     railties (7.2.0.alpha)
       actionpack (= 7.2.0.alpha)
       activesupport (= 7.2.0.alpha)
-      irb
+      irb (~> 1.13)
       rackup (>= 1.0.0)
       rake (>= 12.2)
       thor (~> 1.0, >= 1.2.2)
@@ -108,8 +108,8 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     aws-eventstream (1.3.0)
-    aws-partitions (1.922.0)
-    aws-sdk-core (3.193.0)
+    aws-partitions (1.923.0)
+    aws-sdk-core (3.194.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)
@@ -117,23 +117,15 @@ GEM
     aws-sdk-kms (1.80.0)
       aws-sdk-core (~> 3, >= 3.193.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.148.0)
-      aws-sdk-core (~> 3, >= 3.193.0)
+    aws-sdk-s3 (1.149.0)
+      aws-sdk-core (~> 3, >= 3.194.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    azure-storage-blob (2.0.3)
-      azure-storage-common (~> 2.0)
-      nokogiri (~> 1, >= 1.10.8)
-    azure-storage-common (2.0.4)
-      faraday (~> 1.0)
-      faraday_middleware (~> 1.0, >= 1.0.0.rc1)
-      net-http-persistent (~> 4.0)
-      nokogiri (~> 1, >= 1.10.8)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    better_html (2.0.2)
+    better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
       ast (~> 2.0)
@@ -147,7 +139,6 @@ GEM
     brakeman (6.1.2)
       racc
     builder (3.2.4)
-    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -168,12 +159,9 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
-    declarative (0.0.20)
-    digest-crc (0.6.5)
-      rake (>= 12.0.0, < 14.0.0)
-    dotenv (3.1.0)
-    dotenv-rails (3.1.0)
-      dotenv (= 3.1.0)
+    dotenv (3.1.1)
+    dotenv-rails (3.1.1)
+      dotenv (= 3.1.1)
       railties (>= 6.1)
     drb (2.2.1)
     erb_lint (0.5.0)
@@ -186,11 +174,12 @@ GEM
     erubi (1.12.0)
     et-orbi (1.2.11)
       tzinfo
-    faraday (1.2.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     ffi (1.16.3)
     fugit (1.11.0)
       et-orbi (~> 1, >= 1.2.11)
@@ -204,47 +193,12 @@ GEM
       fugit (>= 1.1)
       railties (>= 6.0.0)
       thor (>= 0.14.1)
-    google-apis-core (0.14.1)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (~> 1.9)
-      httpclient (>= 2.8.1, < 3.a)
-      mini_mime (~> 1.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.a)
-      rexml
-    google-apis-iamcredentials_v1 (0.20.0)
-      google-apis-core (>= 0.14.0, < 2.a)
-    google-apis-storage_v1 (0.37.0)
-      google-apis-core (>= 0.14.0, < 2.a)
-    google-cloud-core (1.7.0)
-      google-cloud-env (>= 1.0, < 3.a)
-      google-cloud-errors (~> 1.0)
-    google-cloud-env (2.1.1)
-      faraday (>= 1.0, < 3.a)
-    google-cloud-errors (1.4.0)
-    google-cloud-storage (1.51.0)
-      addressable (~> 2.8)
-      digest-crc (~> 0.4)
-      google-apis-core (~> 0.13)
-      google-apis-iamcredentials_v1 (~> 0.18)
-      google-apis-storage_v1 (~> 0.37)
-      google-cloud-core (~> 1.6)
-      googleauth (~> 1.9)
-      mini_mime (~> 1.0)
-    googleauth (1.11.0)
-      faraday (>= 1.0, < 3.a)
-      google-cloud-env (~> 2.1)
-      jwt (>= 1.4, < 3.0)
-      multi_json (~> 1.11)
-      os (>= 0.9, < 2.0)
-      signet (>= 0.16, < 2.a)
     hashdiff (1.1.0)
     highline (3.0.1)
-    hotwire-livereload (1.3.2)
+    hotwire-livereload (1.4.0)
       actioncable (>= 6.0.0)
       listen (>= 3.0.0)
       railties (>= 6.0.0)
-    httpclient (2.8.3)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.13)
@@ -269,13 +223,11 @@ GEM
       activesupport (>= 3.0)
       nokogiri (>= 1.6)
     io-console (0.7.2)
-    irb (1.12.0)
-      rdoc
+    irb (1.13.0)
+      rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.7.1)
-    jwt (2.8.1)
-      base64
+    json (2.7.2)
     language_server-protocol (3.17.0.3)
     launchy (3.0.0)
       addressable (~> 2.8)
@@ -301,10 +253,8 @@ GEM
     mocha (2.2.0)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.7.2)
-    multi_json (1.15.0)
-    multipart-post (2.4.0)
-    net-http-persistent (4.0.2)
-      connection_pool (~> 2.2)
+    net-http (0.4.1)
+      uri
     net-imap (0.4.10)
       date
       net-protocol
@@ -331,14 +281,13 @@ GEM
       base64
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    os (1.1.4)
     pagy (8.3.0)
     parallel (1.24.0)
-    parser (3.3.0.5)
+    parser (3.3.1.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
-    prism (0.24.0)
+    prism (0.27.0)
     propshaft (0.8.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -346,7 +295,7 @@ GEM
       railties (>= 7.0.0)
     psych (5.1.2)
       stringio
-    public_suffix (5.0.4)
+    public_suffix (5.0.5)
     puma (6.4.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -366,7 +315,7 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    rails-i18n (7.0.8)
+    rails-i18n (7.0.9)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     rails-settings-cached (2.9.4)
@@ -383,20 +332,11 @@ GEM
       ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
-    redis (5.2.0)
-      redis-client (>= 0.22.0)
-    redis-client (0.22.1)
-      connection_pool
     regexp_parser (2.9.0)
-    reline (0.5.3)
+    reline (0.5.4)
       io-console (~> 0.5)
-    representable (3.2.0)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
-    retriable (3.1.2)
     rexml (3.2.6)
-    rubocop (1.60.2)
+    rubocop (1.63.4)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -404,30 +344,30 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
-    rubocop-minitest (0.34.5)
-      rubocop (>= 1.39, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-performance (1.20.2)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-minitest (0.35.0)
+      rubocop (>= 1.61, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-performance (1.21.0)
       rubocop (>= 1.48.1, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
-    rubocop-rails (2.23.1)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    rubocop-rails (2.24.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rails-omakase (1.0.0)
       rubocop
       rubocop-minitest
       rubocop-performance
       rubocop-rails
-    ruby-lsp (0.16.2)
+    ruby-lsp (0.16.6)
       language_server-protocol (~> 3.17.0)
-      prism (>= 0.22.0, < 0.25)
+      prism (>= 0.23.0, < 0.28)
       sorbet-runtime (>= 0.5.10782)
     ruby-lsp-rails (0.3.5)
       ruby-lsp (>= 0.16.0, < 0.17.0)
@@ -451,13 +391,8 @@ GEM
     sentry-ruby (5.17.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
-    signet (0.19.0)
-      addressable (~> 2.8)
-      faraday (>= 0.17.5, < 3.a)
-      jwt (>= 1.5, < 3.0)
-      multi_json (~> 1.10)
     smart_properties (1.17.0)
-    sorbet-runtime (0.5.11332)
+    sorbet-runtime (0.5.11367)
     stackprof (0.2.26)
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
@@ -478,15 +413,14 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
     timeout (0.4.1)
-    trailblazer-option (0.1.2)
     turbo-rails (2.0.5)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uber (0.1.0)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     useragent (0.16.10)
     vcr (6.2.0)
     web-console (4.2.1)
@@ -517,18 +451,16 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
-  azure-storage-blob (~> 2.0)
-  bcrypt (~> 3.1.7)
+  bcrypt (~> 3.1)
   bootsnap
   brakeman
-  byebug
   capybara
   debug
   dotenv-rails
   erb_lint
   faraday
+  faraday-retry
   good_job
-  google-cloud-storage (~> 1.11)
   hotwire-livereload
   i18n-tasks
   image_processing (>= 1.2)
@@ -545,7 +477,6 @@ DEPENDENCIES
   rails!
   rails-settings-cached
   ransack
-  redis (>= 4.0.1)
   rubocop-rails-omakase
   ruby-lsp-rails
   selenium-webdriver
@@ -564,4 +495,4 @@ RUBY VERSION
    ruby 3.3.0p0
 
 BUNDLED WITH
-   2.5.5
+   2.5.4

--- a/test/models/exchange_rate_test.rb
+++ b/test/models/exchange_rate_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-
+require "ostruct"
 class ExchangeRateTest < ActiveSupport::TestCase
   test "find rate in db" do
     assert_equal exchange_rates(:day_29_ago_eur_to_usd),

--- a/test/models/value_group_test.rb
+++ b/test/models/value_group_test.rb
@@ -1,5 +1,5 @@
 require "test_helper"
-
+require "ostruct"
 class ValueGroupTest < ActiveSupport::TestCase
     setup do
         checking = accounts(:checking)

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -45,34 +45,6 @@ class SettingsTest < ApplicationSystemTestCase
     assert_no_text "Self-Hosting"
   end
 
-  test "can see conditional nav items" do
-    ENV["SELF_HOSTING_ENABLED"] = "true"
-
-    visit root_path
-    sign_in @user
-
-    open_settings_from_sidebar
-
-    click_link "Self-Hosting"
-    assert_selector "h1", text: "Self-Hosting"
-  end
-
-  test "clicking back or hitting escape key takes user back page they opened settings from" do
-    # TODO: Implement test for back navigation and escape key functionality.
-  end
-
-  test "can upload profile image" do
-    open_settings_from_sidebar
-
-    label = find("label", text: "Choose")
-
-    attach_file(label["for"], Rails.root.join("test/fixtures/files/profile_image.png"), make_visible: true)
-
-    click_button "Save"
-
-    assert_selector("img[src*='profile_image.png']")
-  end
-
   private
     def open_settings_from_sidebar
       find("#user-menu").click


### PR DESCRIPTION
The major change here is removing some of the ActiveStorage adapters (which had severely outdated transitive deps).  This was causing some unexpected behavior in tests.

Leaving S3 as the sole adapter for now and can introduce additional ones as requested.

## Tests

Will be introducing a follow-up PR to re-introduce tests removed here without the flakiness.