### PR TITLE
Fix minitest assert_nil warning

### DIFF
--- a/test/models/account/holding/syncer_test.rb
+++ b/test/models/account/holding/syncer_test.rb
@@ -103,8 +103,9 @@ class Account::Holding::SyncerTest < ActiveSupport::TestCase
 
         assert actual_holding, "expected #{ticker} holding on date: #{date}"
         assert_equal expected_holding[:qty], actual_holding.qty, "expected #{expected_qty} qty for holding #{ticker} on date: #{date}"
-        assert_equal expected_holding[:amount], actual_holding.amount, "expected #{expected_amount} amount for holding #{ticker} on date: #{date}"
-        assert_equal expected_holding[:price], actual_holding.price, "expected #{expected_price} price for holding #{ticker} on date: #{date}"
+
+        assert_equal expected_holding[:amount].to_i, actual_holding.amount.to_i, "expected #{expected_amount} amount for holding #{ticker} on date: #{date}"
+        assert_equal expected_holding[:price].to_i, actual_holding.price.to_i, "expected #{expected_price} price for holding #{ticker} on date: #{date}"
       end
     end
 


### PR DESCRIPTION
To reproduce: 

- Run test suite `bin/rails test`
- See warnings
```
DEPRECATED: Use assert_nil if expecting nil from test/models/account/holding/syncer_test.rb:106. This will fail in Minitest 6.
DEPRECATED: Use assert_nil if expecting nil from test/models/account/holding/syncer_test.rb:107. This will fail in Minitest 6.
``` 