### PR TITLE
Add merchant select when editing transaction

### DIFF
--- a/app/views/transactions/bulk_edit.html.erb
+++ b/app/views/transactions/bulk_edit.html.erb
@@ -27,9 +27,9 @@
                   </summary>
 
                   <div class="pb-6 space-y-2">
-                    <%= form.date_field :date, label: t(".date"), max: Date.current %>
-                    <%= form.collection_select :category_id, Current.family.transaction_categories, :id, :name, { prompt: t(".select_category"), label: t(".category"), class: "text-gray-400" } %>
-                    <%= form.collection_select :merchant_id, Current.family.transaction_merchants, :id, :name, { prompt: t(".select_merchant"), label: t(".merchant"), class: "text-gray-400" } %>
+                    <%= form.date_field :date, label: t(".date_label"), max: Date.current %>
+                    <%= form.collection_select :category_id, Current.family.transaction_categories.alphabetically, :id, :name, { prompt: t(".category_placeholder"), label: t(".category_label"), class: "text-gray-400" } %>
+                    <%= form.collection_select :merchant_id, Current.family.transaction_merchants.alphabetically, :id, :name, { prompt: t(".merchant_placeholder"), label: t(".merchant_label"), class: "text-gray-400" } %>
                   </div>
                 </details>
 
@@ -40,7 +40,7 @@
                   </summary>
 
                   <div>
-                    <%= form.text_area :notes, label: t(".note"), placeholder: t(".note_placeholder"), rows: 5 %>
+                    <%= form.text_area :notes, label: t(".note_label"), placeholder: t(".note_placeholder"), rows: 5 %>
                   </div>
                 </details>
 

--- a/app/views/transactions/show.html.erb
+++ b/app/views/transactions/show.html.erb
@@ -19,9 +19,10 @@
         <div class="pb-6">
           <%= form_with model: @transaction, html: { data: { controller: "auto-submit-form" } } do |f| %>
             <div class="space-y-2">
-              <%= f.date_field :date, label: "Date", max: Date.today, "data-auto-submit-form-target": "auto" %>
-              <%= f.collection_select :category_id, Current.family.transaction_categories, :id, :name, { prompt: "Select a category", label: "Category", class: "text-gray-400" }, "data-auto-submit-form-target": "auto" %>
-              <%= f.collection_select :account_id, Current.family.accounts, :id, :name, { prompt: "Select an Account", label: "Account", class: "text-gray-500" }, { class: "form-field__input cursor-not-allowed text-gray-400", disabled: "disabled" } %>
+              <%= f.date_field :date, label: t(".date_label"), max: Date.today, "data-auto-submit-form-target": "auto" %>
+              <%= f.collection_select :category_id, Current.family.transaction_categories.alphabetically, :id, :name, { prompt: t(".category_placeholder"), label: t(".category_label"), class: "text-gray-400" }, "data-auto-submit-form-target": "auto" %>
+              <%= f.collection_select :merchant_id, Current.family.transaction_merchants.alphabetically, :id, :name, { prompt: t(".merchant_placeholder"), label: t(".merchant_label"), class: "text-gray-400" }, "data-auto-submit-form-target": "auto" %>
+              <%= f.collection_select :account_id, Current.family.accounts.alphabetically, :id, :name, { prompt: t(".account_placeholder"), label: t(".account_label"), class: "text-gray-500" }, { class: "form-field__input cursor-not-allowed text-gray-400", disabled: "disabled" } %>
             </div>
           <% end %>
         </div>
@@ -35,7 +36,7 @@
 
         <div class="pb-6">
           <%= form_with model: @transaction, html: { data: { controller: "auto-submit-form" } } do |f| %>
-            <%= f.text_field :name, label: "Name", "data-auto-submit-form-target": "auto" %>
+            <%= f.text_field :name, label: t(".name_label"), "data-auto-submit-form-target": "auto" %>
           <% end %>
         </div>
       </details>
@@ -52,14 +53,11 @@
                          options_for_select(Current.family.tags.alphabetically.pluck(:name, :id), @transaction.tag_ids),
                          {
                            multiple: true,
-                           label: t(".select_tags"),
+                           label: t(".tags_label"),
                            class: "placeholder:text-gray-500"
                          },
                          "data-auto-submit-form-target": "auto" %>
-          <% end %>
-
-          <%= form_with model: @transaction, html: { data: { controller: "auto-submit-form" } } do |f| %>
-            <%= f.text_area :notes, label: "Notes", placeholder: "Enter a note", "data-auto-submit-form-target": "auto" %>
+            <%= f.text_area :notes, label: t(".note_label"), placeholder: t(".note_placeholder"), "data-auto-submit-form-target": "auto" %>
           <% end %>
         </div>
       </details>

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -6,18 +6,18 @@ en:
     bulk_edit:
       additional: Additional
       cancel: Cancel
-      category: Category
-      date: Date
+      category_label: Category
+      category_placeholder: Select a category
+      date_label: Date
       exclude_subtitle: This excludes the transaction from any in-app features or
         analytics.
       exclude_title: Exclude transaction
-      merchant: Merchant
-      note: Notes
+      merchant_label: Merchant
+      merchant_placeholder: Select a merchant
+      note_label: Notes
       note_placeholder: Enter a note that will be applied to selected transactions
       overview: Overview
       save: Save
-      select_category: Select a category
-      select_merchant: Select a merchant
       settings: Settings
     bulk_update:
       failure: Could not update transactions
@@ -117,7 +117,12 @@ en:
       update:
         success: Merchant updated successfully
     show:
+      account_label: Account
+      account_placeholder: Select an account
       additional: Additional
+      category_label: Category
+      category_placeholder: Select a category
+      date_label: Date
       delete: Delete
       delete_subtitle: This permanently deletes the transaction, affects your historical
         balances, and cannot be undone.
@@ -126,8 +131,13 @@ en:
       exclude_subtitle: This excludes the transaction from any in-app features or
         analytics.
       exclude_title: Exclude transaction
+      merchant_label: Merchant
+      merchant_placeholder: Select a merchant
+      name_label: Name
+      note_label: Notes
+      note_placeholder: Enter a note
       overview: Overview
-      select_tags: Select one or more tags
       settings: Settings
+      tags_label: Select one or more tags
     update:
       success: Transaction updated successfully


### PR DESCRIPTION
- Added Merchant field when editing a single transaction
- Added missing localization strings to the form and aligned the naming convention with the bulk edit form
- Options in selects are now alphabetically sorted

<img width="491" alt="Screenshot 2024-06-18 at 08 17 18" src="https://github.com/maybe-finance/maybe/assets/113784/b6cc6f65-e486-4a23-8db8-0b6271782ac7">
