### PR TITLE
Get default valuation currency from the related account, not family

### DIFF
--- a/app/controllers/valuations_controller.rb
+++ b/app/controllers/valuations_controller.rb
@@ -4,7 +4,7 @@ class ValuationsController < ApplicationController
     @account = Current.family.accounts.find(params[:account_id])
 
     # TODO: placeholder logic until we have a better abstraction for trends
-    @valuation = @account.valuations.new(valuation_params.merge(currency: Current.family.currency))
+    @valuation = @account.valuations.new(valuation_params.merge(currency: @account.currency))
     if @valuation.save
       @valuation.account.sync_later(@valuation.date)
 

--- a/test/controllers/valuations_controller_test.rb
+++ b/test/controllers/valuations_controller_test.rb
@@ -20,6 +20,12 @@ class ValuationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to account_path(@valuation.account)
   end
 
+  test "should create valuation with account's currency" do
+    foreign_account = accounts(:eur_checking)
+    post account_valuations_url(foreign_account), params: { valuation: { value: 1, date: Date.current, type: "Appraisal" } }
+    assert_equal foreign_account.currency, Valuation.order(created_at: :desc).first.currency
+  end
+
   test "create should sync account with correct start date" do
     date = Date.current - 1.day
 


### PR DESCRIPTION
Before this fix, manually created valuations always used the currency of the family (the base currency), even when the valuations were created for accounts in foreign currencies.

<img width="1038" alt="Screenshot 2024-05-08 at 19 50 33" src="https://github.com/maybe-finance/maybe/assets/113784/a009f18e-4d6b-4e7e-bebb-f181cd0762c5">
