### PR TITLE
Make balance editing easier

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -40,7 +40,8 @@ class AccountsController < ApplicationController
   end
 
   def update
-    @account.update! account_params.except(:accountable_type)
+    @account.update! account_params.except(:accountable_type, :balance)
+    @account.update_balance!(account_params[:balance]) if account_params[:balance]
     @account.sync_later
     redirect_back_or_to account_path(@account), notice: t(".success")
   end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -41,6 +41,7 @@ class AccountsController < ApplicationController
 
   def update
     @account.update! account_params.except(:accountable_type)
+    @account.sync_later
     redirect_back_or_to account_path(@account), notice: t(".success")
   end
 

--- a/app/helpers/application_form_builder.rb
+++ b/app/helpers/application_form_builder.rb
@@ -53,7 +53,7 @@ class ApplicationFormBuilder < ActionView::Helpers::FormBuilder
       (label(method, *label_args(options)).to_s if options[:label]) +
         @template.tag.div(class: "flex items-center") do
           number_field(money_amount_method, merged_options.except(:label)) +
-            grouped_select(money_currency_method, grouped_options, { selected: selected_currency, disabled: readonly_currency }, class: "ml-auto form-field__input w-fit pr-8", data: { "money-field-target" => "currency", action: "change->money-field#handleCurrencyChange" })
+            grouped_select(money_currency_method, grouped_options, { selected: selected_currency }, disabled: readonly_currency, class: "ml-auto form-field__input w-fit pr-8", data: { "money-field-target" => "currency", action: "change->money-field#handleCurrencyChange" })
         end
     end
   end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -93,4 +93,18 @@ class Account < ApplicationRecord
   rescue Money::ConversionError
     TimeSeries.new([])
   end
+
+  def update_balance!(balance)
+    valuation = entries.account_valuations.find_by(date: Date.current)
+
+    if valuation
+      valuation.update! amount: balance
+    else
+      entries.create! \
+        date: Date.current,
+        amount: balance,
+        currency: currency,
+        entryable: Account::Valuation.new
+    end
+  end
 end

--- a/app/views/account/entries/entryables/valuation/_form.html.erb
+++ b/app/views/account/entries/entryables/valuation/_form.html.erb
@@ -9,7 +9,7 @@
         <%= lucide_icon("pencil-line", class: "w-4 h-4 text-gray-500") %>
       </div>
       <div class="w-full flex items-center justify-between gap-2">
-        <%= f.date_field :date, required: "required", max: 1.day.ago.to_date, class: "border border-alpha-black-200 bg-white rounded-lg shadow-xs min-w-[200px] px-3 py-1.5 text-gray-900 text-sm" %>
+        <%= f.date_field :date, required: "required", max: Date.current, class: "border border-alpha-black-200 bg-white rounded-lg shadow-xs min-w-[200px] px-3 py-1.5 text-gray-900 text-sm" %>
         <%= f.number_field :amount, required: "required", placeholder: "0.00", step: "0.01", class: "bg-white border border-alpha-black-200 rounded-lg shadow-xs text-gray-900 text-sm px-3 py-1.5 text-right" %>
         <%= f.hidden_field :currency, value: entry.account.currency %>
         <%= f.hidden_field :entryable_type, value: entry.entryable_type %>

--- a/app/views/account/entries/entryables/valuation/_form.html.erb
+++ b/app/views/account/entries/entryables/valuation/_form.html.erb
@@ -9,7 +9,7 @@
         <%= lucide_icon("pencil-line", class: "w-4 h-4 text-gray-500") %>
       </div>
       <div class="w-full flex items-center justify-between gap-2">
-        <%= f.date_field :date, required: "required", max: Date.current, class: "border border-alpha-black-200 bg-white rounded-lg shadow-xs min-w-[200px] px-3 py-1.5 text-gray-900 text-sm" %>
+        <%= f.date_field :date, required: "required", max: 1.day.ago.to_date, class: "border border-alpha-black-200 bg-white rounded-lg shadow-xs min-w-[200px] px-3 py-1.5 text-gray-900 text-sm" %>
         <%= f.number_field :amount, required: "required", placeholder: "0.00", step: "0.01", class: "bg-white border border-alpha-black-200 rounded-lg shadow-xs text-gray-900 text-sm px-3 py-1.5 text-right" %>
         <%= f.hidden_field :currency, value: entry.account.currency %>
         <%= f.hidden_field :entryable_type, value: entry.entryable_type %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -6,7 +6,8 @@
     </header>
 
     <%= form_with model: @account, data: { turbo_frame: "_top" } do |f| %>
