### PR TITLE
Update docker compose example with fixed storage volume

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -32,7 +32,7 @@ services:
     image: ghcr.io/maybe-finance/maybe:latest
 
     volumes:
-      - ./storage:/rails/storage
+      - app-storage:/rails/storage
 
     ports:
       - 3000:3000
@@ -70,4 +70,5 @@ services:
       retries: 5
 
 volumes:
+  app-storage:
   postgres-data:


### PR DESCRIPTION
Uses named volumes rather than bind mounts to avoid system-dependent permissions for file uploads.