### PR TITLE
Fix import crash with empty transaction name

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -112,7 +112,7 @@ class Import < ApplicationRecord
       csv.table.each do |row|
         category = account.family.transaction_categories.find_or_initialize_by(name: row["category"])
         txn = account.transactions.build \
-          name: row["name"] || "Imported transaction",
+          name: row["name"].presence || "Imported transaction",
           date: Date.iso8601(row["date"]),
           category: category,
           amount: BigDecimal(row["amount"]) * -1, # User inputs amounts with opposite signage of our internal representation


### PR DESCRIPTION
Fixes crash on import `confirm` page when a transaction with an empty `name` is being imported

<img width="429" alt="Screenshot 2024-05-20 at 22 56 11" src="https://github.com/maybe-finance/maybe/assets/113784/22b3159c-8ece-4d3a-bd49-5d5889f85111">
