### PR TITLE
Fix for invalid accountable data

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -28,6 +28,8 @@ class Account < ApplicationRecord
 
   delegated_type :accountable, types: Accountable::TYPES, dependent: :destroy
 
+  delegate :value, :series, to: :accountable
+
   class << self
     def by_group(period: Period.all, currency: Money.default_currency.iso_code)
       grouped_accounts = { assets: ValueGroup.new("Assets", currency), liabilities: ValueGroup.new("Liabilities", currency) }
@@ -72,31 +74,6 @@ class Account < ApplicationRecord
       account
     end
   end
-
-  # Start of temporary fix for #1068
-  # ==========================================================================
-
-  # TODO: Both `series` and `value` methods are a temporary fix for #1068, which appears to be a data corruption issue.
-  # Every account should have an accountable no matter what, but some self hosted instances seem to have missing accountables.
-  # When this is fixed, we can add this back to `delegate :value, :series, to: :accountable`
-  def series(period: Period.all, currency: self.currency)
-    if accountable.present?
-      accountable.series(period: period, currency: currency)
-    else
-      TimeSeries.new([])
-    end
-  end
-
-  def value
-    if accountable.present?
-      accountable.value
-    else
-      balance_money
-    end
-  end
-
-  # ==========================================================================
-  # End of temporary fix for #1068
 
   def alert
     latest_sync = syncs.latest

--- a/db/migrate/20240813170608_fix_invalid_accountable_data.rb
+++ b/db/migrate/20240813170608_fix_invalid_accountable_data.rb
@@ -1,0 +1,15 @@
+class FixInvalidAccountableData < ActiveRecord::Migration[7.2]
+  def up
+    Account.all.each do |account|
+      unless account.accountable
+        puts "Generating new accountable for id=#{account.id}, name=#{account.name}, type=#{account.accountable_type}"
+        new_accountable = Accountable.from_type(account.accountable_type).new
+        account.update!(accountable: new_accountable)
+      end
+    end
+  end
+
+  def down
+    # Not reversible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_07_153618) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_13_170608) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
A non-destructive, one-time fix for self hosters who currently have invalid account data that is causing the app to crash