### PR TITLE
Fix: Omit layout for turbo frames with custom sidebar layout

### DIFF
--- a/app/controllers/account/entries_controller.rb
+++ b/app/controllers/account/entries_controller.rb
@@ -1,5 +1,5 @@
 class Account::EntriesController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_account
   before_action :set_entry, only: %i[ edit update show destroy ]

--- a/app/controllers/account/holdings_controller.rb
+++ b/app/controllers/account/holdings_controller.rb
@@ -1,5 +1,5 @@
 class Account::HoldingsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_account
   before_action :set_holding, only: :show

--- a/app/controllers/account/transfers_controller.rb
+++ b/app/controllers/account/transfers_controller.rb
@@ -1,5 +1,5 @@
 class Account::TransfersController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_transfer, only: :destroy
 

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,5 +1,5 @@
 class AccountsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   include Filterable
   before_action :set_account, only: %i[ edit show destroy sync update ]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,4 +4,12 @@ class ApplicationController < ActionController::Base
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  private
+
+    def with_sidebar
+      return "turbo_rails/frame" if turbo_frame_request?
+
+      "with_sidebar"
+    end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,5 +1,5 @@
 class CategoriesController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_category, only: %i[ edit update ]
   before_action :set_transaction, only: :create

--- a/app/controllers/category/deletions_controller.rb
+++ b/app/controllers/category/deletions_controller.rb
@@ -1,5 +1,5 @@
 class Category::DeletionsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_category
   before_action :set_replacement_category, only: :create

--- a/app/controllers/help/articles_controller.rb
+++ b/app/controllers/help/articles_controller.rb
@@ -1,5 +1,5 @@
 class Help::ArticlesController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   def show
     @article = Help::Article.find(params[:id])

--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -1,5 +1,5 @@
 class MerchantsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_merchant, only: %i[ edit update destroy ]
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   include Filterable
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,3 +1,3 @@
 class SettingsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 end

--- a/app/controllers/tag/deletions_controller.rb
+++ b/app/controllers/tag/deletions_controller.rb
@@ -1,5 +1,5 @@
 class Tag::DeletionsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_tag
   before_action :set_replacement_tag, only: :create

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,5 +1,5 @@
 class TagsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   before_action :set_tag, only: %i[ edit update ]
 

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -1,5 +1,5 @@
 class TransactionsController < ApplicationController
-  layout "with_sidebar"
+  layout :with_sidebar
 
   def index
     @q = search_params


### PR DESCRIPTION
This PR folows this hint for turbo frame usage [https://github.com/hotwired/turbo-rails?tab=readme-ov-file#a-note-on-custom-layouts](url) and implements custom method for with sidebar layout. This change will ommit rendering layout when turbo frame request is used. It improves performance by returning much smaller html as example for rendering New account modal with layout server retruns 165 KB (request time: 235ms) of html with this change server returns 1.6 KB (request time: 35ms).