### PR TITLE
Implement auto family syncs on login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Authentication, Invitable, SelfHostable
+  include AutoSync, Authentication, Invitable, SelfHostable
   include Pagy::Backend
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/app/controllers/concerns/auto_sync.rb
+++ b/app/controllers/concerns/auto_sync.rb
@@ -1,0 +1,13 @@
+module AutoSync
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :sync_family, if: -> { Current.family.present? && Current.family.needs_sync? }
+  end
+
+  private
+
+    def sync_family
+      Current.family.sync
+    end
+end

--- a/app/models/account/sync.rb
+++ b/app/models/account/sync.rb
@@ -78,5 +78,6 @@ class Account::Sync < ApplicationRecord
         partial: "shared/notification",
         locals: { type: type, message: message }
       )
+      broadcast_refresh_to account
     end
 end

--- a/app/models/account/syncable.rb
+++ b/app/models/account/syncable.rb
@@ -11,6 +11,14 @@ module Account::Syncable
     syncs.syncing.any?
   end
 
+  def latest_sync_date
+    syncs.where.not(last_ran_at: nil).pluck(:last_ran_at).max&.to_date
+  end
+
+  def needs_sync?
+    latest_sync_date.nil? || latest_sync_date < Date.current
+  end
+
   def sync_later(start_date: nil)
     AccountSyncJob.perform_later(self, start_date: start_date)
   end

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -34,10 +34,6 @@ class Demo::Generator
       create_car_and_loan!
 
       puts "accounts created"
-
-      family.sync
-
-      puts "balances synced"
       puts "Demo data loaded successfully!"
     end
   end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -105,6 +105,16 @@ class Family < ApplicationRecord
   end
 
   def sync(start_date: nil)
-    accounts.active.sync(start_date: start_date)
+    accounts.active.each do |account|
+      if account.needs_sync?
+        account.sync_later(start_date: start_date || account.last_sync_date)
+      end
+    end
+
+    update! last_synced_at: Time.now
+  end
+
+  def needs_sync?
+    last_synced_at.nil? || last_synced_at.to_date < Date.current
   end
 end

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from @account %>
+
 <div class="space-y-4">
   <div class="flex justify-between items-center">
     <div class="flex items-center gap-3">

--- a/db/migrate/20240725163339_add_last_synced_at_to_family.rb
+++ b/db/migrate/20240725163339_add_last_synced_at_to_family.rb
@@ -1,0 +1,5 @@
+class AddLastSyncedAtToFamily < ActiveRecord::Migration[7.2]
+  def change
+    add_column :families, :last_synced_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_07_17_113535) do
+ActiveRecord::Schema[7.2].define(version: 2024_07_25_163339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -118,7 +118,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_17_113535) do
     t.boolean "is_active", default: true, null: false
     t.date "last_sync_date"
     t.uuid "institution_id"
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.index ["accountable_type"], name: "index_accounts_on_accountable_type"
     t.index ["family_id"], name: "index_accounts_on_family_id"
     t.index ["institution_id"], name: "index_accounts_on_institution_id"
@@ -194,6 +194,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_17_113535) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "currency", default: "USD"
+    t.datetime "last_synced_at"
   end
 
   create_table "good_job_batches", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -25,6 +25,10 @@ class AccountTest < ActiveSupport::TestCase
     @account.sync start_date: start_date
   end
 
+  test "needs sync if account has not synced today" do
+    assert @account.needs_sync?
+  end
+
   test "groups accounts by type" do
     result = @family.accounts.by_group(period: Period.all)
     assets = result[:assets]


### PR DESCRIPTION
Re-implementation of auto-syncing for accounts.

With the new `Account::Sync` model and the recent additions to the syncing notifications, we're able to implement a much more stable hook for syncing all accounts when needed.

This PR implements a "once per day" sync.

https://github.com/user-attachments/assets/ad12739e-bf6e-433c-a963-41dee7ea20cd

