### PR TITLE
Set last_login_at only on login instead of every single action

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -3,13 +3,11 @@ module Authentication
 
   included do
     before_action :authenticate_user!
-    after_action :set_last_login_at, if: -> { Current.user }
   end
 
   class_methods do
     def skip_authentication(**options)
       skip_before_action :authenticate_user!, **options
-      skip_after_action :set_last_login_at, **options
     end
   end
 
@@ -27,6 +25,7 @@ module Authentication
     Current.user = user
     reset_session
     session[:user_id] = user.id
+    set_last_login_at
   end
 
   def logout

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -24,6 +24,14 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "sets last_login_at on successful registration" do
+    post registration_url, params: { user: {
+      email: "john@example.com",
+      password: "password",
+      password_confirmation: "password" } }
+    assert_not_nil User.find_by(email: "john@example.com").last_login_at
+  end
+
   test "create when hosted requires an invite code" do
     with_env_overrides REQUIRE_INVITE_CODE: "true" do
       assert_no_difference "User.count" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:family_admin)
+  end
+
+  test "can sign in" do
+    post session_url, params: { email: @user.email, password: "password" }
+    assert_redirected_to root_url
+  end
+
+  test "sets last_login_at on successful login" do
+    assert_changes -> { @user.reload.last_login_at }, from: nil do
+      post session_url, params: { email: @user.email, password: "password" }
+    end
+  end
+end


### PR DESCRIPTION
Currently, every request write to the `users` table updating `last_login_at`. Not sure this adds any value. This PR 
limits writing `users.last_login_at` to `POST /session` and `POST /registration` requests only.

<img width="1494" alt="Screenshot 2024-07-22 at 12 45 00" src="https://github.com/user-attachments/assets/5092fe0b-1ed2-4f24-a71b-6430f1b95330">
