### PR TITLE
Add migration to make all existing users admins

### DIFF
--- a/db/migrate/20240520074309_add_admin_role_to_current_users.rb
+++ b/db/migrate/20240520074309_add_admin_role_to_current_users.rb
@@ -1,0 +1,5 @@
+class AddAdminRoleToCurrentUsers < ActiveRecord::Migration[7.2]
+  def up
+    User.update_all(role: "admin")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_05_02_205006) do
+ActiveRecord::Schema[7.2].define(version: 2024_05_20_074309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Updates the role of all existing users to `admin` to make older users match the change introduced here https://github.com/maybe-finance/maybe/commit/daf7ff8ef4da8718a1038f4c679539f2305195f2

As far as I know at this moment each family can only have one user, so running this should be safe.