### PR TITLE
Add currency validation to account, update demo data generator

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -4,7 +4,7 @@ class Account < ApplicationRecord
 
   broadcasts_refreshes
 
-  validates :family, presence: true
+  validates :name, :balance, :currency, presence: true
 
   belongs_to :family
   belongs_to :institution, optional: true

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -100,6 +100,7 @@ class Demo::Generator
         accountable: CreditCard.new,
         name: "Chase Credit Card",
         balance: 2300,
+        currency: "USD",
         institution: family.institutions.find_or_create_by(name: "Chase")
 
       50.times do
@@ -126,6 +127,7 @@ class Demo::Generator
         accountable: Depository.new,
         name: "Chase Checking",
         balance: 15000,
+        currency: "USD",
         institution: family.institutions.find_or_create_by(name: "Chase")
 
       10.times do
@@ -149,6 +151,7 @@ class Demo::Generator
         accountable: Depository.new,
         name: "Demo Savings",
         balance: 40000,
+        currency: "USD",
         subtype: "savings",
         institution: family.institutions.find_or_create_by(name: "Chase")
 
@@ -195,6 +198,7 @@ class Demo::Generator
         accountable: Investment.new,
         name: "Robinhood",
         balance: 100000,
+        currency: "USD",
         institution: family.institutions.find_or_create_by(name: "Robinhood")
 
       aapl = Security.find_by(symbol: "AAPL")
@@ -228,7 +232,8 @@ class Demo::Generator
       house = family.accounts.create! \
         accountable: Property.new,
         name: "123 Maybe Way",
-        balance: 560000
+        balance: 560000,
+        currency: "USD"
 
       create_valuation!(house, 3.years.ago.to_date, 520000)
       create_valuation!(house, 2.years.ago.to_date, 540000)
@@ -237,19 +242,22 @@ class Demo::Generator
       family.accounts.create! \
         accountable: Loan.new,
         name: "Mortgage",
-        balance: 495000
+        balance: 495000,
+        currency: "USD"
     end
 
     def create_car_and_loan!
       family.accounts.create! \
         accountable: Vehicle.new,
         name: "Honda Accord",
-        balance: 18000
+        balance: 18000,
+        currency: "USD"
 
       family.accounts.create! \
         accountable: Loan.new,
         name: "Car Loan",
-        balance: 8000
+        balance: 8000,
+        currency: "USD"
     end
 
     def create_transaction!(attributes = {})

--- a/test/controllers/accounts_controller_test.rb
+++ b/test/controllers/accounts_controller_test.rb
@@ -84,6 +84,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_difference [ "Account.count", "Account::Valuation.count", "Account::Entry.count" ], 1 do
       post accounts_path, params: {
         account: {
+          name: "Test",
           accountable_type: "Depository",
           balance: 200,
           currency: "USD",
@@ -101,6 +102,7 @@ class AccountsControllerTest < ActionDispatch::IntegrationTest
     assert_difference -> { Account.count } => 1, -> { Account::Valuation.count } => 2 do
       post accounts_path, params: {
         account: {
+          name: "Test",
           accountable_type: "Depository",
           balance: 200,
           currency: "USD",

--- a/test/controllers/transactions_controller_test.rb
+++ b/test/controllers/transactions_controller_test.rb
@@ -88,7 +88,7 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
   test "transaction count represents filtered total" do
     family = families(:empty)
     sign_in family.users.first
-    account = family.accounts.create! name: "Test", balance: 0, accountable: Depository.new
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
 
     3.times do
       create_transaction(account: account)
@@ -110,7 +110,7 @@ class TransactionsControllerTest < ActionDispatch::IntegrationTest
   test "can paginate" do
     family = families(:empty)
     sign_in family.users.first
-    account = family.accounts.create! name: "Test", balance: 0, accountable: Depository.new
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
 
     11.times do
       create_transaction(account: account)

--- a/test/models/account/entry_test.rb
+++ b/test/models/account/entry_test.rb
@@ -48,7 +48,7 @@ class Account::EntryTest < ActiveSupport::TestCase
 
   test "can search entries" do
     family = families(:empty)
-    account = family.accounts.create! name: "Test", balance: 0, accountable: Depository.new
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
     category = family.categories.first
     merchant = family.merchants.first
 
@@ -70,7 +70,7 @@ class Account::EntryTest < ActiveSupport::TestCase
 
   test "can calculate total spending for a group of transactions" do
     family = families(:empty)
-    account = family.accounts.create! name: "Test", balance: 0, accountable: Depository.new
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
     create_transaction(account: account, amount: 100)
     create_transaction(account: account, amount: 100)
     create_transaction(account: account, amount: -500) # income, will be ignored
@@ -80,7 +80,7 @@ class Account::EntryTest < ActiveSupport::TestCase
 
   test "can calculate total income for a group of transactions" do
     family = families(:empty)
-    account = family.accounts.create! name: "Test", balance: 0, accountable: Depository.new
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
     create_transaction(account: account, amount: -100)
     create_transaction(account: account, amount: -100)
     create_transaction(account: account, amount: 500) # income, will be ignored
@@ -95,7 +95,7 @@ class Account::EntryTest < ActiveSupport::TestCase
   end
 
   test "cannot sell more shares of stock than owned" do
-    account = families(:empty).accounts.create! name: "Test", balance: 0, accountable: Investment.new
+    account = families(:empty).accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Investment.new
     security = securities(:aapl)
 
     error = assert_raises ActiveRecord::RecordInvalid do


### PR DESCRIPTION
Previous account validation was not being done correctly (oversight).  #994 removed some of the default values being generated for accounts, so adding these validations required a few tweaks of tests / controllers.