### PR TITLE
Ignore empty categories while importing

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -11,6 +11,8 @@ class Import < ApplicationRecord
 
   scope :ordered, -> { order(created_at: :desc) }
 
+  FALLBACK_TRANSACTION_NAME = "Imported transaction"
+
   def publish_later
     ImportJob.perform_later(self)
   end
@@ -110,9 +112,9 @@ class Import < ApplicationRecord
       transactions = []
 
       csv.table.each do |row|
-        category = account.family.transaction_categories.find_or_initialize_by(name: row["category"])
+        category = account.family.transaction_categories.find_or_initialize_by(name: row["category"]) if row["category"].present?
         txn = account.transactions.build \
-          name: row["name"].presence || "Imported transaction",
+          name: row["name"].presence || FALLBACK_TRANSACTION_NAME,
           date: Date.iso8601(row["date"]),
           category: category,
           amount: BigDecimal(row["amount"]) * -1, # User inputs amounts with opposite signage of our internal representation

--- a/app/views/transactions/categories/_badge.html.erb
+++ b/app/views/transactions/categories/_badge.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (category:) %>
 <% category ||= null_category %>
 
-<span class="border text-sm font-medium px-2.5 py-1 rounded-full cursor-pointer content-center"
+<span class="border text-sm font-medium px-2.5 py-1 rounded-full content-center"
   style="
     background-color: color-mix(in srgb, <%= category.color %> 5%, white);
     border-color: color-mix(in srgb, <%= category.color %> 10%, white);

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -14,6 +14,18 @@ loaded_import:
     2024-01-02,Amazon stuff,Shopping,200
   created_at: <%= 2.days.ago %>
 
+loaded_import_with_missing_data:
+  account: checking
+  raw_csv_str: |
+    date,name,category,amount
+    2024-01-01,,Food,20
+    2024-01-02,Amazon stuff,,200
+  normalized_csv_str: |
+    date,name,category,amount
+    2024-01-01,,Food,20
+    2024-01-02,Amazon stuff,,200
+  created_at: <%= 2.days.ago %>
+
 completed_import:
   account: checking
   column_mappings:


### PR DESCRIPTION
- Empty transaction categories in the imported CSV are now ignored
- Added tests for this and a bunch of other fixed we've merged recently
- Removed `cursor-pointer` class from the badge itself (the class is already provided by the _menu partial where we actually want the cursor to change)

Before:
<img width="815" alt="Screenshot 2024-05-22 at 07 44 27" src="https://github.com/maybe-finance/maybe/assets/113784/f57330b9-b6c9-41c1-a83d-6837853ff4f0">

After:
<img width="796" alt="Screenshot 2024-05-22 at 07 43 57" src="https://github.com/maybe-finance/maybe/assets/113784/492f5ef2-ac65-4341-ab6a-e7fe80bd67c6">

