### PR TITLE
Refactor: Use native error i18n lookup

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -17,7 +17,7 @@ class Settings::ProfilesController < SettingsController
     if Current.user.update(user_params_with_family)
       redirect_to settings_profile_path, notice: t(".success")
     else
-      redirect_to settings_profile_path, alert: t(".file_size_error")
+      redirect_to settings_profile_path, alert: Current.user.errors.full_messages.to_sentence
     end
   end
 

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -204,7 +204,14 @@ class Account::Entry < ApplicationRecord
         current_qty = account.holding_qty(account_trade.security)
 
         if current_qty < account_trade.qty.abs
-          errors.add(:base, "cannot sell #{account_trade.qty.abs} shares of #{account_trade.security.ticker} because you only own #{current_qty} shares")
+          # i18n-tasks-use t('activerecord.errors.models.account/entry.attributes.base.invalid_sell_quantity')
+          errors.add(
+            :base,
+            :invalid_sell_quantity,
+            sell_qty: account_trade.qty.abs,
+            ticker: account_trade.security.ticker,
+            current_qty: current_qty
+          )
         end
       end
     end

--- a/app/models/account/transfer.rb
+++ b/app/models/account/transfer.rb
@@ -13,15 +13,15 @@ class Account::Transfer < ApplicationRecord
   end
 
   def from_name
-    outflow_transaction&.account&.name || I18n.t("account.transfer.from_fallback_name")
+    outflow_transaction&.account&.name || I18n.t("account/transfer.from_fallback_name")
   end
 
   def to_name
-    inflow_transaction&.account&.name || I18n.t("account.transfer.to_fallback_name")
+    inflow_transaction&.account&.name || I18n.t("account/transfer.to_fallback_name")
   end
 
   def name
-    I18n.t("account.transfer.name", from_account: from_name, to_account: to_name)
+    I18n.t("account/transfer.name", from_account: from_name, to_account: to_name)
   end
 
   def inflow_transaction
@@ -72,24 +72,28 @@ class Account::Transfer < ApplicationRecord
 
     def transaction_count
       unless entries.size == 2
-        errors.add :entries, "must have exactly 2 entries"
+        # i18n-tasks-use t('activerecord.errors.models.account/transfer.attributes.entries.must_have_exactly_2_entries')
+        errors.add :entries, :must_have_exactly_2_entries
       end
     end
 
     def from_different_accounts
       accounts = entries.map { |e| e.account_id }.uniq
-      errors.add :entries, "must be from different accounts" if accounts.size < entries.size
+      # i18n-tasks-use t('activerecord.errors.models.account/transfer.attributes.entries.must_be_from_different_accounts')
+      errors.add :entries, :must_be_from_different_accounts if accounts.size < entries.size
     end
 
     def net_zero_flows
       unless entries.sum(&:amount).zero?
-        errors.add :transactions, "must have an inflow and outflow that net to zero"
+        # i18n-tasks-use t('activerecord.errors.models.account/transfer.attributes.entries.must_have_an_inflow_and_outflow_that_net_to_zero')
+        errors.add :entries, :must_have_an_inflow_and_outflow_that_net_to_zero
       end
     end
 
     def all_transactions_marked
       unless entries.all?(&:marked_as_transfer)
-        errors.add :entries, "must be marked as transfer"
+        # i18n-tasks-use t('activerecord.errors.models.account/transfer.attributes.entries.must_be_marked_as_transfer')
+        errors.add :entries, :must_be_marked_as_transfer
       end
     end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -178,7 +178,8 @@ class Import < ApplicationRecord
       begin
         CSV.parse(raw_csv_str || "")
       rescue CSV::MalformedCSVError
-        errors.add(:raw_csv_str, "is not a valid CSV format")
+        # i18n-tasks-use t('activerecord.errors.models.import.attributes.raw_csv_str.invalid_csv_format')
+        errors.add(:raw_csv_str, :invalid_csv_format)
       end
     end
 end

--- a/app/models/time_series/trend.rb
+++ b/app/models/time_series/trend.rb
@@ -83,18 +83,22 @@ class TimeSeries::Trend
 
     def values_must_be_of_same_type
       unless current.class == previous.class || [ previous, current ].any?(&:nil?)
-        errors.add :current, "must be of the same type as previous"
-        errors.add :previous, "must be of the same type as current"
+        # i18n-tasks-use t('activemodel.errors.models.time_series/trend.attributes.current.must_be_of_the_same_type_as_previous')
+        errors.add :current, :must_be_of_the_same_type_as_previous
+        # i18n-tasks-use t('activemodel.errors.models.time_series/trend.attributes.previous.must_be_of_the_same_type_as_current')
+        errors.add :previous, :must_be_of_the_same_type_as_current
       end
     end
 
     def values_must_be_of_known_type
       unless current.is_a?(Money) || current.is_a?(Numeric) || current.nil?
-        errors.add :current, "must be of type Money, Numeric, or nil"
+        # i18n-tasks-use t('activemodel.errors.models.time_series/trend.attributes.current.must_be_of_type_money_numeric_or_nil')
+        errors.add :current, :must_be_of_type_money_numeric_or_nil
       end
 
       unless previous.is_a?(Money) || previous.is_a?(Numeric) || previous.nil?
-        errors.add :previous, "must be of type Money, Numeric, or nil"
+        # i18n-tasks-use t('activemodel.errors.models.time_series/trend.attributes.previous.must_be_of_type_money_numeric_or_nil')
+        errors.add :previous, :must_be_of_type_money_numeric_or_nil
       end
     end
 

--- a/app/models/time_series/value.rb
+++ b/app/models/time_series/value.rb
@@ -40,7 +40,8 @@ class TimeSeries::Value
 
     def value_must_be_of_known_type
       unless value.is_a?(Money) || value.is_a?(Numeric)
