### PR TITLE
Bump pagy with fix for breaking changes 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,7 @@ GEM
     octokit (9.1.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    pagy (8.6.3)
+    pagy (9.0.2)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -4,7 +4,7 @@ class TransactionsController < ApplicationController
   def index
     @q = search_params
     result = Current.family.entries.account_transactions.search(@q).reverse_chronological
-    @pagy, @transaction_entries = pagy(result, items: params[:per_page] || "50")
+    @pagy, @transaction_entries = pagy(result, limit: params[:per_page] || "50")
 
     @totals = {
       count: result.select { |t| t.currency == Current.family.currency }.count,

--- a/app/views/transactions/_pagination.html.erb
+++ b/app/views/transactions/_pagination.html.erb
@@ -46,7 +46,7 @@
                 data: { controller: "auto-submit-form" } do |f| %>
     <%= f.label :per_page, t(".rows_per_page"), class: "text-sm text-gray-500" %>
     <%= f.select :per_page,
-                 options_for_select(["10", "20", "30", "50"], pagy.items),
+                 options_for_select(["10", "20", "30", "50"], pagy.limit),
                  {},
                  class: "py-1.5 pr-8 text-sm text-gray-900 font-medium border border-gray-200 rounded-lg focus:border-gray-900 focus:ring-gray-900 focus-visible:ring-gray-900",
                  data: { "auto-submit-form-target": "auto" } %>


### PR DESCRIPTION
Page 9x has [breaking changes](https://ddnexus.github.io/pagy/changelog/#breaking-changes-1) this PR bumps pagy with replacing the obsolete `items` with `limit`