### PR TITLE
Allow for optional start date on account creation

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -3,6 +3,7 @@ class AccountsController < ApplicationController
 
   include Filterable
   before_action :set_account, only: %i[ show destroy sync update ]
+  after_action :sync_account, only: :create
 
   def index
     @accounts = Current.family.accounts
@@ -38,17 +39,14 @@ class AccountsController < ApplicationController
   end
 
   def create
-    @account = Current.family.accounts.build(account_params.except(:accountable_type, :start_date))
-    @account.accountable = Accountable.from_type(account_params[:accountable_type])&.new
+    @account = Current.family
+                      .accounts
+                      .create_with_optional_start_balance! \
+                        attributes: account_params.except(:start_date, :start_balance),
+                        start_date: account_params[:start_date],
+                        start_balance: account_params[:start_balance]
 
-    if @account.save
-      @valuation = @account.valuations.new(date: account_params[:start_date] || Date.today, value: @account.balance, currency: @account.currency)
-      @valuation.save!
-
-      redirect_to account_path(@account), notice: t(".success")
-    else
-      render "new", status: :unprocessable_entity
-    end
+    redirect_to account_path(@account), notice: t(".success")
   end
 
   def destroy
@@ -82,6 +80,10 @@ class AccountsController < ApplicationController
     end
 
     def account_params
-      params.require(:account).permit(:name, :accountable_type, :balance, :start_date, :currency, :subtype, :is_active)
+      params.require(:account).permit(:name, :accountable_type, :balance, :start_date, :start_balance, :currency, :subtype, :is_active)
+    end
+
+    def sync_account
+      @account.sync_later
     end
 end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -80,4 +80,20 @@ class Account < ApplicationRecord
 
     grouped_accounts
   end
+
+  def self.create_with_optional_start_balance!(attributes:, start_date: nil, start_balance: nil)
+    account = self.new(attributes.except(:accountable_type))
+    account.accountable = Accountable.from_type(attributes[:accountable_type])&.new
+
+    # Always build the initial valuation
+    account.valuations.build(date: Date.current, value: attributes[:balance], currency: account.currency)
+
+    # Conditionally build the optional start valuation
+    if start_date.present? && start_balance.present?
+      account.valuations.build(date: start_date, value: start_balance, currency: account.currency)
+    end
+
+    account.save!
+    account
+  end
 end

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -20,14 +20,18 @@
       <div class="border-t border-alpha-black-25 p-4 text-gray-500 text-sm flex justify-between">
         <div class="flex space-x-5">
           <div class="flex items-center space-x-2">
-            <span>Select</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("corner-down-left", class: "inline w-3 h-3") %></kbd>
+            <span>Select</span>
+            <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("corner-down-left", class: "inline w-3 h-3") %></kbd>
           </div>
           <div class="flex items-center space-x-2">
-            <span>Navigate</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-up", class: "inline w-3 h-3") %></kbd> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-down", class: "inline w-3 h-3") %></kbd>
+            <span>Navigate</span>
+            <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-up", class: "inline w-3 h-3") %></kbd>
+            <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-down", class: "inline w-3 h-3") %></kbd>
           </div>
         </div>
         <div class="flex items-center space-x-2">
-          <button data-action="modal#close">Close</button> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+          <button data-action="modal#close">Close</button>
+          <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
         </div>
       </div>
     <% elsif params[:step] == 'method' && @account.accountable.present? %>
@@ -47,14 +51,18 @@
       <div class="border-t border-alpha-black-25 p-4 text-gray-500 text-sm flex justify-between">
         <div class="flex space-x-5">
           <div class="flex items-center space-x-2">
-            <span>Select</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("corner-down-left", class: "inline w-3 h-3") %></kbd>
+            <span>Select</span>
+            <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("corner-down-left", class: "inline w-3 h-3") %></kbd>
           </div>
           <div class="flex items-center space-x-2">
-            <span>Navigate</span> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-up", class: "inline w-3 h-3") %></kbd> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-down", class: "inline w-3 h-3") %></kbd>
+            <span>Navigate</span>
+            <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-up", class: "inline w-3 h-3") %></kbd>
+            <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-5 h-5 shrink-0 grow-0 items-center justify-center"><%= lucide_icon("arrow-down", class: "inline w-3 h-3") %></kbd>
           </div>
         </div>
         <div class="flex items-center space-x-2">
