### PR TITLE
Fix issue #861: Correct header selection logic in get_selected_header_for_field method

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -38,7 +38,7 @@ class Import < ApplicationRecord
   end
 
   def get_selected_header_for_field(field)
-    column_mappings&.dig(field) || field.key
+    column_mappings&.dig(field.key) || field.key
   end
 
   def update_csv!(row_idx:, col_idx:, value:)


### PR DESCRIPTION
**Fix issue #861**

The get_selected_header_for_field method was incorrectly using the entire field object instead of the field key to dig into the column_mappings hash. This caused an error when trying to retrieve the selected header for a field.