### PR TITLE
Add ARM target for Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: CI
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 jobs:
   scan_ruby:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,8 +64,15 @@ jobs:
 
   build:
     name: Build docker image
-    runs-on: ubuntu-latest
     needs: [ test ]
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
 
     permissions:
       contents: read
@@ -75,9 +82,11 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Set up Docker Context for Buildx
-        run: docker context create builders
-        shell: bash
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the container registry
         uses: docker/login-action@v3
@@ -106,3 +115,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ matrix.platform }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Adds `linux/arm/v8` for Docker image publishing to run Maybe on Raspberry Pi / Mac devices.