### PR TITLE
Add tag preview when importing and fix empty category bug

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -122,7 +122,7 @@ class Import < ApplicationRecord
           tags << tag_cache[tag_string] ||= account.family.tags.find_or_initialize_by(name: tag_string)
         end
 
-        category = category_cache[category_name] ||= account.family.transaction_categories.find_or_initialize_by(name: category_name)
+        category = category_cache[category_name] ||= account.family.transaction_categories.find_or_initialize_by(name: category_name) if category_name.present?
 
         txn = account.transactions.build \
           name: row["name"].presence || FALLBACK_TRANSACTION_NAME,

--- a/app/views/imports/transactions/_transaction.html.erb
+++ b/app/views/imports/transactions/_transaction.html.erb
@@ -6,6 +6,12 @@
     <%= render partial: "transactions/categories/badge", locals: { category: transaction.category } %>
   </div>
 
+  <div class="w-48 flex gap-1">
+    <% transaction.tags.each do |tag| %>
+      <%= render partial: "tags/badge", locals: { tag: tag } %>
+    <% end %>
+  </div>
+
   <div class="ml-auto">
     <%= content_tag :p, format_money(Money.new(-transaction.amount, @import.account.currency)), class: ["whitespace-nowrap", BigDecimal(transaction.amount).negative? ? "text-green-600" : "text-red-600"] %>
   </div>


### PR DESCRIPTION
- Fixed reintroduced bug when importing transactions with empty categories (see screenshot below)
- I have added tags to the import preview to verify visually that tags don't suffer from the same issue

Before category fix:

![Screenshot 2024-05-23 at 21 53 14](https://github.com/maybe-finance/maybe/assets/113784/429a8a11-d73a-4f07-92f6-fc7376e214ab)


After category fix:

![Screenshot 2024-05-23 at 21 52 56](https://github.com/maybe-finance/maybe/assets/113784/c1c3bb32-babc-4e99-ac12-2999ffefe477)

