### PR TITLE
Validate transaction filtering params

### DIFF
--- a/app/controllers/transactions/merchants_controller.rb
+++ b/app/controllers/transactions/merchants_controller.rb
@@ -4,7 +4,7 @@ class Transactions::MerchantsController < ApplicationController
   before_action :set_merchant, only: %i[ edit update destroy ]
 
   def index
-    @merchants = Current.family.transaction_merchants
+    @merchants = Current.family.transaction_merchants.alphabetically
   end
 
   def new

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -13,7 +13,8 @@ class TransactionsController < ApplicationController
       income: result.inflows.sum(&:amount_money).abs,
       expense: result.outflows.sum(&:amount_money).abs
     }
-    @filter_list = Transaction.build_filter_list(search_params, Current.family)
+    @filter_list, valid_params = Transaction.build_filter_list(search_params, Current.family)
+    session[ransack_session_key] = valid_params
 
     respond_to do |format|
       format.html

--- a/app/views/transactions/search_form/_account_filter.html.erb
+++ b/app/views/transactions/search_form/_account_filter.html.erb
@@ -5,7 +5,7 @@
     <%= lucide_icon("search", class: "w-5 h-5 text-gray-500 absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
-    <% Current.family.accounts.each do |account| %>
+    <% Current.family.accounts.alphabetically.each do |account| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= account.name %>">
         <%= form.check_box :account_id_in, { multiple: true, class: "rounded-sm border-gray-300 text-indigo-600 shadow-xs focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" }, account.id, nil %>
         <%= form.label :account_id_in, account.name, value: account.id, class: "text-sm text-gray-900" %>

--- a/app/views/transactions/search_form/_category_filter.html.erb
+++ b/app/views/transactions/search_form/_category_filter.html.erb
@@ -5,7 +5,7 @@
     <%= lucide_icon("search", class: "w-5 h-5 text-gray-500 absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
-    <% Current.family.transaction_categories.each do |transaction_category| %>
+    <% Current.family.transaction_categories.alphabetically.each do |transaction_category| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= transaction_category.name %>">
         <%= form.check_box :category_id_in, { "data-auto-submit-form-target": "auto", multiple: true, class: "rounded-sm border-gray-300 text-indigo-600 shadow-xs focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" }, transaction_category.id, nil %>
         <%= form.label :category_id_in, transaction_category.name, value: transaction_category.id, class: "text-sm text-gray-900 cursor-pointer" do %>

--- a/app/views/transactions/search_form/_merchant_filter.html.erb
+++ b/app/views/transactions/search_form/_merchant_filter.html.erb
@@ -5,7 +5,7 @@
     <%= lucide_icon("search", class: "w-5 h-5 text-gray-500 absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
-    <% Current.family.transaction_merchants.each do |merchant| %>
+    <% Current.family.transaction_merchants.alphabetically.each do |merchant| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= merchant.name %>">
         <%= form.check_box :merchant_id_in, { multiple: true, class: "rounded-sm border-gray-300 text-indigo-600 shadow-xs focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" }, merchant.id, nil %>
         <%= form.label :merchant_id_in, merchant.name, value: merchant.id, class: "text-sm text-gray-900" %>


### PR DESCRIPTION
Filtering transactions by account/category/merchant and then removing the account/category/merchant breaks the transactions page (selected filters are stored in session). This PR fixes that.

Also fixes alphabetical sorting in a few places.