### PR TITLE
Ensure correct form's hidden input for selectedIds

### DIFF
--- a/app/javascript/controllers/bulk_select_controller.js
+++ b/app/javascript/controllers/bulk_select_controller.js
@@ -66,6 +66,8 @@ export default class extends Controller {
   }
 
   #addHiddenFormInputsForSelectedIds(form, paramName, transactionIds) {
+    this.#resetFormInputs(form, paramName);
+
     transactionIds.forEach(id => {
       const input = document.createElement("input");
       input.type = 'hidden'
@@ -73,6 +75,11 @@ export default class extends Controller {
       input.value = id
       form.appendChild(input)
     })
+  }
+
+  #resetFormInputs(form, paramName) {
+    const existingInputs = form.querySelectorAll(`input[name='${paramName}']`);
+    existingInputs.forEach((input) => input.remove());
   }
 
   #rowsForGroup(group) {


### PR DESCRIPTION
When adding transactions for bulk edit/delete, clicking on “Delete” or “Edit” icons  creates hidden form inputs for the selected transactions.

If the modal is closed and a selected transaction(s) is deselected , its hidden form input is already added and wont be removed upon deselecting hence will be accidentally deleted (or updated) on submit.


This PR addresses that by reseting the `paramName`, before creating hidden form inputs.

https://github.com/maybe-finance/maybe/assets/41262193/a3a899dd-4cdd-41bb-990e-dd37cb50a899