-      <%= f.text_field :name, label: "Name" %>
+      <%= f.text_field :name, label: t(".name") %>
+      <%= f.money_field :balance_money, label: t(".balance") %>
 
       <div class="relative">
         <%= f.collection_select :institution_id, Current.family.institutions.alphabetically, :id, :name, { include_blank: t(".ungrouped"), label: t(".institution") } %>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -7,7 +7,7 @@
 
     <%= form_with model: @account, data: { turbo_frame: "_top" } do |f| %>
       <%= f.text_field :name, label: t(".name") %>
-      <%= f.money_field :balance_money, label: t(".balance") %>
+      <%= f.money_field :balance_money, label: t(".balance"), readonly_currency: true %>
 
       <div class="relative">
         <%= f.collection_select :institution_id, Current.family.institutions.alphabetically, :id, :name, { include_blank: t(".ungrouped"), label: t(".institution") } %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -57,17 +57,12 @@
     <div class="p-4 flex justify-between">
       <div class="space-y-2">
         <%= tag.p t(".total_value"), class: "text-sm font-medium text-gray-500" %>
-        <div class="flex items-center gap-2 group">
-          <%= tag.p format_money(@account.balance_money), class: "text-gray-900 text-3xl font-medium" %>
-          <%= link_to edit_account_path(@account), data: { turbo_frame: :modal } do %>
-            <%= lucide_icon "pencil-line", class: "hidden group-hover:inline text-gray-500 w-5 h-5" %>
-          <% end %>
-        </div>
+        <%= tag.p format_money(@account.balance_money, precision: 0), class: "text-gray-900 text-3xl font-medium" %>
         <div>
           <% if @balance_series.trend.direction.flat? %>
             <%= tag.span t(".no_change"), class: "text-gray-500" %>
           <% else %>
-            <%= tag.span @balance_series.trend.value, style: "color: #{@balance_series.trend.color}" %>
+            <%= tag.span format_money(@balance_series.trend.value), style: "color: #{@balance_series.trend.color}" %>
             <%= tag.span "(#{@balance_series.trend.percent}%)", style: "color: #{@balance_series.trend.color}" %>
           <% end %>
 

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -44,6 +44,7 @@
       <% end %>
     </div>
   </div>
+
   <%= turbo_frame_tag "sync_message" do %>
     <%= render partial: "accounts/sync_message", locals: { is_syncing: @account.syncing? } %>
   <% end %>
@@ -55,12 +56,23 @@
   <div class="bg-white shadow-xs rounded-xl border border-alpha-black-25 rounded-lg">
     <div class="p-4 flex justify-between">
       <div class="space-y-2">
-        <%= render partial: "shared/value_heading", locals: {
-          label: "Total Value",
-          period: @period,
-          value: @account.balance_money,
-          trend: @balance_series.trend
-        } %>
+        <%= tag.p t(".total_value"), class: "text-sm font-medium text-gray-500" %>
+        <div class="flex items-center gap-2 group">
+          <%= tag.p format_money(@account.balance_money), class: "text-gray-900 text-3xl font-medium" %>
+          <%= link_to edit_account_path(@account), data: { turbo_frame: :modal } do %>
+            <%= lucide_icon "pencil-line", class: "hidden group-hover:inline text-gray-500 w-5 h-5" %>
+          <% end %>
+        </div>
+        <div>
+          <% if @balance_series.trend.direction.flat? %>
+            <%= tag.span t(".no_change"), class: "text-gray-500" %>
+          <% else %>
+            <%= tag.span @balance_series.trend.value, style: "color: #{@balance_series.trend.color}" %>
+            <%= tag.span "(#{@balance_series.trend.percent}%)", style: "color: #{@balance_series.trend.color}" %>
+          <% end %>
+
+          <%= tag.span period_label(@period), class: "text-gray-500" %>
+        </div>
       </div>
       <%= form_with url: account_path(@account), method: :get, class: "flex items-center gap-4", data: { controller: "auto-submit-form" } do %>
         <%= render partial: "shared/period_select", locals: { value: @period.name } %>
