### PR TITLE
Fix: i18n symbol typo

### DIFF
--- a/app/models/time_series/value.rb
+++ b/app/models/time_series/value.rb
@@ -41,7 +41,7 @@ class TimeSeries::Value
     def value_must_be_of_known_type
       unless value.is_a?(Money) || value.is_a?(Numeric)
         # i18n-tasks-use t('activemodel.errors.models.time_series/value.attributes.value.must_be_a_money_or_numeric')
-        errors.add :value, must_be_a_money_or_numeric
+        errors.add :value, :must_be_a_money_or_numeric
       end
     end
 end


### PR DESCRIPTION
Hi @zachgoll,

I missed a colon in the previous PR #1076. 
Now I added tests to that part. 
Maybe the value validation could also be dropped because, as we can see the the tests, the trend validation comes first, so the only way to test that missing colon is to mock trend. On the other hand, code could change in the future and that validation does not hurt.

Sorry and thank you,
Pedro