### PR TITLE
Allow two decimals for value in transaction history

### DIFF
--- a/app/views/valuations/_form_row.html.erb
+++ b/app/views/valuations/_form_row.html.erb
@@ -7,7 +7,7 @@
   </div>
   <div class="flex items-center justify-between grow">
     <%= f.date_field :date, required: "required", class: "border border-alpha-black-200 bg-white rounded-lg shadow-xs min-w-[200px] px-3 py-1.5 text-gray-900 text-sm" %>
-    <%= f.number_field :value, required: "required", placeholder: "0.00", class: "bg-white border border-alpha-black-200 rounded-lg shadow-xs text-gray-900 text-sm px-3 py-1.5 text-right" %>
+    <%= f.number_field :value, required: "required", placeholder: "0.00", step: "0.01", class: "bg-white border border-alpha-black-200 rounded-lg shadow-xs text-gray-900 text-sm px-3 py-1.5 text-right" %>
   </div>
   <div class="w-[296px] flex gap-2 justify-end items-center">
     <%= link_to "Cancel", account_path(@valuation.account), class: "text-sm text-gray-900 hover:text-gray-800 font-medium px-3 py-1.5" %>


### PR DESCRIPTION
Fixes #669

This fix now allows to add cents to transaction history value field.

![transaction_history](https://github.com/maybe-finance/maybe/assets/514363/fb3b5344-2655-4184-b061-7ba388c59a3f)