@@ -71,11 +83,11 @@
     </div>
   </div>
 
-  <% selected_tab = params[:tab] || "history" %>
+  <% selected_tab = params[:tab] || "value" %>
 
-  <div class="flex gap-1 text-sm text-gray-900 font-medium mb-4">
-    <%= link_to "History", account_path(tab: "history"), class: ["p-2 rounded-lg", "bg-gray-100": selected_tab == "history"] %>
-    <%= link_to "Transactions", account_path(tab: "transactions"), class: ["p-2 rounded-lg", "bg-gray-100": selected_tab == "transactions"] %>
+  <div class="flex gap-2 text-sm text-gray-900 font-medium mb-4">
+    <%= link_to t(".value"), account_path(tab: "value"), class: ["px-2 py-1.5 rounded-md border border-transparent", "bg-white shadow-xs border-alpha-black-50": selected_tab == "value"] %>
+    <%= link_to t(".transactions"), account_path(tab: "transactions"), class: ["px-2 py-1.5 rounded-md border border-transparent", "bg-white shadow-xs border-alpha-black-50": selected_tab == "transactions"] %>
   </div>
 
   <div class="min-h-[800px]">

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -6,11 +6,11 @@ en:
     destroy:
       success: Account deleted successfully
     edit:
+      balance: Balance
       edit: Edit %{account}
       institution: Financial institution
+      name: Name
       ungrouped: "(none)"
-      balance: "Balance"
-      name: "Name"
     empty:
       empty_message: Add an account either via connection, importing or entering manually.
       new_account: New account
@@ -60,13 +60,13 @@ en:
       confirm_title: Delete account?
       edit: Edit
       import: Import transactions
+      no_change: No change
       sync_message_missing_rates: Since exchange rates haven't been synced, balance
         graphs may not reflect accurate values.
       sync_message_unknown_error: An error has occurred during the sync.
-      value: "Value"
-      transactions: "Transactions"
       total_value: Total Value
-      no_change: "No change"
+      transactions: Transactions
+      value: Value
     summary:
       new: New account
     sync:

--- a/config/locales/views/accounts/en.yml
+++ b/config/locales/views/accounts/en.yml
@@ -9,6 +9,8 @@ en:
       edit: Edit %{account}
       institution: Financial institution
       ungrouped: "(none)"
+      balance: "Balance"
+      name: "Name"
     empty:
       empty_message: Add an account either via connection, importing or entering manually.
       new_account: New account
@@ -61,6 +63,10 @@ en:
       sync_message_missing_rates: Since exchange rates haven't been synced, balance
         graphs may not reflect accurate values.
       sync_message_unknown_error: An error has occurred during the sync.
+      value: "Value"
+      transactions: "Transactions"
+      total_value: Total Value
+      no_change: "No change"
     summary:
       new: New account
     sync:

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -41,11 +41,39 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       account: {
         name: "Updated name",
         is_active: "0",
-        balance: 5000,
-        currency: "EUR",
         institution_id: institutions(:chase).id
       }
     }
+
+    assert_redirected_to account_url(@account)
+    assert_enqueued_with job: AccountSyncJob
+    assert_equal "Account updated", flash[:notice]
+  end
+
+  test "updates account balance by creating new valuation" do
+    assert_difference [ "Account::Entry.count", "Account::Valuation.count" ], 1 do
+      patch account_url(@account), params: {
+        account: {
+          balance: 10000
+        }
+      }
+    end
+
+    assert_redirected_to account_url(@account)
+    assert_enqueued_with job: AccountSyncJob
+    assert_equal "Account updated", flash[:notice]
+  end
+
+  test "updates account balance by editing existing valuation for today" do
+    @account.entries.create! date: Date.current, amount: 6000, currency: "USD", entryable: Account::Valuation.new
+
+    assert_no_difference [ "Account::Entry.count", "Account::Valuation.count" ] do
+      patch account_url(@account), params: {
+        account: {
+          balance: 10000
+        }
+      }
+    end
 
     assert_redirected_to account_url(@account)
     assert_enqueued_with job: AccountSyncJob

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -41,11 +41,14 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
       account: {
         name: "Updated name",
         is_active: "0",
+        balance: 5000,
+        currency: "EUR",
         institution_id: institutions(:chase).id
       }
     }
 
     assert_redirected_to account_url(@account)
