### PR TITLE
Remove stale Redis dep

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,4 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: maybe_production
+  adapter: postgresql


### PR DESCRIPTION
While we may eventually end up with Redis, we've removed it from the Gemfile and having this here causes errors with self-hosted instances in prod