### PR TITLE
Create tagging system

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1,5 +1,6 @@
 class Family < ApplicationRecord
   has_many :users, dependent: :destroy
+  has_many :tags, dependent: :destroy
   has_many :accounts, dependent: :destroy
   has_many :transactions, through: :accounts
   has_many :imports, through: :accounts

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -108,9 +108,13 @@ class Import < ApplicationRecord
 
     def generate_transactions
       transactions = []
+      category_cache = {}
 
       csv.table.each do |row|
-        category = account.family.transaction_categories.find_or_initialize_by(name: row["category"])
+        category_name = row["category"]
+
+        category = category_cache[category_name] ||= account.family.transaction_categories.find_or_initialize_by(name: category_name)
+
         txn = account.transactions.build \
           name: row["name"].presence || "Imported transaction",
           date: Date.iso8601(row["date"]),

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,4 @@
+class Tag < ApplicationRecord
+  belongs_to :family
+  has_many :taggings, dependent: :destroy
+end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,4 @@
+class Tagging < ApplicationRecord
+  belongs_to :tag
+  belongs_to :taggable, polymorphic: true
+end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -5,6 +5,9 @@ class Transaction < ApplicationRecord
   belongs_to :category, optional: true
   belongs_to :merchant, optional: true
 
+  has_many :taggings, as: :taggable, dependent: :destroy
+  has_many :tags, through: :taggings
+
   validates :name, :date, :amount, :account, presence: true
 
   monetize :amount

--- a/db/migrate/20240522133147_create_tags.rb
+++ b/db/migrate/20240522133147_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags, id: :uuid do |t|
+      t.string :name
+      t.string "color", default: "#e99537", null: false
+      t.references :family, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240522151453_create_taggings.rb
+++ b/db/migrate/20240522151453_create_taggings.rb
@@ -1,0 +1,9 @@
+class CreateTaggings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :taggings, id: :uuid do |t|
+      t.references :tag, null: false, foreign_key: true, type: :uuid
+      t.references :taggable, polymorphic: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/test/controllers/imports_controller_test.rb
+++ b/test/controllers/imports_controller_test.rb
@@ -6,7 +6,10 @@ class ImportsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in @user = users(:family_admin)
     @empty_import = imports(:empty_import)
-    @loaded_import = imports(:loaded_import)
+
+    @loaded_import = @empty_import.dup
+    @loaded_import.update! raw_csv_str: valid_csv_str
+
     @completed_import = imports(:completed_import)
   end
 

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -27,10 +27,10 @@ completed_import:
     amount: amount
   raw_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,20
+    2024-01-01,Starbucks drink,Food & Drink,-20
   normalized_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,20
+    2024-01-01,Starbucks drink,Food & Drink,-20
   created_at: <%= 2.days.ago %>
 
 

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -6,12 +6,16 @@ loaded_import:
   account: checking
   raw_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
-    2024-01-02,Amazon stuff,Shopping,200
+    2024-01-01,Starbucks drink,Food & Drink,-8.55
+    2024-01-01,Etsy,Shopping,-80.98
+    2024-01-02,Amazon stuff,Shopping,-200
+    2024-01-03,Paycheck,Income,1000
   normalized_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
-    2024-01-02,Amazon stuff,Shopping,200
+    2024-01-01,Starbucks drink,Food & Drink,-8.55
+    2024-01-01,Etsy,Shopping,-80.98
+    2024-01-02,Amazon stuff,Shopping,-200
+    2024-01-03,Paycheck,Income,1000
   created_at: <%= 2.days.ago %>
 
 completed_import:
@@ -23,10 +27,10 @@ completed_import:
     amount: amount
   raw_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
+    2024-01-01,Starbucks drink,Food & Drink,20
   normalized_csv_str: |
     date,name,category,amount
-    2024-01-01,Starbucks drink,Food,20
+    2024-01-01,Starbucks drink,Food & Drink,20
   created_at: <%= 2.days.ago %>
 
 

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -2,22 +2,6 @@ empty_import:
   account: checking
   created_at: <%= 1.minute.ago %>
 
-loaded_import:
-  account: checking
-  raw_csv_str: |
-    date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,-8.55
-    2024-01-01,Etsy,Shopping,-80.98
-    2024-01-02,Amazon stuff,Shopping,-200
-    2024-01-03,Paycheck,Income,1000
-  normalized_csv_str: |
-    date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,-8.55
-    2024-01-01,Etsy,Shopping,-80.98
-    2024-01-02,Amazon stuff,Shopping,-200
-    2024-01-03,Paycheck,Income,1000
-  created_at: <%= 2.days.ago %>
-
 completed_import:
   account: checking
   column_mappings:
@@ -26,11 +10,11 @@ completed_import:
     category: category
     amount: amount
   raw_csv_str: |