-          <button data-action="modal#close">Close</button> <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
+          <button data-action="modal#close">Close</button>
+          <kbd class="bg-alpha-black-50 shadow-[inset_0_-1px_0_0_rgba(0,0,0,0.1)] p-1 rounded-md flex w-8 h-5 shrink-0 grow-0 items-center justify-center text-xs">ESC</kbd>
         </div>
       </div>
     <% else %>
@@ -69,8 +77,17 @@
           <%= f.hidden_field :accountable_type %>
           <%= f.text_field :name, placeholder: t(".name.placeholder"), required: "required", label: t(".name.label"), autofocus: true %>
           <%= render "accounts/#{permitted_accountable_partial(@account.accountable_type)}", f: f %>
-          <%= f.money_field :balance_money, label: t(".balance.label"), required: "required" %>
-          <%= f.date_field :start_date, label: t(".start_date.label"), required: true, max: Date.today, value: Date.today %>
+          <%= f.money_field :balance_money, label: t(".balance"), required: "required" %>
+
+          <div>
+            <%= check_box_tag :add_start_values, class: "maybe-checkbox maybe-checkbox--light peer mb-1" %>
+            <%= label_tag :add_start_values, t(".optional_start_balance_message"), class: "pl-1 text-sm text-gray-500" %>
+
+            <div class="hidden peer-checked:flex items-center gap-2 mt-3">
+              <div class="w-1/2"><%= f.date_field :start_date, label: t(".start_date"), max: Date.current %></div>
+              <div class="w-1/2"><%= f.number_field :start_balance, label: t(".start_balance") %></div>
+            </div>
+          </div>
         </div>
         <%= f.submit "Add #{@account.accountable.model_name.human.downcase}" %>
       <% end %>

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -19,17 +19,17 @@ en:
     index:
       new_account: New account
     new:
-      balance:
-        label: Balance
+      balance: Current balance
       currency:
         all_others: All Others
         popular: Popular
       name:
         label: Account name
         placeholder: Example account name
+      optional_start_balance_message: Add a start balance for this account
       select_accountable_type: What would you like to add?
-      start_date:
-        label: Start date
+      start_balance: Start balance (optional)
+      start_date: Start date (optional)
       title: Add an account
     show:
       confirm_accept: Delete "%{name}"

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -27,20 +27,35 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Account updated", flash[:notice]
   end
 
-  test "should create account" do
-    assert_difference -> { Account.count }, +1 do
-      post accounts_path, params: { account: { accountable_type: "Account::Credit" } }
+  test "should create an account" do
+    assert_difference [ "Account.count", "Valuation.count" ], 1 do
+      post accounts_path, params: {
+        account: {
+          accountable_type: "Account::Depository",
+          balance: 200,
+          subtype: "checking"
+        }
+      }
+
+      assert_equal "New account created successfully", flash[:notice]
       assert_redirected_to account_url(Account.order(:created_at).last)
     end
   end
 
-  test "should create a valuation together with account" do
-    balance = 700
-    start_date = 3.days.ago.to_date
-    post accounts_path, params: { account: { accountable_type: "Account::Credit", balance:, start_date: } }
+  test "can add optional start date and balance to an account on create" do
+    assert_difference -> { Account.count } => 1, -> { Valuation.count } => 2 do
+      post accounts_path, params: {
+        account: {
+          accountable_type: "Account::Depository",
+          balance: 200,
+          subtype: "checking",
+          start_balance: 100,
+          start_date: 10.days.ago
+        }
+      }
 
-    new_valuation = Valuation.order(:created_at).last
-    assert new_valuation.value == balance
-    assert new_valuation.date == start_date
+      assert_equal "New account created successfully", flash[:notice]
+      assert_redirected_to account_url(Account.order(:created_at).last)
+    end
   end
 end


### PR DESCRIPTION
Adds the ability for a user to provide an _optional_ start date + balance for a new account.

https://github.com/maybe-finance/maybe/assets/16676157/d11bb457-d9af-4dd2-b374-61b6d95b74bb