-        errors.add :value, "must be a Money or Numeric"
+        # i18n-tasks-use t('activemodel.errors.models.time_series/value.attributes.value.must_be_a_money_or_numeric')
+        errors.add :value, must_be_a_money_or_numeric
       end
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -55,7 +55,8 @@ class User < ApplicationRecord
 
   def can_deactivate
     if admin? && family.users.count > 1
-      errors.add(:base, I18n.t("activerecord.errors.user.cannot_deactivate_admin_with_other_users"))
+      # i18n-tasks-use t('activerecord.errors.models.user.attributes.base.cannot_deactivate_admin_with_other_users')
+      errors.add(:base, :cannot_deactivate_admin_with_other_users)
     end
   end
 
@@ -83,7 +84,8 @@ class User < ApplicationRecord
 
   def profile_image_size
     if profile_image.attached? && profile_image.byte_size > 5.megabytes
-      errors.add(:profile_image, "is too large. Maximum size is 5 MB.")
+      # i18n-tasks-use t('activerecord.errors.models.user.attributes.profile_image.invalid_file_size')
+      errors.add(:profile_image, :invalid_file_size, max_megabytes: 5)
     end
   end
 end

--- a/config/locales/models/account/entry/en.yml
+++ b/config/locales/models/account/entry/en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        account/entry:
+          attributes:
+            base:
+              invalid_sell_quantity: cannot sell %{sell_qty} shares of %{ticker} because
+                you only own %{current_qty} shares

--- a/config/locales/models/account/transfer/en.yml
+++ b/config/locales/models/account/transfer/en.yml
@@ -1,7 +1,17 @@
 ---
 en:
-  account:
-    transfer:
-      from_fallback_name: Originator
-      name: Transfer from %{from_account} to %{to_account}
-      to_fallback_name: Receiver
+  account/transfer:
+    from_fallback_name: Originator
+    name: Transfer from %{from_account} to %{to_account}
+    to_fallback_name: Receiver
+  activerecord:
+    errors:
+      models:
+        account/transfer:
+          attributes:
+            entries:
+              must_be_from_different_accounts: must be from different accounts
+              must_be_marked_as_transfer: must be marked as transfer
+              must_have_an_inflow_and_outflow_that_net_to_zero: must have an inflow
+                and outflow that net to zero
+              must_have_exactly_2_entries: must have exactly 2 entries

--- a/config/locales/models/import/en.yml
+++ b/config/locales/models/import/en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  activerecord:
+    errors:
+      models:
+        import:
+          attributes:
+            raw_csv_str:
+              invalid_csv_format: is not a valid CSV format

--- a/config/locales/models/time_series/trend/en.yml
+++ b/config/locales/models/time_series/trend/en.yml
@@ -1,0 +1,15 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        time_series/trend:
+          attributes:
+            current:
+              must_be_of_the_same_type_as_previous: must be of the same type as previous
+              must_be_of_type_money_numeric_or_nil: must be of type Money, Numeric,
+                or nil
+            previous:
+              must_be_of_the_same_type_as_current: must be of the same type as current
+              must_be_of_type_money_numeric_or_nil: must be of type Money, Numeric,
+                or nil

--- a/config/locales/models/time_series/value/en.yml
+++ b/config/locales/models/time_series/value/en.yml
@@ -1,0 +1,9 @@
+---
+en:
+  activemodel:
+    errors:
+      models:
+        time_series/value:
+          attributes:
+            value:
+              must_be_a_money_or_numeric: must be a Money or Numeric

--- a/config/locales/models/user/en.yml
+++ b/config/locales/models/user/en.yml
@@ -11,6 +11,11 @@ en:
         password: Password
         password_confirmation: Password Confirmation
     errors:
-      user:
-        cannot_deactivate_admin_with_other_users: Admin cannot delete account while
-          other users are present. Please delete all members first.
+      models:
+        user:
+          attributes:
+            base:
+              cannot_deactivate_admin_with_other_users: Admin cannot delete account
+                while other users are present. Please delete all members first.
+            profile_image:
+              invalid_file_size: file size must be less than %{max_megabytes}MB

--- a/config/locales/views/settings/en.yml
+++ b/config/locales/views/settings/en.yml
@@ -108,5 +108,4 @@ en:
         profile_title: Profile
         save: Save
       update:
-        file_size_error: File size must be less than 5MB
         success: Profile updated successfully.

--- a/test/controllers/settings/profiles_controller_test.rb
+++ b/test/controllers/settings/profiles_controller_test.rb
@@ -25,6 +25,7 @@ class Settings::ProfilesControllerTest < ActionDispatch::IntegrationTest
     delete settings_profile_url
 
     assert_redirected_to settings_profile_url
+    assert_equal "Admin cannot delete account while other users are present. Please delete all members first.", flash[:alert]
     assert_no_enqueued_jobs only: UserPurgeJob
     assert User.find(@admin.id).active?
   end


### PR DESCRIPTION
This pull request refactors the existing error handling system to implement native internationalization (i18n) for error messages.

Rails [guides](https://guides.rubyonrails.org/i18n.html#error-message-scopes) documents the lookup order for a validation of name is not empty on the user model:
```
activerecord.errors.models.user.attributes.name.blank
activerecord.errors.models.user.blank
activerecord.errors.messages.blank
errors.attributes.name.blank
errors.messages.blank
```

I had to add magic comment hints for [i18n-tasks to recognized](https://github.com/glebm/i18n-tasks?tab=readme-ov-file#fine-tuning) that this translations are used.
I have not perfomed changes in lib/money.rb because i18n-tasks would not peek into that file.
