### PR TITLE
Fix duplicate category creation on import

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -108,9 +108,13 @@ class Import < ApplicationRecord
 
     def generate_transactions
       transactions = []
+      category_cache = {}
 
       csv.table.each do |row|
-        category = account.family.transaction_categories.find_or_initialize_by(name: row["category"])
+        category_name = row["category"]
+
+        category = category_cache[category_name] ||= account.family.transaction_categories.find_or_initialize_by(name: category_name)
+
         txn = account.transactions.build \
           name: row["name"].presence || "Imported transaction",
           date: Date.iso8601(row["date"]),

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -27,10 +27,10 @@ completed_import:
     amount: amount
   raw_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,20
+    2024-01-01,Starbucks drink,Food & Drink,-20
   normalized_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,20
+    2024-01-01,Starbucks drink,Food & Drink,-20
   created_at: <%= 2.days.ago %>
 
 

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -6,12 +6,16 @@ loaded_import:
   account: checking
   raw_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
-    2024-01-02,Amazon stuff,Shopping,200
+    2024-01-01,Starbucks drink,Food & Drink,-8.55
+    2024-01-01,Etsy,Shopping,-80.98
+    2024-01-02,Amazon stuff,Shopping,-200
+    2024-01-03,Paycheck,Income,1000
   normalized_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
-    2024-01-02,Amazon stuff,Shopping,200
+    2024-01-01,Starbucks drink,Food & Drink,-8.55
+    2024-01-01,Etsy,Shopping,-80.98
+    2024-01-02,Amazon stuff,Shopping,-200
+    2024-01-03,Paycheck,Income,1000
   created_at: <%= 2.days.ago %>
 
 completed_import:
@@ -23,10 +27,10 @@ completed_import:
     amount: amount
   raw_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
+    2024-01-01,Starbucks drink,Food & Drink,20
   normalized_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
+    2024-01-01,Starbucks drink,Food & Drink,20
   created_at: <%= 2.days.ago %>
 
 

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -39,7 +39,10 @@ class ImportTest < ActiveSupport::TestCase
   end
 
   test "publishes a valid import" do
-    assert_difference "Transaction.count", 2 do
+    # Import has 3 unique categories: "Food & Drink", "Income", and "Shopping" (x2)
+    # Fixtures already define "Food & Drink" and "Income", so these should not be created
+    # "Shopping" is a new category, but should only be created 1x during import
+    assert_difference -> { Transaction.count } => 4, -> { Transaction::Category.count } => 1 do
       @loaded_import.publish
     end
 

--- a/test/support/import_test_helper.rb
+++ b/test/support/import_test_helper.rb
@@ -2,8 +2,9 @@ module ImportTestHelper
   def valid_csv_str
     <<-ROWS
       date,name,category,amount
-      2024-01-01,Starbucks drink,Food,20
-      2024-01-02,Amazon stuff,Shopping,200
+      2024-01-01,Starbucks drink,Food,-20
+      2024-01-02,Amazon stuff,Shopping,-200
+      2024-01-03,Paycheck,Income,1000
     ROWS
   end
 
@@ -17,8 +18,8 @@ module ImportTestHelper
   def valid_csv_with_extra_column
     <<-ROWS
       date,name,category,"optional id",amount
-      2024-01-01,Starbucks drink,Food,1234,20
-      2024-01-02,Amazon stuff,Shopping,,200
+      2024-01-01,Starbucks drink,Food,1234,-20
+      2024-01-02,Amazon stuff,Shopping,,-200
     ROWS
   end
 


### PR DESCRIPTION
Caches categories while generating `ActiveRecord` objects during import.