-    date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,-20
+    date,name,category,tags,amount
+    2024-01-01,Starbucks drink,Food & Drink,Test Tag,-20
   normalized_csv_str: |
-    date,name,category,amount
-    2024-01-01,Starbucks drink,Food & Drink,-20
+    date,name,category,tags,amount
+    2024-01-01,Starbucks drink,Food & Drink,Test Tag,-20
   created_at: <%= 2.days.ago %>
 
 

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,3 @@
+one:
+  name: Hawaii Trip
+  family: dylan_family

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -5,7 +5,9 @@ class ImportTest < ActiveSupport::TestCase
 
   setup do
     @empty_import = imports(:empty_import)
-    @loaded_import = imports(:loaded_import)
+
+    @loaded_import = @empty_import.dup
+    @loaded_import.update! raw_csv_str: valid_csv_str
   end
 
   test "raw csv input must conform to csv spec" do
@@ -42,7 +44,11 @@ class ImportTest < ActiveSupport::TestCase
     # Import has 3 unique categories: "Food & Drink", "Income", and "Shopping" (x2)
     # Fixtures already define "Food & Drink" and "Income", so these should not be created
     # "Shopping" is a new category, but should only be created 1x during import
-    assert_difference -> { Transaction.count } => 4, -> { Transaction::Category.count } => 1 do
+    assert_difference \
+      -> { Transaction.count } => 4,
+      -> { Transaction::Category.count } => 1,
+      -> { Tagging.count } => 4,
+      -> { Tag.count } => 2 do
       @loaded_import.publish
     end
 

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -39,7 +39,10 @@ class ImportTest < ActiveSupport::TestCase
   end
 
   test "publishes a valid import" do
-    assert_difference "Transaction.count", 2 do
+    # Import has 3 unique categories: "Food & Drink", "Income", and "Shopping" (x2)
+    # Fixtures already define "Food & Drink" and "Income", so these should not be created
+    # "Shopping" is a new category, but should only be created 1x during import
+    assert_difference -> { Transaction.count } => 4, -> { Transaction::Category.count } => 1 do
       @loaded_import.publish
     end
 

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/support/import_test_helper.rb
+++ b/test/support/import_test_helper.rb
@@ -1,17 +1,18 @@
 module ImportTestHelper
   def valid_csv_str
     <<-ROWS
-      date,name,category,amount
-      2024-01-01,Starbucks drink,Food,-20
-      2024-01-02,Amazon stuff,Shopping,-200
-      2024-01-03,Paycheck,Income,1000
+      date,name,category,tags,amount
+      2024-01-01,Starbucks drink,Food & Drink,Tag1|Tag2,-8.55
+      2024-01-01,Etsy,Shopping,Tag1,-80.98
+      2024-01-02,Amazon stuff,Shopping,Tag2,-200
+      2024-01-03,Paycheck,Income,,1000
     ROWS
   end
 
   def valid_csv_with_invalid_values
     <<-ROWS
-      date,name,category,amount
-      invalid_date,Starbucks drink,Food,invalid_amount
+      date,name,category,tags,amount
+      invalid_date,Starbucks drink,Food,,invalid_amount
     ROWS
   end
 

--- a/test/support/import_test_helper.rb
+++ b/test/support/import_test_helper.rb
@@ -2,8 +2,9 @@ module ImportTestHelper
   def valid_csv_str
     <<-ROWS
       date,name,category,amount
-      2024-01-01,Starbucks drink,Food,20
-      2024-01-02,Amazon stuff,Shopping,200
+      2024-01-01,Starbucks drink,Food,-20
+      2024-01-02,Amazon stuff,Shopping,-200
+      2024-01-03,Paycheck,Income,1000
     ROWS
   end
 
@@ -17,8 +18,8 @@ module ImportTestHelper
   def valid_csv_with_extra_column
     <<-ROWS
       date,name,category,"optional id",amount
-      2024-01-01,Starbucks drink,Food,1234,20
-      2024-01-02,Amazon stuff,Shopping,,200
+      2024-01-01,Starbucks drink,Food,1234,-20
+      2024-01-02,Amazon stuff,Shopping,,-200
     ROWS
   end
 


### PR DESCRIPTION
## Overview

This PR adds a general purpose tagging system to the app via the `taggable` association.  To start, users can add tags to transactions, but will be able to tag other entities like `Account` in the future.

- [x] Add tags model
- [x] Add tags row to CSV imports
- [ ] Add tag dropdown to transaction detail drawer
- [ ] Add tag management view in settings

### Note on code duplication

A lot of the code here is duplicative to the categories and tags views that have already been created.  This is to avoid early abstractions as we'll likely need a larger refactor of these once we get all the entities established in the app.