### PR TITLE
Simplify account sync logic

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -55,22 +55,11 @@ class AccountsController < ApplicationController
   end
 
   def sync
-    if @account.can_sync?
+    unless @account.syncing?
       @account.sync_later
-      respond_to do |format|
-        format.html { redirect_to account_path(@account), notice: t(".success") }
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.append("notification-tray", partial: "shared/notification", locals: { type: "success", content: { body: t(".success") } })
-        end
-      end
-    else
-      respond_to do |format|
-        format.html { redirect_to account_path(@account), notice: t(".cannot_sync") }
-        format.turbo_stream do
-          render turbo_stream: turbo_stream.append("notification-tray", partial: "shared/notification", locals: { type: "error", content: { body: t(".cannot_sync") } })
-        end
-      end
     end
+
+    redirect_to account_path(@account), notice: t(".success")
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,20 +2,8 @@ class ApplicationController < ActionController::Base
   include Authentication, Invitable, SelfHostable
   include Pagy::Backend
 
-  before_action :sync_accounts
-
   default_form_builder ApplicationFormBuilder
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
-
-  private
-
-  def sync_accounts
-    return if Current.user.blank?
-
-    if Current.user.last_login_at.nil? || Current.user.last_login_at.before?(Date.current.beginning_of_day)
-      Current.family.sync_accounts
-    end
-  end
 end

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -46,7 +46,6 @@ en:
     summary:
       new: New account
     sync:
-      cannot_sync: Account cannot be synced at the moment
       success: Account sync started
     update:
       success: Account updated

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -16,6 +16,11 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
+  test "can sync an account" do
+    post sync_account_path(@account)
+    assert_redirected_to account_url(@account)
+  end
+
   test "should update account" do
     patch account_url(@account), params: {
       account: {


### PR DESCRIPTION
The main purpose of this PR is to remove the "Cannot sync account" alert message when a user clicks to trigger a sync as this is confusing behavior to a user who doesn't understand the backend sync process.

I have also removed the "sync on login" logic.  This logic will return in future versions of the app, but it was a premature optimization that adds complexity and we never had a fully complete UI flow for.  

Moving forward, it's probably best to optimize for manual, user-triggered syncs and then incrementally add in "auto-sync" logic once these core flows are more stable and well-tested.