### PR TITLE
Fix bug where transactions were duplicated in import confirm

### DIFF
--- a/app/views/imports/confirm.html.erb
+++ b/app/views/imports/confirm.html.erb
@@ -13,7 +13,7 @@
     <% transaction_entries.group_by(&:date).each do |date, transactions| %>
       <%= render "account/entries/entry_group",
                  date: date,
-                 entries: transaction_entries,
+                 entries: transactions,
                  show_tags: true,
                  selectable: false,
                  editable: false %>

--- a/test/system/imports_test.rb
+++ b/test/system/imports_test.rb
@@ -89,6 +89,7 @@ class ImportsTest < ApplicationSystemTestCase
 
     # 5) Confirm step
     assert_selector "h1", text: "Confirm import"
+    assert_selector "#new_account_entry", count: 2
     click_button "Import 2 transactions"
     assert_selector "h1", text: "Imports"
   end


### PR DESCRIPTION
### What

When reviewing imported transactions on the confirm page, transactions were duplicated for every date in the CSV. This was a view issue only. Clicking import imported the correct number of transactions

http://0.0.0.0:3000/imports/edc55bb1-0fcb-460d-b26b-dfb263728e55/confirm

Example CSV data

```
date,name,category,amount
2024-07-01,McDonalds,Food & Drink, -10
2024-06-30,Delta,Travel, -100
2024-06-30,Lyft,Auto & Transport, -5
```

_Before_
<img width="910" alt="Screenshot 2024-07-03 at 00 21 03" src="https://github.com/maybe-finance/maybe/assets/9142868/5806eb22-c7b7-46c2-9dd9-4400f10ccda3">

### How

- Use grouped `transactions` instead of all `transaction_entries`

### Validation


_After_
<img width="860" alt="Screenshot 2024-07-03 at 00 20 33" src="https://github.com/maybe-finance/maybe/assets/9142868/783585f2-4f86-4b4d-9362-1db3f624903f">