### PR TITLE
fix: Income summed under Expense

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -141,9 +141,9 @@ class TransactionsController < ApplicationController
 
     def amount
       if nature.income?
-        transaction_params[:amount].to_d * -1
-      else
         transaction_params[:amount].to_d
+      else
+        transaction_params[:amount].to_d * -1
       end
     end
 


### PR DESCRIPTION
## Description
- Fixes https://github.com/maybe-finance/maybe/issues/721
- Adjusted the transaction controller to ensure correct handling of income and expense amounts.
  - Incomes are now processed with positive amounts, aligning with the `inflows` scope.
  - Expenses are now processed with negative amounts, ensuring consistency.
  
https://github.com/maybe-finance/maybe/assets/55315065/f0e60d03-7934-476c-a980-f647def72180