+    assert_enqueued_with job: AccountSyncJob
     assert_equal "Account updated", flash[:notice]
   end
 

--- a/test/models/account/balance/syncer_test.rb
+++ b/test/models/account/balance/syncer_test.rb
@@ -22,7 +22,8 @@ class Account::Balance::SyncerTest < ActiveSupport::TestCase
     syncer = Account::Balance::Syncer.new(@account)
     syncer.run
 
-    assert_equal [ 22000, 22000, @account.balance ], @account.balances.chronological.map(&:balance)
+    assert_equal 22000, @account.balance
+    assert_equal [ 22000, 22000, 22000 ], @account.balances.chronological.map(&:balance)
   end
 
   test "syncs account with transactions only" do
@@ -32,7 +33,8 @@ class Account::Balance::SyncerTest < ActiveSupport::TestCase
     syncer = Account::Balance::Syncer.new(@account)
     syncer.run
 
-    assert_equal [ 19600, 19500, 19500, 20000, 20000, @account.balance ], @account.balances.chronological.map(&:balance)
+    assert_equal 20000, @account.balance
+    assert_equal [ 19600, 19500, 19500, 20000, 20000, 20000 ], @account.balances.chronological.map(&:balance)
   end
 
   test "syncs account with valuations and transactions" do
@@ -44,7 +46,8 @@ class Account::Balance::SyncerTest < ActiveSupport::TestCase
     syncer = Account::Balance::Syncer.new(@account)
     syncer.run
 
-    assert_equal [ 20000, 20000, 20500, 20400, 25000, @account.balance ], @account.balances.chronological.map(&:balance)
+    assert_equal 25000, @account.balance
+    assert_equal [ 20000, 20000, 20500, 20400, 25000, 25000 ], @account.balances.chronological.map(&:balance)
   end
 
   test "syncs account with transactions in multiple currencies" do
@@ -57,7 +60,8 @@ class Account::Balance::SyncerTest < ActiveSupport::TestCase
     syncer = Account::Balance::Syncer.new(@account)
     syncer.run
 
-    assert_equal [ 21000, 20900, 20600, 20000, @account.balance ], @account.balances.chronological.map(&:balance)
+    assert_equal 20000, @account.balance
+    assert_equal [ 21000, 20900, 20600, 20000, 20000 ], @account.balances.chronological.map(&:balance)
   end
 
   test "converts foreign account balances to family currency" do
@@ -75,8 +79,9 @@ class Account::Balance::SyncerTest < ActiveSupport::TestCase
     usd_balances = @account.balances.where(currency: "USD").chronological.map(&:balance)
     eur_balances = @account.balances.where(currency: "EUR").chronological.map(&:balance)
 
-    assert_equal [ 21000, 20000, @account.balance ], eur_balances # native account balances
-    assert_equal [ 42000, 40000, @account.balance * 2 ], usd_balances # converted balances at rate of 2:1
+    assert_equal 20000, @account.balance
+    assert_equal [ 21000, 20000, 20000 ], eur_balances # native account balances
+    assert_equal [ 42000, 40000, 40000 ], usd_balances # converted balances at rate of 2:1
   end
 
   test "fails with error if exchange rate not available for any entry" do


### PR DESCRIPTION
This PR makes balance editing and syncing more straightforward:

https://github.com/user-attachments/assets/d7a80d04-93b5-4d2e-b8a2-ea589fb7e58f

- To edit current account balance, there are 2 primary ways to do it:
  - Edit the account (top right)
  - Add / edit a "valuation" entry for the current day
- To alter historical value of an account, just update the value entries

