### PR TITLE
Fix currency when importing to foreign accounts

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -115,7 +115,8 @@ class Import < ApplicationRecord
           name: row["name"] || "Imported transaction",
           date: Date.iso8601(row["date"]),
           category: category,
-          amount: BigDecimal(row["amount"]) * -1 # User inputs amounts with opposite signage of our internal representation
+          amount: BigDecimal(row["amount"]) * -1, # User inputs amounts with opposite signage of our internal representation
+          currency: account.currency
 
         transactions << txn
       end

--- a/app/views/imports/transactions/_transaction.html.erb
+++ b/app/views/imports/transactions/_transaction.html.erb
@@ -7,6 +7,6 @@
   </div>
 
   <div class="ml-auto">
-    <%= content_tag :p, format_money(-transaction.amount), class: ["whitespace-nowrap", BigDecimal(transaction.amount).negative? ? "text-green-600" : "text-red-600"] %>
+    <%= content_tag :p, format_money(Money.new(-transaction.amount, @import.account.currency)), class: ["whitespace-nowrap", BigDecimal(transaction.amount).negative? ? "text-green-600" : "text-red-600"] %>
   </div>
 </div>

--- a/app/views/imports/transactions/_transaction_group.html.erb
+++ b/app/views/imports/transactions/_transaction_group.html.erb
@@ -5,7 +5,7 @@
 <div class="bg-gray-25 rounded-xl p-1 w-full">
   <div class="py-2 px-4 flex items-center justify-between font-medium text-xs text-gray-500">
     <h4><%= date.strftime("%b %d, %Y") %> &middot; <%= transactions.size %></h4>
-    <span><%= format_money -transactions.sum { |t| t.amount } %></span>
+    <span><%= format_money Money.new(-transactions.sum { |t| t.amount }, @import.account.currency) %></span>
   </div>
   <div class="bg-white shadow-xs rounded-md border border-alpha-black-25 divide-y divide-alpha-black-50">
     <%= render partial: "imports/transactions/transaction", collection: transactions %>


### PR DESCRIPTION
When importing transactions to a foreign account:
- use the account's currency on the imported transactions
- use the account's currency in the import preview

<img width="898" alt="Screenshot 2024-05-18 at 20 13 24" src="https://github.com/maybe-finance/maybe/assets/113784/cf70e940-7135-429e-80b8-efda82b23f3f">
