### PR TITLE
Fix curency format

### DIFF
--- a/lib/money.rb
+++ b/lib/money.rb
@@ -91,8 +91,7 @@ class Money
       unit: currency.symbol,
       precision: currency.default_precision,
       delimiter: currency.delimiter,
-      separator: currency.separator,
-      format: currency.default_format
+      separator: currency.separator
     }
   end
 

--- a/lib/money.rb
+++ b/lib/money.rb
@@ -91,7 +91,8 @@ class Money
       unit: currency.symbol,
       precision: currency.default_precision,
       delimiter: currency.delimiter,
-      separator: currency.separator
+      separator: currency.separator,
+      format: currency.default_format
     }
   end
 


### PR DESCRIPTION
Fixes issue: #1019

![Screenshot from 2024-07-25 11-21-37](https://github.com/user-attachments/assets/de92ada1-46df-4ea7-8c0d-54d55278373e)

As you can see dollar sign is on the left of the number and 'kr' is on the right.