### PR TITLE
Fix password resets

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -3,7 +3,7 @@ class PasswordResetsController < ApplicationController
 
   layout "auth"
 
-  before_action :set_user_by_token, only: :update
+  before_action :set_user_by_token, only: %i[ edit update ]
 
   def new
   end
@@ -20,6 +20,7 @@ class PasswordResetsController < ApplicationController
   end
 
   def edit
+    @user = User.new
   end
 
   def update

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -2,7 +2,7 @@
   header_title t(".title")
 %>
 
-<%= form_with url: password_reset_path(token: params[:token]), html: {class: "space-y-6"} do |form| %>
+<%= form_with model: @user, url: password_reset_path(token: params[:token]), method: :patch, html: {class: "space-y-6"} do |form| %>
   <%= auth_messages form %>
 
   <div class="relative border border-gray-100 bg-gray-25 rounded-xl focus-within:bg-white focus-within:shadow focus-within:opacity-100">


### PR DESCRIPTION
- Fix the incorrect path when submitting the edit password form.
- Redirect to the invalid token page when accessing the edit path.
