### PR TITLE
Fix transfer note overflow style

### DIFF
--- a/app/views/account/transfers/_transfer.html.erb
+++ b/app/views/account/transfers/_transfer.html.erb
@@ -27,9 +27,13 @@
 
     <div class="pt-2 divide-y divide-alpha-black-200">
       <% transfer.transactions.each do |transaction| %>
-        <div class="py-3 flex items-center justify-between">
-          <%= render "transactions/name", transaction: transaction %>
-          <%= render "transactions/amount", transaction: transaction %>
+        <div class="py-3 grid grid-cols-12 items-center">
+          <div class="col-span-10">
+            <%= render "transactions/name", transaction: transaction %>
+          </div>
+          <div class="col-span-2 ml-auto">
+            <%= render "transactions/amount", transaction: transaction %>
+          </div>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
Fixes transaction note inside the transfer collapsible overflowing the container if the note is too long

<img width="802" alt="style_fix" src="https://github.com/maybe-finance/maybe/assets/113784/d138a1f9-e64b-4633-8f0d-07fbc79b06c8">
