### PR TITLE
Add ability to import pdfs from financial institutions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,8 @@ SECRET_KEY_BASE=secret-value
 # Disable enforcing SSL connections
 # DISABLE_SSL=true
 
+MAYBE_PDF_IMPORTS=false
+
 # ======================================================================================================
 # Upgrades Module - responsible for triggering upgrade alerts, prompts, and auto-upgrade functionality
 # ======================================================================================================
@@ -86,3 +88,11 @@ GITHUB_REPO_BRANCH=main
 # S3_SECRET_ACCESS_KEY=
 # S3_REGION= # defaults to `us-east-1` if not set
 # S3_BUCKET=
+
+# ======================================================================================================
+# Active Record Encryption - responsible for encrypting the database contents.
+# ======================================================================================================
+# Requires you to generated the keys eg. by running `bin/rails db:encryption:init`
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=

--- a/.env.test.example
+++ b/.env.test.example
@@ -15,3 +15,9 @@ COVERAGE=false
 
 # Set to true to run test suite serially
 DISABLE_PARALLELIZATION=false
+
+MAYBE_PDF_IMPORTS=true
+
+ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=maybe_test_encryption_primary_key
+ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=maybe_test_encryption_deterministic_key
+ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=maybe_test_encryption_key_derivation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432
       RAILS_ENV: test
+      MAYBE_PDF_IMPORTS: true
+      ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY: maybe_test_encryption_primary_key
+      ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY: maybe_test_encryption_deterministic_key
+      ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT: maybe_test_encryption_key_derivation
+
 
     services:
       postgres:

--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,5 @@ group :test do
   gem "climate_control"
   gem "simplecov", require: false
 end
+
+gem "pdf-reader", "~> 2.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.1.1)
     actioncable (7.2.0)
       actionpack (= 7.2.0)
       activesupport (= 7.2.0)
@@ -80,6 +81,7 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
+    afm (0.2.2)
     ast (2.4.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.965.0)
@@ -179,6 +181,7 @@ GEM
       railties (>= 6.1.0)
       thor (>= 1.0.0)
     hashdiff (1.1.0)
+    hashery (2.1.2)
     highline (3.0.1)
     hotwire-livereload (1.4.0)
       actioncable (>= 6.0.0)
@@ -270,6 +273,12 @@ GEM
     parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
+    pdf-reader (2.12.0)
+      Ascii85 (~> 1.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pg (1.5.7)
     prism (0.30.0)
     propshaft (0.9.1)
@@ -379,6 +388,7 @@ GEM
     ruby-lsp-rails (0.3.13)
       ruby-lsp (>= 0.17.12, < 0.18.0)
     ruby-progressbar (1.13.0)
+    ruby-rc4 (0.1.5)
     ruby-vips (2.2.2)
       ffi (~> 1.12)
       logger
@@ -429,6 +439,8 @@ GEM
       unicode-display_width (>= 1.1.1, < 3)
     thor (1.3.1)
     timeout (0.4.1)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     turbo-rails (2.0.6)
       actionpack (>= 6.0.0)
       activejob (>= 6.0.0)
@@ -490,6 +502,7 @@ DEPENDENCIES
   mocha
   octokit
   pagy
+  pdf-reader (~> 2.12)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -9,8 +9,9 @@ class ImportsController < ApplicationController
   end
 
   def new
+    raw_type = params[:raw_type] || "csv"
     account = Current.family.accounts.find_by(id: params[:account_id])
-    @import = Import.new account: account
+    @import = Import.new account: account, raw_type: raw_type
   end
 
   def edit
@@ -18,14 +19,18 @@ class ImportsController < ApplicationController
 
   def update
     account = Current.family.accounts.find(params[:import][:account_id])
-    @import.update! account: account, col_sep: params[:import][:col_sep]
+    pdf_regex = params[:import][:pdf_regex_id].present? ? Current.family.pdf_regexes.find(params[:import][:pdf_regex_id]) : nil
+    @import.update! account: account, col_sep: params[:import][:col_sep], pdf_regex: pdf_regex
 
     redirect_to load_import_path(@import), notice: t(".import_updated")
   end
 
   def create
+    create_params = params.require(:import).permit(:col_sep, :raw_type)
     account = Current.family.accounts.find(params[:import][:account_id])
-    @import = Import.create! account: account, col_sep: params[:import][:col_sep]
+    pdf_regex = params[:import][:pdf_regex_id].present? ? Current.family.pdf_regexes.find(params[:import][:pdf_regex_id]) : nil
+
+    @import = Import.create! account: account, raw_type: create_params[:raw_type] || "csv", col_sep: create_params[:col_sep], pdf_regex: pdf_regex
 
     redirect_to load_import_path(@import), notice: t(".import_created")
   end

--- a/app/controllers/pdf_regexes_controller.rb
+++ b/app/controllers/pdf_regexes_controller.rb
@@ -1,0 +1,53 @@
+class PdfRegexesController < ApplicationController
+  layout :with_sidebar
+
+  before_action :verify_pdf_imports_enabled
+  before_action :set_pdf_regex, only: %i[edit update]
+
+  def index
+    @pdf_regexes = Current.family.pdf_regexes.all
+  end
+
+  def new
+    @pdf_regex = Current.family.pdf_regexes.new
+  end
+
+  def create
+    Current.family.pdf_regexes.create!(pdf_regex_params)
+    redirect_to pdf_regexes_path, notice: t(".created")
+  end
+
+  def edit
+  end
+
+  def update
+    @pdf_regex.update!(pdf_regex_params)
+    redirect_to pdf_regexes_path, notice: t(".updated")
+  end
+
+  def destroy
+    # TODO: cant use @pdf_regex, why Current.user is nil?
+    PdfRegex.find(params[:id]).destroy!
+    redirect_to pdf_regexes_path, notice: t(".success")
+  end
+
+  private
+
+    def set_pdf_regex
+      @pdf_regex = Current.family.pdf_regexes.find(params[:id])
+    end
+
+    def pdf_regex_params
+      params.require(:pdf_regex).permit(
+        :name,
+        :transaction_line_regex_str,
+        :metadata_regex_str,
+        :pdf_transaction_date_format,
+        :pdf_range_date_format,
+      )
+    end
+
+    def verify_pdf_imports_enabled
+      head :not_found unless Rails.application.config.x.maybe.pdf_imports_enabled
+    end
+end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -9,6 +9,7 @@ class Family < ApplicationRecord
   has_many :categories, dependent: :destroy
   has_many :merchants, dependent: :destroy
   has_many :issues, through: :accounts
+  has_many :pdf_regexes, dependent: :destroy
 
   def snapshot(period = Period.all)
     query = accounts.active.joins(:balances)

--- a/app/models/import/csv.rb
+++ b/app/models/import/csv.rb
@@ -12,10 +12,14 @@ class Import::Csv
   end
 
   def self.create_with_field_mappings(raw_file_str, fields, field_mappings, col_sep = DEFAULT_COL_SEP)
-    raw_csv = self.parse_csv(raw_file_str, col_sep:)
+    rows = self.parse_csv(raw_file_str, col_sep:)
 
-    generated_csv_str = CSV.generate headers: fields.map { |f| f.key }, write_headers: true, col_sep: do |csv|
-      raw_csv.each do |row|
+    create_from(rows, fields, field_mappings, col_sep)
+  end
+
+  def self.create_from(rows, fields, field_mappings, col_sep = DEFAULT_COL_SEP)
+    generated_csv_str = CSV.generate(headers: fields.map { |f| f.key }, write_headers: true, col_sep:) do |csv|
+      rows.each do |row|
         row_values = []
 
         fields.each do |field|

--- a/app/models/import/file_coder.rb
+++ b/app/models/import/file_coder.rb
@@ -1,0 +1,16 @@
+class Import::FileCoder
+  def self.load(payload)
+    return nil unless payload.is_a?(String)
+
+    if Base64.encode64(Base64.decode64(payload)) == payload
+      Base64.decode64(payload)
+    else
+      # backwards compatibility allow load raw data from db
+      payload
+    end
+  end
+
+  def self.dump(payload)
+    Base64.encode64(payload)
+  end
+end

--- a/app/models/import/raw_csv.rb
+++ b/app/models/import/raw_csv.rb
@@ -1,0 +1,28 @@
+class Import::RawCsv
+  attr_accessor :import
+
+  def initialize(import)
+    @import = import
+  end
+
+  def available_fields
+    get_raw_csv.table.headers
+  end
+
+  def parse_raw
+    CSV.parse(import.raw_file_str || "", col_sep: import.col_sep)
+  end
+
+  # Uses the user-provided raw CSV + mappings to generate a normalized CSV for the import
+  def generate_normalized_csv
+    Import::Csv.create_with_field_mappings(import.raw_file_str, import.expected_fields, import.column_mappings, import.col_sep)
+ end
+
+  private
+
+    def get_raw_csv
+      return nil if import.raw_file_str.nil?
+
+      Import::Csv.new(import.raw_file_str, col_sep: import.col_sep)
+    end
+end

--- a/app/models/import/raw_pdf.rb
+++ b/app/models/import/raw_pdf.rb
@@ -1,0 +1,79 @@
+class Import::RawPdf
+  attr_accessor :import
+
+  def initialize(import)
+    @import = import
+  end
+
+  def available_fields
+    transation_line_regex.named_captures.keys
+  end
+
+  def parse_raw
+    return unless import.raw_file_str.present?
+
+    PDF::Reader.new(StringIO.new(import.raw_file_str))
+  end
+
+  def generate_normalized_csv
+    Import::Csv.create_from(transactions_rows, import.expected_fields, import.column_mappings)
+  end
+
+  private
+
+    # PDF parsing
+    def lines
+      reader = PDF::Reader.new(StringIO.new(import.raw_file_str))
+      reader.pages.flat_map { |page| page.text.split("\n") }
+    end
+
+    def transation_line_regex
+      @transation_line_regex ||= Regexp.new(import.pdf_regex.transaction_line_regex_str)
+    end
+
+    def transactions_lines
+      lines.map { |line| transation_line_regex.match?(line) ? line : nil }.compact_blank
+    end
+
+    def transform_row(line)
+      row = transation_line_regex.match(line).named_captures
+      row["date"] = iso_dates[row["date"]] if iso_dates[row["date"]]
+      row["amount"] = row["amount"].to_s.gsub(".", "").gsub(",", ".") if /\A(\d+(.)?)*\d?\d?\d,(\d?\d)\z/.match(row["amount"].to_s.gsub("\s", ""))
+      row["currency_code"] = metadata["currency_code"] if metadata["currency_code"].present?
+
+      row
+    end
+
+    def transactions_rows
+      transactions_lines.map { |line| transform_row(line) }
+    end
+
+    def metadata
+      return @metadata unless defined?(:@metadata)
+
+      return @metadata = {} if import.pdf_regex.metadata_regex_str.nil?
+
+      @metadata = Regexp.new(
+        import.pdf_regex.metadata_regex_str,
+        Regexp::MULTILINE
+      ).match(lines.join("\n"))&.named_captures
+    end
+
+    def iso_dates
+      return @iso_dates unless defined?(:@iso_dates)
+
+      @iso_dates = date_range.map { |date|
+        [
+          date.strftime(import.pdf_regex.pdf_transaction_date_format),
+          date.iso8601
+        ]
+      }.to_h.presence
+    end
+
+    def date_range
+      return [] if metadata["start_date"].nil?
+      return [] if metadata["end_date"].nil?
+
+      Date.parse(metadata["start_date"])..Date.parse(metadata["end_date"])
+    end
+end

--- a/app/models/pdf_regex.rb
+++ b/app/models/pdf_regex.rb
@@ -1,0 +1,3 @@
+class PdfRegex < ApplicationRecord
+  belongs_to :family
+end

--- a/app/views/imports/_form.html.erb
+++ b/app/views/imports/_form.html.erb
@@ -1,7 +1,13 @@
 <%= styled_form_with model: @import do |form| %>
+  <%= form.hidden_field :raw_type %>
   <div class="mb-4 space-y-3">
     <%= form.collection_select :account_id, Current.family.accounts.alphabetically, :id, :name, { prompt: t(".select_account"), label: t(".account"), required: true } %>
-    <%= form.collection_select :col_sep, Import::Csv::COL_SEP_LIST, :to_s, -> { t(".col_sep_char.#{_1.ord}") }, { prompt: t(".select_col_sep"), label: t(".col_sep"), required: true } %>
+    <% case @import.raw_type %>
+    <% when "csv" %>
+      <%= form.collection_select :col_sep, Import::Csv::COL_SEP_LIST, :to_s, -> { t(".col_sep_char.#{_1.ord}") }, { prompt: t(".select_col_sep"), label: t(".col_sep"), required: true } %>
+    <% when "pdf" %>
+      <%= form.collection_select :pdf_regex_id, PdfRegex.all, :id, :name, { label: PdfRegex.model_name.human }, required: true %>
+    <% end %>
   </div>
 
   <%= form.submit t(".next"), class: "px-4 py-2 block w-full rounded-lg bg-gray-900 text-white text-sm font-medium cursor-pointer hover:bg-gray-700" %>

--- a/app/views/imports/_pdf_upload.html.erb
+++ b/app/views/imports/_pdf_upload.html.erb
@@ -1,0 +1,24 @@
+<%= styled_form_with model: @import, url: upload_import_path(@import), class: "dropzone space-y-4", data: { controller: "import-upload", import_upload_accepted_types_value: ["application/pdf", ".pdf"], import_upload_extension_value: "csv", import_upload_unacceptable_type_label_value: t(".allowed_filetypes") }, method: :patch, multipart: true do |form| %>
+  <div class="flex items-center justify-center w-full">
+    <label for="import_raw_file_str" class="raw-file-drop-box flex flex-col items-center justify-center w-full h-64 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50" data-action="dragover->import-upload#dragover dragleave->import-upload#dragleave drop->import-upload#drop click->import-upload#click">
+      <div class="flex flex-col items-center justify-center pt-5 pb-6">
+        <%= lucide_icon "plus", class: "w-5 h-5 text-gray-500" %>
+        <%= form.file_field :raw_file_str, class: "hidden", direct_upload: false, accept: ".pdf,application/pdf", data: { import_upload_target: "input", action: "change->import-upload#addFile" } %>
+        <p class="mb-2 text-sm text-gray-500 mt-3">Drag and drop your pdf file here or <span class="text-black">click to browse</span></p>
+        <p class="text-xs text-gray-500">PDF (Max. 5MB)</p>
+        <div class="pdf-preview" data-import-upload-target="preview"></div>
+      </div>
+    </label>
+  </div>
+  <%= form.submit t(".next"), class: "px-4 py-2 mb-4 block w-full rounded-lg bg-alpha-black-25 text-gray text-sm font-medium", data: { import_upload_target: "submit", turbo_confirm: (@import.raw_file_str? ? { title: t(".confirm_title"), body: t(".confirm_body"), accept: t(".confirm_accept") } : nil) } %>
+<% end %>
+
+<div id="template-preview" class="hidden">
+  <div class="flex flex-col items-center justify-center">
+    <%= lucide_icon "file-text", class: "w-10 h-10 pt-2 text-black" %>
+    <div class="flex flex-row items-center justify-center gap-0.5">
+      <div><span data-import-upload-target="filename"></span></div>
+      <div><span data-import-upload-target="filesize" class="font-semibold"></span></div>
+    </div>
+  </div>
+</div>

--- a/app/views/imports/_type_selector.html.erb
+++ b/app/views/imports/_type_selector.html.erb
@@ -46,6 +46,23 @@
             <div class="h-px bg-alpha-black-50"></div>
           </div>
         </li>
+        <% if Rails.application.config.x.maybe.pdf_imports_enabled %>
+          <li>
+            <%= link_to new_import_path(raw_type: "pdf"), class: "flex items-center gap-3 p-4 group cursor-pointer", data: { turbo: false } do %>
+              <div class="bg-indigo-500/5 rounded-md w-8 h-8 flex items-center justify-center">
+                <%= lucide_icon("file-spreadsheet", class: "w-5 h-5 text-indigo-500") %>
+              </div>
+              <span class="text-sm text-gray-900 group-hover:text-gray-700">
+                <%= t(".import_from_pdf") %>
+              </span>
+              <%= lucide_icon("chevron-right", class: "w-5 h-5 text-gray-500 ml-auto") %>
+            <% end %>
+
+            <div class="pl-14 pr-3">
+              <div class="h-px bg-alpha-black-50"></div>
+            </div>
+          </li>
+        <% end %>
         <li>
           <div class="flex items-center gap-3 p-4 group cursor-not-allowed">
             <%= image_tag("mint-logo.jpeg", alt: "Mint logo", class: "w-8 h-8 rounded-md") %>

--- a/app/views/imports/configure.html.erb
+++ b/app/views/imports/configure.html.erb
@@ -4,17 +4,17 @@
   <h1 class="sr-only"><%= t(".configure_title") %></h1>
 
   <div class="text-center space-y-2">
-    <h2 class="text-3xl text-gray-900 font-medium"><%= t(".configure_subtitle") %></h2>
-    <p class="text-gray-500 text-sm"><%= t(".configure_description") %></p>
+    <h2 class="text-3xl text-gray-900 font-medium"><%= t(".configure_subtitle_#{@import.raw_type}") %></h2>
+    <p class="text-gray-500 text-sm"><%= t(".configure_description_#{@import.raw_type}") %></p>
   </div>
 
   <%= styled_form_with model: @import, url: configure_import_path(@import), class: "space-y-4" do |form| %>
       <%= form.fields_for :column_mappings do |mappings| %>
         <% @import.expected_fields.each do |field| %>
           <%= mappings.select field.key,
-                              options_for_select(@import.available_headers, @import.get_selected_header_for_field(field)),
+                              options_for_select(@import.available_fields, @import.get_selected_header_for_field(field)),
                               label: field.label,
-                              include_blank: field.optional? ? t(".optional") : false %>
+                              include_blank: field.optional? ? t(".optional_#{@import.raw_type}") : false %>
         <% end %>
       <% end %>
 

--- a/app/views/imports/index.html.erb
+++ b/app/views/imports/index.html.erb
@@ -5,11 +5,22 @@
 <div class="space-y-4">
   <div class="flex items-center justify-between">
     <h1 class="text-xl font-medium text-gray-900"><%= t(".title") %></h1>
-
-    <%= link_to new_import_path(enable_type_selector: true), class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2", data: { turbo_frame: :modal } do %>
-      <%= lucide_icon("plus", class: "w-5 h-5") %>
-      <span><%= t(".new") %></span>
-    <% end %>
+      <div class="flex items-center gap-2">
+        <% if Rails.application.config.x.maybe.pdf_imports_enabled %>
+          <%= contextual_menu do %>
+            <div class="w-48 p-1 text-sm leading-6 text-gray-900 bg-white shadow-lg shrink rounded-xl ring-1 ring-gray-900/5">
+              <%= link_to pdf_regexes_path, class: "block w-full py-2 px-3 space-x-2 text-gray-900 hover:bg-gray-50 flex items-center rounded-lg font-normal" do %>
+                <%= lucide_icon "cpu", class: "w-5 h-5 text-gray-500" %>
+                <span class="text-black"><%= t(".pdf_regexes") %></span>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+      <%= link_to new_import_path(enable_type_selector: true), class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2", data: { turbo_frame: :modal } do %>
+        <%= lucide_icon("plus", class: "w-5 h-5") %>
+        <span><%= t(".new") %></span>
+      <% end %>
+    </div>
   </div>
   <div class="bg-white shadow-xs border border-alpha-black-25 rounded-xl p-4">
     <% if @imports.empty? %>

--- a/app/views/imports/load.html.erb
+++ b/app/views/imports/load.html.erb
@@ -5,21 +5,28 @@
 
   <div class="text-center space-y-2">
     <h2 class="text-3xl text-gray-900 font-medium"><%= t(".subtitle") %></h2>
-    <p class="text-gray-500 text-sm"><%= t(".description") %></p>
+    <p class="text-gray-500 text-sm"><%= t(".description_#{@import.raw_type}") %></p>
   </div>
 
-  <div data-controller="tabs" data-tabs-active-class="bg-white" data-tabs-default-tab-value="csv-upload-tab">
-    <div class="flex justify-center mb-4">
-      <div class="bg-gray-50 rounded-lg inline-flex p-1 space-x-2 text-sm text-gray-900 font-medium">
-        <button data-id="csv-upload-tab" class="p-2 rounded-lg" data-tabs-target="btn" data-action="click->tabs#select">Upload CSV</button>
-        <button data-id="csv-paste-tab" class="p-2 rounded-lg" data-tabs-target="btn" data-action="click->tabs#select">Copy & Paste</button>
+  <% case @import.raw_type %>
+  <% when "csv" %>
+    <div data-controller="tabs" data-tabs-active-class="bg-white" data-tabs-default-tab-value="csv-upload-tab">
+      <div class="flex justify-center mb-4">
+        <div class="bg-gray-50 rounded-lg inline-flex p-1 space-x-2 text-sm text-gray-900 font-medium">
+          <button data-id="csv-upload-tab" class="p-2 rounded-lg" data-tabs-target="btn" data-action="click->tabs#select">Upload CSV</button>
+          <button data-id="csv-paste-tab" class="p-2 rounded-lg" data-tabs-target="btn" data-action="click->tabs#select">Copy & Paste</button>
+        </div>
+      </div>
+      <div data-tabs-target="tab" id="csv-upload-tab">
+        <%= render partial: "imports/csv_upload", locals: { import: @import } %>
+      </div>
+      <div data-tabs-target="tab" id="csv-paste-tab" class="hidden">
+        <%= render partial: "imports/csv_paste", locals: { import: @import } %>
       </div>
     </div>
-    <div data-tabs-target="tab" id="csv-upload-tab">
-      <%= render partial: "imports/csv_upload", locals: { import: @import } %>
+  <% when "pdf" %>
+    <div data-tabs-target="tab" id="raw-upload-tab">
+      <%= render partial: "imports/pdf_upload", locals: { import: @import } %>
     </div>
-    <div data-tabs-target="tab" id="csv-paste-tab" class="hidden">
-      <%= render partial: "imports/csv_paste", locals: { import: @import } %>
-    </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/pdf_regexes/_form.html.erb
+++ b/app/views/pdf_regexes/_form.html.erb
@@ -1,0 +1,60 @@
+<%= styled_form_with model: pdf_regex, data: { turbo: false } do |form| %>
+  <div class="flex flex-col space-y-4 w-96">
+    <fieldset class="relative">
+      <span class="pointer-events-none absolute inset-y-3.5 left-3 flex items-center pl-1 block w-1 rounded-lg"></span>
+      <%= form.text_field :name,
+                          value: pdf_regex.name,
+                          autofocus: "",
+                          required: true,
+                          placeholder: "Enter pdf_regex name",
+                          class: "rounded-lg w-full focus:ring-black focus:border-transparent placeholder:text-gray-500 pl-6" %>
+    </fieldset>
+
+    <fieldset class="relative">
+      <span class="pointer-events-none absolute inset-y-3.5 left-3 flex items-center pl-1 block w-1 rounded-lg"></span>
+      <%= form.text_area :transaction_line_regex_str,
+                          autofocus: "",
+                          required: true,
+                          size: "70x5",
+                          placeholder: "Enter transaction_line_regex_str",
+                          class: "rounded-lg w-full focus:ring-black focus:border-transparent placeholder:text-gray-500 pl-6" %>
+    </fieldset>
+
+    <fieldset class="relative">
+      <span class="pointer-events-none absolute inset-y-3.5 left-3 flex items-center pl-1 block w-1 rounded-lg"></span>
+      <%= form.text_area :metadata_regex_str,
+                          autofocus: "",
+                          size: "70x5",
+                          placeholder: "Enter metadata_regex_str",
+                          class: "rounded-lg w-full focus:ring-black focus:border-transparent placeholder:text-gray-500 pl-6" %>
+    </fieldset>
+
+    <fieldset class="relative">
+      <span class="pointer-events-none absolute inset-y-3.5 left-3 flex items-center pl-1 block w-1 rounded-lg"></span>
+      <%= form.text_field :pdf_transaction_date_format,
+                          autofocus: "",
+                          required: true,
+                          placeholder: "Enter pdf_transaction_date_format",
+                          class: "rounded-lg w-full focus:ring-black focus:border-transparent placeholder:text-gray-500 pl-6" %>
+    </fieldset>
+
+    <fieldset class="relative">
+      <span class="pointer-events-none absolute inset-y-3.5 left-3 flex items-center pl-1 block w-1 rounded-lg"></span>
+      <%= form.text_field :pdf_range_date_format,
+                          autofocus: "",
+                          required: true,
+                          placeholder: "Enter pdf_transaction_date_format",
+                          class: "rounded-lg w-full focus:ring-black focus:border-transparent placeholder:text-gray-500 pl-6" %>
+    </fieldset>
+
+    <section>
+      <%= hidden_field_tag :pdf_regex_id, params[:pdf_regex_id] %>
+
+      <% if pdf_regex.persisted? %>
+        <%= form.submit t(".update") %>
+      <% else %>
+        <%= form.submit t(".create") %>
+      <% end %>
+    </section>
+  </div>
+<% end %>

--- a/app/views/pdf_regexes/_pdf_regex.erb
+++ b/app/views/pdf_regexes/_pdf_regex.erb
@@ -1,0 +1,31 @@
+<div id="<%= dom_id(pdf_regex) %>" class="flex justify-between mx-4 py-5 border-b last:border-b-0 border-alpha-black-50">
+  <div class="flex items-center gap-2">
+    <div class="w-8 h-8 flex items-center justify-center rounded-full text-xs font-medium bg-blue-500/10 text-blue-500">
+      <%= pdf_regex.name[0].upcase %>
+    </div>
+    <%= pdf_regex.name %>
+  </div>
+  <%= contextual_menu do %>
+    <div class="w-48 p-1 text-sm leading-6 text-gray-900 bg-white shadow-lg shrink rounded-xl ring-1 ring-gray-900/5">
+      <%= link_to edit_pdf_regex_path(pdf_regex),
+                  class: "block w-full py-2 px-3 space-x-2 text-gray-900 hover:bg-gray-50 flex items-center rounded-lg",
+                  data: { turbo_frame: :modal } do %>
+        <%= lucide_icon "pencil-line", class: "w-5 h-5 text-gray-500" %>
+
+        <span><%= t(".edit") %></span>
+      <% end %>
+
+      <%= button_to pdf_regex_path(pdf_regex),
+                        method: :delete,
+                        class: "block w-full py-2 px-3 space-x-2 text-red-600 hover:bg-red-50 flex items-center rounded-lg",
+                        data: {
+                          turbo_confirm: {
+                            title: t(".confirm_title"),
+                            accept: t(".confirm_accept", name: pdf_regex.name)
+                          }
+                        } do %>
+            <%= lucide_icon("trash-2", class: "w-5 h-5 mr-2") %><%= t(".delete") %>
+          <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/pdf_regexes/edit.html.erb
+++ b/app/views/pdf_regexes/edit.html.erb
@@ -1,0 +1,3 @@
+<%= modal_form_wrapper title: t(".edit") do %>
+  <%= render "form", pdf_regex: @pdf_regex %>
+<% end %>

--- a/app/views/pdf_regexes/index.html.erb
+++ b/app/views/pdf_regexes/index.html.erb
@@ -1,0 +1,49 @@
+<% content_for :sidebar do %>
+  <%= render "settings/nav" %>
+<% end %>
+
+<section class="space-y-4">
+  <header class="flex items-center justify-between">
+    <h1 class="text-gray-900 text-xl font-medium"><%= t(".pdf_regexes") %></h1>
+
+    <%= link_to new_pdf_regex_path, class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2", data: { turbo_frame: :modal } do %>
+      <%= lucide_icon "plus", class: "w-5 h-5" %>
+      <p><%= t(".new") %></p>
+    <% end %>
+  </header>
+
+  <div class="bg-white shadow-xs border border-alpha-black-25 rounded-xl p-4">
+
+    <% if @pdf_regexes.any? %>
+
+      <div class="rounded-xl bg-gray-25 p-1">
+        <h2 class="uppercase px-4 py-2 text-gray-500 text-xs"><%= t(".pdf_regexes") %> · <%= @pdf_regexes.size %></h2>
+
+        <div class="border border-alpha-gray-100 rounded-lg bg-white shadow-xs">
+
+          <%= render @pdf_regexes %>
+
+        </div>
+      </div>
+
+    <% else %>
+
+      <div class="flex justify-center items-center py-20">
+        <div class="text-center flex flex-col items-center max-w-[300px]">
+          <p class="text-gray-900 mb-1 font-medium text-sm"><%= t(".empty") %></p>
+          <%= link_to new_pdf_regex_path, class: "w-fit flex text-white text-sm font-medium items-center gap-1 bg-gray-900 rounded-lg p-2 pr-3", data: { turbo_frame: "modal" } do %>
+            <%= lucide_icon("plus", class: "w-5 h-5") %>
+            <span><%= t(".new") %></span>
+          <% end %>
+        </div>
+      </div>
+
+    <% end %>
+
+  </div>
+
+  <footer class="flex justify-between gap-4">
+    <%= previous_setting("Rules", rules_transactions_path) %>
+    <%= next_setting("Imports", imports_path) %>
+  </footer>
+</section>

--- a/app/views/pdf_regexes/new.html.erb
+++ b/app/views/pdf_regexes/new.html.erb
@@ -1,0 +1,3 @@
+<%= modal_form_wrapper title: t(".new") do %>
+  <%= render "form", pdf_regex: @pdf_regex %>
+<% end %>

--- a/bin/pdf-from-text
+++ b/bin/pdf-from-text
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Utility script to create fake bank/credit card statements
+# Create a PDF file from a colection of numbered txt files in a given folder
+# ex: bin/pdf-from-text tmp/pdfs/026af4
+
+require "rubygems"
+require "bundler/inline"
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'prawn'
+end
+
+folder_path =  File.expand_path(ARGV[0])
+pdf_path = File.join(File.dirname(folder_path), [File.basename(folder_path), "pdf"].join("."))
+page_paths = Dir["#{folder_path}/*"]
+page_paths = page_paths.select { |file| /\d+.txt/.match(File.basename(file)) }
+page_paths = page_paths.sort_by { |file| /(?<page_number>\d+).txt/.match(File.basename(file))[:page_number].to_i }
+
+raise(ArgumentError, "no txt pages found") if page_paths.size == 0
+
+def page_lines(page_path)
+  File.read(page_path)
+    .gsub(/^([^\S\r\n]+)/m) { |m| Prawn::Text::NBSP * m.size }
+end
+
+Prawn::Document.generate(pdf_path) do |pdf|
+  # mono font in order to spaces render same size as letters
+  pdf.font(File.expand_path("~/Library/Fonts/DejaVu Sans Mono for Powerline.ttf"), size: 6)
+  page_paths[0..-2].each do |page_path|
+    pdf.text(page_lines(page_path))
+    pdf.start_new_page
+  end
+  pdf.text(page_lines(page_paths[-1]))
+end
+
+puts "pdf created in: #{pdf_path}"

--- a/bin/pdf-to-text
+++ b/bin/pdf-to-text
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Utility script to create fake bank/credit card statements
+# Create text files for each page of a given PDF
+# ex: bin/pdf-to-text some-folder/file.pdf
+
+require "rubygems"
+require 'securerandom'
+require "bundler/inline"
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'pdf-reader'
+end
+
+io = open(ARGV[0])
+reader = ::PDF::Reader.new(io)
+folder_path =  File.join(File.expand_path(File.dirname(File.dirname(__FILE__))), "tmp/pdfs/#{SecureRandom.hex(3)}")
+
+Dir.mkdir(folder_path)
+
+reader.pages.each do |page|
+  File.write(File.join(folder_path, "#{page.number}.txt"), page.text)
+end
+
+puts "pdf text written into: #{folder_path}"

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,11 @@ module Maybe
     config.active_job.queue_adapter = :good_job
 
     config.app_mode = (ENV["SELF_HOSTING_ENABLED"] == "true" ? "self_hosted" : "managed").inquiry
+
+    config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
+    config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
+    config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+
+    config.x.maybe.pdf_imports_enabled = ActiveModel::Type::Boolean.new.cast(ENV["MAYBE_PDF_IMPORTS"])
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.autoload_paths += %w[test/support]
+
+  config.active_record.encryption.encrypt_fixtures = true
 end

--- a/config/locales/models/import/en.yml
+++ b/config/locales/models/import/en.yml
@@ -7,3 +7,4 @@ en:
           attributes:
             raw_file_str:
               invalid_csv_format: is not a valid CSV format
+              invalid_pdf_format: is not a valid PDF format

--- a/config/locales/models/pdf_regex/en.yml
+++ b/config/locales/models/pdf_regex/en.yml
@@ -1,0 +1,5 @@
+---
+en:
+  activerecord:
+    models:
+      pdf_regex: PDF regex

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -8,9 +8,13 @@ en:
       clean_import: Clean import
       invalid_csv: Please load a CSV first
     configure:
-      configure_description: Select the columns that match the necessary data fields,
-        so that the columns in your CSV can be correctly mapped with our format.
-      configure_subtitle: Setup your CSV file
+      configure_description_csv: Select the columns that match the necessary data
+        fields, so that the columns in your CSV can be correctly mapped with our format.
+      configure_description_pdf: Select the regex variables that match the necessary
+        data fields, so that the regex captured fields on your PDF can be correctly
+        mapped with our format.
+      configure_subtitle_csv: Setup your CSV file
+      configure_subtitle_pdf: Setup your PDF file regex
       configure_title: Configure import
       confirm_accept: Change mappings
       confirm_body: Changing your mappings may erase any edits you have made to the
@@ -18,7 +22,8 @@ en:
       confirm_title: Are you sure?
       invalid_csv: Please load a CSV first
       next: Next
-      optional: "(optional) No column selected"
+      optional_csv: "(optional) No column selected"
+      optional_pdf: "(optional) No regex capture selected"
     confirm:
       confirm_description: Preview your transactions below and check to see if there
         are any changes that are required.
@@ -79,10 +84,12 @@ en:
     index:
       imports: Imports
       new: New import
+      pdf_regexes: PDF regexes
       title: Imports
     load:
-      description: Create a spreadsheet or upload an exported CSV from your financial
+      description_csv: Create a spreadsheet or upload an exported CSV from your financial
         institution.
+      description_pdf: Upload an exported PDF from your financial institution.
       load_title: Load import
       subtitle: Import your transactions
     load_csv:
@@ -91,6 +98,13 @@ en:
       description_text: Importing transactions can only be done for one account at
         a time. You will need to go through this process again for other accounts.
       header_text: Select the account your transactions will belong to
+    pdf_upload:
+      allowed_filetypes: Only PDF files are allowed.
+      confirm_accept: Yep, start over!
+      confirm_body: This will reset your import. Any data changes you have made to
+        processed data from this PDF will be erased.
+      confirm_title: Are you sure?
+      next: Next
     publish:
       import_published: Import has started in the background
       invalid_data: Your import is invalid
@@ -101,6 +115,7 @@ en:
       import_from_csv: New import from CSV
       import_from_empower: Import from Empower
       import_from_mint: Import from Mint
+      import_from_pdf: New import from PDF
       import_transactions: Import transactions
       resume_latest_import: Resume latest import
       soon: Soon

--- a/config/locales/views/pdf_regexes/en.yml
+++ b/config/locales/views/pdf_regexes/en.yml
@@ -1,0 +1,25 @@
+---
+en:
+  pdf_regexes:
+    create:
+      created: PDF Regex created
+    destroy:
+      success: PDF regex removed
+    edit:
+      edit: Edit PDF regex
+    form:
+      create: Create PDF regex
+      update: Update
+    index:
+      empty: No PDF regexes yet
+      new: New PDF regex
+      pdf_regexes: PDF regexes
+    new:
+      new: New PDF regex
+    pdf_regex:
+      confirm_accept: Delete PDF regex
+      confirm_title: Delete Entry?
+      delete: Delete PDF regex
+      edit: Edit
+    update:
+      updated: PDF regex updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :pdf_regexes, except: %i[show]
+
   resources :tags, except: %i[show destroy] do
     resources :deletions, only: %i[new create], module: :tag
   end

--- a/db/migrate/20240823174905_create_pdf_regexes.rb
+++ b/db/migrate/20240823174905_create_pdf_regexes.rb
@@ -1,0 +1,14 @@
+class CreatePdfRegexes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :pdf_regexes, id: :uuid do |t|
+      t.references :family, null: false, foreign_key: true, type: :uuid
+      t.string :name, null: false
+      t.string :transaction_line_regex_str, null: false
+      t.string :metadata_regex_str
+      t.string :pdf_transaction_date_format, null: false
+      t.string :pdf_range_date_format
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240823175026_add_raw_type_and_pdf_regex_to_import.rb
+++ b/db/migrate/20240823175026_add_raw_type_and_pdf_regex_to_import.rb
@@ -1,0 +1,9 @@
+class AddRawTypeAndPdfRegexToImport < ActiveRecord::Migration[7.2]
+  def change
+    # sets default from existing records, and then removes the default
+    add_column :imports, :raw_type, :string, default: 'csv', null: false
+    change_column_default :imports, :raw_type, from: 'csv', to: nil
+    # adds a pdf regex
+    add_reference :imports, :pdf_regex, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_23_125526) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_23_175026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -309,7 +309,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_23_125526) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "col_sep", default: ","
+    t.string "raw_type", null: false
+    t.uuid "pdf_regex_id"
     t.index ["account_id"], name: "index_imports_on_account_id"
+    t.index ["pdf_regex_id"], name: "index_imports_on_pdf_regex_id"
   end
 
   create_table "institutions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -368,6 +371,18 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_23_125526) do
   create_table "other_liabilities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "pdf_regexes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.string "name", null: false
+    t.string "transaction_line_regex_str", null: false
+    t.string "metadata_regex_str"
+    t.string "pdf_transaction_date_format", null: false
+    t.string "pdf_range_date_format"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_id"], name: "index_pdf_regexes_on_family_id"
   end
 
   create_table "properties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -463,8 +478,10 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_23_125526) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "categories", "families"
   add_foreign_key "imports", "accounts"
+  add_foreign_key "imports", "pdf_regexes"
   add_foreign_key "institutions", "families"
   add_foreign_key "merchants", "families"
+  add_foreign_key "pdf_regexes", "families"
   add_foreign_key "taggings", "tags"
   add_foreign_key "tags", "families"
   add_foreign_key "users", "families"

--- a/test/controllers/pdf_regexes_controller_test.rb
+++ b/test/controllers/pdf_regexes_controller_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class PdfRegexesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    sign_in @user = users(:family_admin)
+    @pdf_regex = pdf_regexes(:awesome_bank_pdf_regex)
+
+    @pdf_regex_params = {
+      name: "name",
+      transaction_line_regex_str: "transaction_line_regex_str",
+      metadata_regex_str: "metadata_regex_str",
+      pdf_transaction_date_format: "pdf_transaction_date_format",
+      pdf_range_date_format: "pdf_range_date_format"
+    }
+  end
+
+  test "index" do
+    get pdf_regexes_path
+    assert_response :success
+  end
+
+  test "new" do
+    get new_pdf_regex_path
+    assert_response :success
+  end
+
+  test "should create pdf_regex" do
+    assert_difference("PdfRegex.count") do
+      post pdf_regexes_url, params: { pdf_regex: @pdf_regex_params }
+    end
+
+    assert_redirected_to pdf_regexes_path
+  end
+
+  test "should update pdf_regex" do
+    patch pdf_regex_url(@pdf_regex), params: { pdf_regex: @pdf_regex_params }
+    assert_redirected_to pdf_regexes_path
+  end
+
+  test "should destroy pdf_regex" do
+    assert_difference("PdfRegex.count", -1) do
+      delete pdf_regex_url(@pdf_regex)
+    end
+
+    assert_redirected_to pdf_regexes_path
+  end
+end

--- a/test/fixtures/files/transactions.pdf
+++ b/test/fixtures/files/transactions.pdf
@@ -1,0 +1,733 @@
+%PDF-1.3
+%ÿÿÿÿ
+1 0 obj
+<< /Creator <feff0050007200610077006e>
+/Producer <feff0050007200610077006e>
+>>
+endobj
+2 0 obj
+<< /Pages 3 0 R
+/Type /Catalog
+>>
+endobj
+3 0 obj
+<< /Count 1
+/Kids [5 0 R]
+/Type /Pages
+>>
+endobj
+4 0 obj
+<< /Length 7431
+>>
+stream
+q
+
+BT
+36.0 751.446 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca4555522053746174656d656e74> Tj
+ET
+
+
+BT
+36.0 744.252 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca47656e657261746564206f6e20746865204175672031392c2032303234> Tj
+ET
+
+
+BT
+36.0 729.864 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca417765736f6d652042616e6b20575757> Tj
+ET
+
+
+BT
+36.0 693.894 Td
+/F1.0 6 Tf
+<435553544f4d4552204e414d4520504949> Tj
+ET
+
+
+BT
+36.0 672.312 Td
+/F1.0 6 Tf
+<437573746f6d657220537472656574204164647265737320504949> Tj
+ET
+
+
+BT
+36.0 657.924 Td
+/F1.0 6 Tf
+<3735303038> Tj
+ET
+
+
+BT
+36.0 643.536 Td
+/F1.0 6 Tf
+<5061726973> Tj
+ET
+
+
+BT
+36.0 636.342 Td
+/F1.0 6 Tf
+<5061726973> Tj
+ET
+
+
+BT
+36.0 621.954 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca4942414e202020202020205757573030303030303030303030303030303031> Tj
+ET
+
+
+BT
+36.0 614.76 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca4249432020202020202020415745534f4d3939> Tj
+ET
+
+
+BT
+36.0 564.402 Td
+/F1.0 6 Tf
+<42616c616e63652073756d6d617279> Tj
+ET
+
+
+BT
+36.0 535.626 Td
+/F1.0 6 Tf
+<ca50726f6475637420202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020204f70656e696e672062616c616e63652020202020204d6f6e6579206f75742020202020202020202020204d6f6e657920696e2020202020202020202020202020202020202020436c6f73696e67> Tj
+ET
+
+
+BT
+36.0 528.432 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaca62616c616e6365> Tj
+ET
+
+
+BT
+36.0 506.85 Td
+/F1.0 6 Tf
+<ca4163636f756e74202843757272656e74204163636f756e7429202020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<302e3031202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<32302e303020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<31392e39392020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<302e3030> Tj
+ET
+
+
+BT
+36.0 492.462 Td
+/F1.0 6 Tf
+<ca546f74616c20202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<32302e3030202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<32302e303020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<31392e39392020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<302e3030> Tj
+ET
+
+
+BT
+36.0 478.074 Td
+/F1.0 6 Tf
+<546865726520617265206d616e7920766172696174696f6e73206f66207061737361676573206f66204c6f72656d20497073756d20617661696c61626c652e> Tj
+ET
+
+
+BT
+36.0 434.91 Td
+/F1.0 6 Tf
+<4163636f756e74207472616e73616374696f6e732066726f6d204d61792033302c203230323420746f204a756e652033302c2032303234> Tj
+ET
+
+
+BT
+36.0 413.328 Td
+/F1.0 6 Tf
+<ca4461746520202020202020202020202020202020204465736372697074696f6e202020202020202020202020202020202020202020202020202020202020202020202020202020202020204d6f6e6579206f75742020202020202020202020204d6f6e657920696e202020202020202020202020202020202020202042616c616e6365> Tj
+ET
+
+
+BT
+36.0 391.746 Td
+/F1.0 6 Tf
+<ca4a756e20392c203230323420202020202020202020546f702d5570206279202a38383838202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<31392e39392020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<32302e3030> Tj
+ET
+
+
+BT
+36.0 384.552 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacaca46726f6d3a202a38383838> Tj
+ET
+
+
+BT
+36.0 370.164 Td
+/F1.0 6 Tf
+<ca4a756e2031342c203230323420202020202020202052657374617572616e7420417765736f6d652c2050617269732020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<392e3939202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<31302e3031> Tj
+ET
+
+
+BT
+36.0 362.97 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacaca436172643a203838383838382a2a2a2a2a2a383838> Tj
+ET
+
+
+BT
+36.0 348.582 Td
+/F1.0 6 Tf
+<ca4a756e2032332c20323032342020202020202020204361736820617420505347207374616469756d2020202020202020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<31302e3031202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020> Tj
+/F1.1 6 Tf
+<21> Tj
+/F1.0 6 Tf
+<302e3030> Tj
+ET
+
+
+BT
+36.0 341.388 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacaca546f3a20505347207374616469756d2c205061726973> Tj
+ET
+
+
+BT
+36.0 334.194 Td
+/F1.0 6 Tf
+<cacacacacacacacacacacacacacacacacacacacacaca436172643a203838383838382a2a2a2a2a2a383838> Tj
+ET
+
+
+BT
+36.0 226.284 Td
+/F1.0 6 Tf
+<cacacacacacacacaca49742069732061206c6f6e672065737461626c6973686564206661637420746861742061207265616465722077696c6c206265206469737472616374656420627920746865207265616461626c6520636f6e74656e74206f6620612070616765207768656e206c6f6f6b696e6720617420697473206c61796f75742e2054686520706f696e74206f66> Tj
+ET
+
+
+BT
+36.0 219.09 Td
+/F1.0 6 Tf
+<7573696e67204c6f72656d20497073756d206973> Tj
+ET
+
+
+BT
+36.0 211.896 Td
+/F1.0 6 Tf
+<cacacacacacacacaca74686174206974206861732061206d6f72652d6f722d6c657373206e6f726d616c20646973747269627574696f6e206f66206c6574746572732c206173206f70706f73656420746f207573696e672027436f6e74656e7420686572652c20636f6e74656e742068657265272c206d616b696e67206974206c6f6f6b206c696b65207265616461626c65> Tj
+ET
+
+
+BT
+36.0 204.702 Td
+/F1.0 6 Tf
+<456e676c6973682e204d616e79206465736b746f70> Tj
+ET
+
+
+BT
+36.0 197.508 Td
+/F1.0 6 Tf
+<cacacacacacacacaca7075626c697368696e67207061636b6167657320616e6420776562207061676520656469746f7273206e6f7720757365204c6f72656d20497073756d2061732074686569722064656661756c74206d6f64656c20746578742c20616e6420612073656172636820666f7220276c6f72656d20697073756d272077696c6c20756e636f766572206d616e79> Tj
+ET
+
+
+BT
+36.0 190.314 Td
+/F1.0 6 Tf
+<776562207369746573207374696c6c20696e> Tj
+ET
+
+
+BT
+36.0 183.12 Td
+/F1.0 6 Tf
+<cacacacacacacacaca746865697220696e66616e63792e20566172696f75732076657273696f6e7320686176652065766f6c766564206f766572207468652079656172732c20736f6d6574696d6573206279206163636964656e742c20736f6d6574696d6573206f6e20707572706f73652028696e6a65637465642068756d6f757220616e6420746865206c696b65292e> Tj
+ET
+
+
+BT
+36.0 168.732 Td
+/F1.0 6 Tf
+<a9203230323420417765736f6d652042616e6b2057575720202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020202020506167652031206f662031> Tj
+ET
+
+Q
+
+endstream
+endobj
+5 0 obj
+<< /ArtBox [0 0 612 792]
+/BleedBox [0 0 612 792]
+/Contents 4 0 R
+/CropBox [0 0 612 792]
+/MediaBox [0 0 612 792]
+/Parent 3 0 R
+/Resources << /Font << /F1.0 6 0 R
+/F1.1 7 0 R
+>>
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+>>
+/TrimBox [0 0 612 792]
+/Type /Page
+>>
+endobj
+6 0 obj
+<< /BaseFont /06d787+DejaVuSansMonoPowerline
+/FirstChar 32
+/FontDescriptor 9 0 R
+/LastChar 202
+/Subtype /TrueType
+/ToUnicode 10 0 R
+/Type /Font
+/Widths 11 0 R
+>>
+endobj
+7 0 obj
+<< /BaseFont /44b6cc+DejaVuSansMonoPowerline
+/FirstChar 32
+/FontDescriptor 13 0 R
+/LastChar 33
+/Subtype /TrueType
+/ToUnicode 14 0 R
+/Type /Font
+/Widths 15 0 R
+>>
+endobj
+8 0 obj
+<< /Length 21820
+/Length1 21820
+>>
+stream
+     €  POS/2i÷  X   Vcmap@äŞ7  ´  cvt é—    0fpgm[kß  È   ¬glyfo‰øÂ  D  $øhead	   Ü   6hhea@0     $hmtx9+G  °  loca¨  À   „maxp¶ß  8    nameÊø  3<  !ZposttW  T˜   ¤prep:ÇÀ  t      ^¸¼B=C_<õŸ     ÕB´~    ÕB´~  şHÑ              mş  Ñ    Ñ                A    A :        ™   W
+     Ñ   3™  3™  × f  	                PfEd @   Êşšmã          Ñ hÑ  ÑÑªÑ\Ñ ¦Ñ“ÑdÑéÑ …Ñ öÑ ˜Ñ ‰Ñ fÑ Ñ ‹Ñ ƒÑ ÑéÑ %Ñ ¦Ñ ‹Ñ ‰Ñ ÅÑ éÑ fÑ ÉÑ mÑ ×Ñ VÑ ‹Ñ uÑ ÅÑ Ñ ‹Ñ /Ñ “Ñ 9Ñ  Ñ …Ñ ÁÑ ÃÑ {Ñ {Ñ ÃÑ {Ñ ÃÑ ²Ñ ºÑ ìÑ  Ñ mÑ ÃÑ ‰Ñ ¾ÑjÑ ÕÑ ƒÑ ÃÑ dÑ  Ñ LÑ hÑ  Ñ                                                       	
+           !"#$%&         '()*+,-./0123456 789:;<=>                                               ?                                @                                                       · , °%Id°@QX ÈY!-,°%Id°@QX ÈY!-,  ° P°y ¸ÿÿPXY°°%°%#á ° P°y ¸ÿÿPXY°°%á-,KPX ¸EDY!-,°%E`D-,KSX°%°%EDY!!-,ED-,°%°%I°%°%I`° ch ŠŠ#:Še:-¹€²”]A –  €  ş  ş    ş  ş  š  ş ²ëGA% }  %  2 
+ – 	 ş    ş  %  ş    %  ş @Yşşşı}üşûşú2ù»ø}÷öŒ÷ş÷ÀöõYöŒö€õô&õYõ@ô&óò/óúò/ñşğşï2îí–ìëGìşì¸ÿÑ@ÿëGêédê–édèşçæçşæåşäkãşâ»áàáúàß–ŞşİşÜÛÜşÛÚ–ÙØÙşØØ×}Ö:ÕÕ:ÔşÓÒ
+ÓşÒ
+ÑşĞşÏŠÏÎÍşÌ–Ë‹%ËşÊşÉ}ÈşÇşÆşÅšÄşÃşÂşÁşÀÀ¿¾½»¾ş½¼]½»½€¼»%¼]¼@»%ºş¹–¸A·ş¶A¶úµš´ş³d²d±°¯ş®ş@ı­ş¬ş«ªş©¨©2¨§¦§(¦¥¤-¥}¤-£ş¢ş¡ş Ÿ dŸŸ
+œş›š›şš™˜.™ş˜.—A—––•»–ş•”]•»•€”%”]”@“ş’ş‘%‘»%‹%AŒ‹%Œd‹Š‹%Š‰şˆş‡ş†…†ş…„şƒş‚B‚Sş€x~}ş~}}|ş{zşwşvşutuu¸ @ÚttÀss@rşqşpşonSo–nm(nSm(lşk2jşi2húg»fşeşdşcbcşb baş`ş_ş^Z^]d\È[Z[ZYşXWşVşUU2TşSşRşQ}PşONşM-MşL»K(JIJ7ICIHEHşGCGdFEF»EDCD7CBCC¸@@	BABB¸ @	A@AA¸À@	@?@@¸€@	?	??¸@@d>ş=-=ú<ş;(:ş9B9d818K7ş6-6ş5K404K303ş2B2ş1-10/-/.	.»-,--¸€@	,,,¸@@–+*%+ş*	*%):)ş(ş'ş&%B%E$#ş""ş! -!} -KBşşş şşşBF-B- Bş-B¸ @	¸À@	
+¸€@		
+¸@´	¸ @7ş
+	
+ş	ş-ş:ú-: - ¸d…+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  ¸ Ë ¸ Ë ª‘ ¸ f   ¸ ‡      ¸ Ã Ë  Ë ¸ ¸Ë‰º Ë ¦ ü Ë ƒ ò
+Ç7 ƒ ¾   X! Ë  œ   ç u¼ Ó É Û uç9º ËÓ !ß ¸ ‰     ¾ ‰ Ã¾ {¾Xm ¤®   { ¸o { ¸R  ÍÑ   Í ‡ ‡ “ ¤ o Í Ë ¸ ƒ‘ İ ´ ‹ ô ˜é Z ´ º Å! ş    Õ ö ª=f ‹ Å  š šƒ Õ s 
+ ş áÕ+ ¤ ´ œ   b œÕ˜ ‡ÕÕğ ¤   ¸#Ó ¸ Ë ¦¼1N Ó
+ { T\qÛ…#wé  ` j ÏÕ # fy```{   {w`ª ébø {! Å œ {   ´RNNÑ f œ œ f œ  f œ  Íú ƒ ‘şHF?  {L ˜ ¢   ' o   o5 j o { ª ª -–{ ö ª3= œf‹ ö Í oD 7 f î …´  } sÕ      & & > j – ä.òvÖbúTvŞ2x²àZ†¼Ø8†Æ fä		L	†
+
+ˆ
+Ğ\°ìPˆ¼øv¢(`œæ.¤Ş\xî||  hş–h¤   ¼    ¶ƒ /ÄÔì1 ÔìÔì0!%!!h üsüåş–øòr)    ª¾Õ  · ˆ Ôì1 ôÄ0#¾®ÕıÕ+    ªşòu  @œ ›  
+Ôì2ì991 üì0#&547u…ƒƒ… —””—äş;æåş:æîÃàßÄì \şò'  @œ › Ôüì2991 üì03#654\ —””— …ƒƒìş<ßáş<ìèÆãäÆ   ¦J+ğ  N@, 	
+–
+	 	Ô<ì2Ü<ì2991 ôÔ<ì2Äì2990%#'-73%+şšf9ş°sş°9fşš9PsPßÂÃbËş‡yËbÃÂcËyş‡Ë   “şáò/  @£ ¢ ÔìÔÌ1 üì03#öüÅšc/Ïş    dßmƒ  ¶   ÔÄ1 Ôì0!!d	ı÷ƒ¤ é  å1  ¶ ¢ Ôì1 /ì03#éüü1şÏ    …ÿãLğ   #
+@¥	——–™$! "!$üììÔìî1 äôìîÔî0@Ö/ /////////	/
+/? ?????????	?
+?O OOO
+O_ ___
+_Ÿ ŸŸŸŸŸŸŸŸŸ	Ÿ
+Ÿ¯ ¯¯¯¯¯¯¯¯¯	¯
+¯¿ ¿¿¿¿¿¿¿¿¿	¿
+¿F/ /////////	/
+/_ _________	_
+_¿ ¿¿¿¿¿¿¿¿¿	¿
+¿$]]4632#"&"32'2#"ãM68PO98K…‹‹‹‹ïõõïïôôî7PP78NLœşĞşÉşÊşĞ0670 şxşş‚şxˆ~ˆ    ö  FÕ 
+ &@——ˆ —	# #ÔìÄüì1 /ì2ôìÔì0%!5%3!!:ş®PÊ6üÈªuL¸JúÕª     ˜  #ğ  Q@) %%B§—– — 
+
+"$üÄüìÀÀ91 /ì2ôìôÌ0KSXí9í2Y"%!!56 7>54&#"5>32u®üu»5dF“€[ÈpgÇaÛYd8ÕªªªÅ.>z—O}BCÌ12é½`ÀtAæ   ‰ÿã7ğ ( G@) —
+‹	¦—‹ ¦—#–™©) &"	)üÄÄüìÔì91 ìäôìôìîöîî90#"&'532654&+532654&#"5>32“œşëõgÖgfÆb¦²²˜šš‹œ‘†Y¾hy½IÚ‰'Ç•Îë&$É54–‚™¦zms{((º  Ûµ{¤     f  oÕ   B@ B —ˆ	
+ $üüÔ<ì291 /äÔ<ì290KSXÉÉY"	!33##!5ßş)×!êÇÇÉı‡üëÍü3¤şœd¿   ÿã-Õ  =@"—‹—— ˆ™ª 
+" üÄüÄìî1 ääôìîöîşÄ90!!>32  #"&'532654&#"ÏôıÄ+W,èşã÷wÅN\ºa§µ»§QšFÕªş‘şîêìşğ  Í21°¢ ²%%  ‹  7Õ  5@%%B— ˆ" üìÄ991 /ôì0KSXííY"!#!‹¬ıêÓı5ÕVú+   ƒÿãNğ  # / C@% —'—-—–™'©0$*$	"!0üÄìüÄìîî991 ìäôìîî990"32654&%.54632#"$54632654&#"h‡“•…ˆ“•şÊ‘òĞÑò‘–ŸşşääşÿŸM€yz€{y€Å—ŠŠ™—Œ‰˜T!´²ÑÑ²´!!ÈŸÊäãÉ Ébx~~xz€     ÿãFğ  $ ;@" —«‹—"—–"™%"	&%üäìüìì1 äôìîöîõî902654&#"532#"543  !"&T““†ˆ‡á?MÀÅ/ªnØíóŞòşİşëI”–º¤¤º±­®°ı‰º%'!dk
+ôñ	şŠşoş‡şs  é  å'   @¢ ¬¢ Ô<ì21 /ìôì03#3#éüüüü'şÑş9şÏ     %  ¬Õ  
+ ˜@A % %%%	%
+%
+%
+
+ % 
+B —°ˆ		 	/
+Üì91 /<äüì90KSXííííííííY"²]@
+    	†‰] ]!3#!#hÕªş±õÉÑnıõlÑ#ı®ú+…ş{   ¦  qÕ     =@# —
+	—ˆ—
+± 21	 0!üì2üìÔì9991 /ììôìî9032654&#32654&#%!2)qï°–¨ïë’ƒ”şJºåøƒƒ“§şöşùşFÉıİ{’‰fş>p}qd¦Æµ‰Ï ËÏ  ‹ÿã1ğ  .@³ ²—³²—	–™2 10üì2ì1 äôìôìîöî0%#   !2.#"32671M¢[şáşÃ?[¢MJªVÅÄÄÅX©I5))–pn™))Ï=@şĞşÍşÎşĞ@=    ‰  RÕ   (@—	ˆ — 	210üìüì99991 /ìôì0% 6&!#   )´ ÿÊÉÿ `dVDş¼şªşÑ¦ûHKûûw/ş”ş€ş‚ş•Õ   Å  NÕ  )@—— ˆ—±
+	1 3üì2üÄÄ1 /ììôìî0!!!!!!ÅvıTır¿üwÕªşFªıãª     é  XÕ 	 $@—— ˆ±1 4
+üì2üÄ1 /ìôìî0!!!!#éoı\eı›ËÕªşHªı7    fÿãPğ  <@! ——³²—	–™ 625üìüÄüÄ1 äôìôìşÔî990%#   !2.#"3267#5!PQËvşäşÄ@^¬PQª_ÅÅ¿ÆCe)Ùš{KM—on™56ÏMIşÏşÎşÉşÕ!‘¦    É  Õ  %@
+— ˆ—7 7	Ôì2üì21 /ì2ôì20!!!!5!!É=şÇ9üÃ9şÇÕªûªª     mÿã¼Õ  ,@ ²——
+ˆ™	 5üÔüÄ1 äôìîöÎ990753265!5!#"&m[ÂhqşƒGÓ÷`¾=ìQQ•ËDªüşæê,     ×  sÕ  @— ˆ1 4üìì1 /äì03!!×ËÑüdÕúÕª   V  yÕ  …@,
+	B
+  ´	
+/
+ 0üìüì91 /<ì2Ä90KSXÉÉÉÉY"²
+ ]@$
+		&)&)	6968	
+]]!	!###V»şö™şõºÕıøú+'üíúÙ  ‹  FÕ 	 m@B ´1 0
+üìüì991 /<ì2990KSXÉÉY"²]@&)&8Wdjuz
+&)FIWgh] ]!3!#‹ øÃÿ şÃÕû3Íú+Íû3  uÿã\ğ   #@	——–™ 2625üìüì1 äôìî0#"32#"32‰‡š™‡‡™š‡Ó÷ııö÷üı÷éIşæş·ş¸şæIşzş€~ˆ‡€ş€    Å  uÕ   +@— —	ˆ
+ 28 	3üì2üì91 /ôìÔì032654&#%!2+#êŒœşL´úşÿûêÊ/ıÏ”……“¦ãÛİâı¨       ÑÕ   j@8	
+%%B —	—ˆ	
+ 
+21
+0üì2üÄì99991 /<ôìÔì9990KSXíí9Y"#.+#!232654&#øNnRËÙ²M{cÁË ö¡ıĞİ‘—Áo¦şhy¡]ı‰ÕŞÒ”»Yıî‚†‰  ‹ÿãJğ ' „@=%	
+%B
+³§—³ §—%–™(
+ &919"0(üìÄüìä99991 äôìôìîöî90KSXí9í9Y"²]@
+ ] ].#"#"&'532654&/.54$32ô\¹^¦m•jÒÀşøüiÔksÍh™ªu‘lĞ¼ßV¾¢Í;<…qch#1ÒµÕà--×ID‰{pv /¾ Èñ'  /  ¢Õ  @— ˆ: :Ôìüì1 /ôì20!!#!/sş-Ëş+ÕªúÕ+     “ÿã=Õ  )@ 	—™ˆ1 0üìüì1 ä2ôì9033267>53#"&'.“Ë yVWx!Ê9FBªjiªCE:=˜üm];<<;\löühåÁ?;::;>Å     9  ˜Õ  L@)% %  % %B ´ /0üì91 /ì290KSXííííY"%3#3h_ÑşKõşKÑª+ú+Õ      ÑÕ  á@D	
+	
+	
+
+
+%%% % B
+ ´
+	 /Ì91 /<ü<Ä90KSXííííÉÉÉÉY"²	]@^
+//+
+??8
+ZZ&*%*(+	%&5:5:;:	46T TZXWV[[RW	X]ghyvy	v#] ]333##ÅªÓ¬Åß¿ËÊ¿ÕûD"üÜ¾ú+wü‰  …ÿã#{  ) n@*
+   ¶Œ!‹ ¿Œ$¾™
+D >*ôìÄüì22991 /Ääôüôìîî99990@00 0!0"     
+ ¢    ]#"326757#5#"&546;5.#"5>32¾=¡£zl˜®¹¹;³€«Ìûó÷†“^À[f»X‹Å=& 3qpepÓº)Lı¦d_Á¢»Â†y64¸''RR2“     ÁÿãX   0@	Œ	Œ™¾› GFôì22üì1 /ìäôìî9904&#"326>32#"&'#3–ˆ…†ŠŠ†…ˆıã,›fÊèéËd™.¸¸/ÖÚÛÕÔÜÚxRXşÉşïşëşÅWS   Ãÿã%{  /@‹À ‹ÀŒŒ	¾™ FôÄ2ì1 äôìşôîõî0%#   !2.#"3267%JRşüşÛ%QšNI“]­º»¬`˜A9++88*,ÁA:àĞÏá;>   {ÿã   0@ ŒŒ™¾› GHôìüì221 /ìäôìî9903#5#"3232654&#"Z¸¸.™dËéêÊešşˆ……‹‹……ˆÑCùìSW;7WşÖÚÜÔÕÛÚ   {ÿãX{   E@& 
+‹	¶ŒÁŒ¾™	 IHôìüìÄ991 äôìäîîôî990!3267#   32.#"Xüã¿®XÀmiÃ[şûşÚ ğÖ÷¸‘ˆ…¬^Z·È89·++9@şŞÅ¢©°œ  Ã  '  4@¶Œ ›Â
+ 	Ô<Äü<Ä2991 /ä2üìî2990#"!!#!5!5463'ÑcMş¸şÕ+©³™Qgcü/ÑN¸®     {şH{  ) H@''	‹	ŒŒŒ$¾Ã(Â*' G!H*ôÄìüì221 ääÄôìîîÕî999904&#"326#"&'5326=#"3253Z‡‡ˆ‡¸îçL¦Sb C•ˆ,˜mÄêêÄl–/¸9Ï××ÏÏÙÚşİüşü¶.,¢°}^\::VZ‘     Ã    ,@	 Œ¾›
+ J	Fôì2üì1 /<ìôì990#4&#"#3>32¹jq‹¸¸1¨s«©¶ıJ¶—·«ı‡ı¤`cá   ²  D 	  .@¶ Ä
+› Â¶LL K
+Ô<äìü<ì1 /ì2äüìî0!!!5!!3# ×münmşá¸¸`ü/BCé   ºşV   8@ 
+Œ¶Ä›ÂÃ	 Ô<ì2ÄÄ991 ääüìîî990!5!+53263#XşÃõ³¥şêZZ¸¸åûŒÃÓœ}¥é     ì  ²  Å@:		BÂ ›
+	D Eôìì291 /<ìä90KSXííííííY"²]@R546Ffuv	('(;;797JIYYkiiiyxyy] ]33	##ì¾ãàşGşáşb‰¾ü{ÑşZıFBş?     
+  &@	 
+¶Å¶ L	ÔìüÌ991 /ìüì990;#"&5!5![Y×é¥µşÙß–|~œÔÂù  m  o{ " £@'	 Œ ¾Â MNMNME#ôK°TK°T[X¹ ÿÀ8Yü<üìüì91 /<<äô<ì299990@G000000	0
+0?????????€€€€€€€	€
+€#]>32#4&#"#4&#"#3>32¤"iJ‡o¨5FP;¨9JI9§§!c?LeîHEÑşßıwís{åığp{åı``<?F   Ã  {  ,@	 Œ¾Â
+ J	Fôì2üì1 /<äôì990#4&#"#3>32¹jq‹¸¸1¨s«©¶ıJ¶—·«ı‡`¨`cá    ‰ÿãH{   #@Œ Œ¾™	D>ôìüì1 äôìî0"32654&'2#"hŒŒé÷öêéöößÚÖÕÛÛÕÖÚœşÒşâşáşÓ-.   ¾şVT{   3@ ŒŒ¾™ÃÂG Fôì22üì1 äääôìî990%#3>32#"&4&#"326w¹¹.™dËçèÊf™ğ‡…†ŠŠ†…‡ıÉ
+SWşÆşêşïşÉWõÖÚÛÕÔÜÚ    j  ƒ{  O@ —¾	Â
+ ÔÄì21 /äôìÔÌ990@%     0 030@ @C@P PPP].#"#3>32ƒ;zI¬¶¹¹.¿ƒDv6y.*ØÌıÓ`Ûw"$     Õÿã{ ' u@@	
+B
+ ‹À‹ÀŒŒ%¾™(
+ OI"E(ôÄìüìä99991 äôìşõîõî990KSXí9í9Y".#"#"&'532654/.54632ÍO S}{\·J‰ìÒS¶jg¼Tz†õEŸ’ÚÊZ¦9´..QSKJ#œ}¦»##¾55cY€1“¡¯!    ƒ    1@¶ Â¶
+	 Ô<Äü<Ä2991 /ìô<Äì2990!!;#"&5!5!f¢ş^^uÏáÏªşÕ+şÂı |b“¦Ë`>  Ãÿã^  ,@	 Œ™
+Â	J Fôìüì21 /ä2ôì990332653#5#"&Ã¸kp‚Š¹¹1©q¬¨¨¶ıJ—·«yû¢¨adá     d  m`  e@)   B ÂI Eôì91 /ä290KSXííííY"²' ]@ %]]3	3#d¿EF¿şrí`üT¬û      Ñ` @E
+	
+
+
+	  B
+ Â
+	 /Ì91 /<ô<Ä90KSXííííÉÉÉÉY"²
+ ]@Œ	 	
+& &)&))#,96993<EI	FJVX	WYfifij	evzx|	r-
+
+
+++>><
+H
+Y
+jih
+{yz|
+
+]]333##¶Ã ¢Ã¶şú°³²°`üwBı¾‰û fıš     L  …`  ©@H  
+	
+ 
+
+	B
+ Â
+ IEôÄüÄ91 /<ä290KSXííííííííY"²
+ ]@	fivy
+
+:4
+ZV
+]]	#	#	3	^şo¸Õş¸ş¹Õ¸şoÌ)'`ıèı¸Áş?Hşk•     hşV`   @E
+	   B 	ŒÃÂ
+ IEôìÄ91 ä2ôì9990KSXííííí9íY"²8]@v&&8IIY
+] ]+532673	3Z.Gc".Š\”mQ\GşOÃLGÃhu¿şø:NNš^ÄNü”l       }ÑN  1 I D@'Ú
+ÚÜ&Ô>Ú ÚÙÔ>Ó2ÑJ\ ^,8 8YD/æşÅşå2î1 ôìüôìÔìşıîÖî0.#"3267#"&54632'"3267>54&'.'2#"&'.5467>`:o:u‡Œ‚8g24r=´ÏĞ³=rÄjµKKMMKLµijµLLKLKKµkÚZZ\[[[Ú~}Ú[[[\ZZÚ/l•€„hÈ¬­Ê¡JKK¸jh·KLLLLLµij¸KKJgZZ[Ü~}Ú[[[[[[Ú}~Ü[ZZ             _          _        }                Ÿ        ½        É        ç        ø      	“       4
+¨  	   ¾
+Ü  	  <š  	  Ö  	  <Ş  	  <  	  V  	  "n  	  :  	 &Ê  	  hğCopyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
+DejaVu changes are in public domain
+DejaVu Sans Mono for PowerlineBookDejaVu Sans Mono for PowerlineDejaVu Sans Mono for PowerlineVersion 2.3706d787+DejaVuSansMonoPowerlineDejaVu fonts teamhttp://dejavu.sourceforge.netFonts are (c) Bitstream (see below). DejaVu changes are in public domain.
+
+Bitstream Vera Fonts Copyright
+------------------------------
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated documentation files (the "Font Software"), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
+
+The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words "Bitstream" or the word "Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the "Bitstream Vera" names.
+
+The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. 
+http://dejavu.sourceforge.net/wiki/index.php/License C o p y r i g h t   ( c )   2 0 0 3   b y   B i t s t r e a m ,   I n c .   A l l   R i g h t s   R e s e r v e d . 
+ D e j a V u   c h a n g e s   a r e   i n   p u b l i c   d o m a i n 
+ D e j a V u   S a n s   M o n o   f o r   P o w e r l i n e B o o k D e j a V u   S a n s   M o n o   f o r   P o w e r l i n e D e j a V u   S a n s   M o n o   f o r   P o w e r l i n e V e r s i o n   2 . 3 7 D e j a V u   f o n t s   t e a m h t t p : / / d e j a v u . s o u r c e f o r g e . n e t F o n t s   a r e   ( c )   B i t s t r e a m   ( s e e   b e l o w ) .   D e j a V u   c h a n g e s   a r e   i n   p u b l i c   d o m a i n . 
+ 
+ B i t s t r e a m   V e r a   F o n t s   C o p y r i g h t 
+ - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+ 
+ C o p y r i g h t   ( c )   2 0 0 3   b y   B i t s t r e a m ,   I n c .   A l l   R i g h t s   R e s e r v e d .   B i t s t r e a m   V e r a   i s   a   t r a d e m a r k   o f   B i t s t r e a m ,   I n c . 
+ 
+ P e r m i s s i o n   i s   h e r e b y   g r a n t e d ,   f r e e   o f   c h a r g e ,   t o   a n y   p e r s o n   o b t a i n i n g   a   c o p y   o f   t h e   f o n t s   a c c o m p a n y i n g   t h i s   l i c e n s e   ( " F o n t s " )   a n d   a s s o c i a t e d   d o c u m e n t a t i o n   f i l e s   ( t h e   " F o n t   S o f t w a r e " ) ,   t o   r e p r o d u c e   a n d   d i s t r i b u t e   t h e   F o n t   S o f t w a r e ,   i n c l u d i n g   w i t h o u t   l i m i t a t i o n   t h e   r i g h t s   t o   u s e ,   c o p y ,   m e r g e ,   p u b l i s h ,   d i s t r i b u t e ,   a n d / o r   s e l l   c o p i e s   o f   t h e   F o n t   S o f t w a r e ,   a n d   t o   p e r m i t   p e r s o n s   t o   w h o m   t h e   F o n t   S o f t w a r e   i s   f u r n i s h e d   t o   d o   s o ,   s u b j e c t   t o   t h e   f o l l o w i n g   c o n d i t i o n s : 
+ 
+ T h e   a b o v e   c o p y r i g h t   a n d   t r a d e m a r k   n o t i c e s   a n d   t h i s   p e r m i s s i o n   n o t i c e   s h a l l   b e   i n c l u d e d   i n   a l l   c o p i e s   o f   o n e   o r   m o r e   o f   t h e   F o n t   S o f t w a r e   t y p e f a c e s . 
+ 
+ T h e   F o n t   S o f t w a r e   m a y   b e   m o d i f i e d ,   a l t e r e d ,   o r   a d d e d   t o ,   a n d   i n   p a r t i c u l a r   t h e   d e s i g n s   o f   g l y p h s   o r   c h a r a c t e r s   i n   t h e   F o n t s   m a y   b e   m o d i f i e d   a n d   a d d i t i o n a l   g l y p h s   o r     o r   c h a r a c t e r s   m a y   b e   a d d e d   t o   t h e   F o n t s ,   o n l y   i f   t h e   f o n t s   a r e   r e n a m e d   t o   n a m e s   n o t   c o n t a i n i n g   e i t h e r   t h e   w o r d s   " B i t s t r e a m "   o r   t h e   w o r d   " V e r a " . 
+ 
+ T h i s   L i c e n s e   b e c o m e s   n u l l   a n d   v o i d   t o   t h e   e x t e n t   a p p l i c a b l e   t o   F o n t s   o r   F o n t   S o f t w a r e   t h a t   h a s   b e e n   m o d i f i e d   a n d   i s   d i s t r i b u t e d   u n d e r   t h e   " B i t s t r e a m   V e r a "   n a m e s . 
+ 
+ T h e   F o n t   S o f t w a r e   m a y   b e   s o l d   a s   p a r t   o f   a   l a r g e r   s o f t w a r e   p a c k a g e   b u t   n o   c o p y   o f   o n e   o r   m o r e   o f   t h e   F o n t   S o f t w a r e   t y p e f a c e s   m a y   b e   s o l d   b y   i t s e l f . 
+ 
+ T H E   F O N T   S O F T W A R E   I S   P R O V I D E D   " A S   I S " ,   W I T H O U T   W A R R A N T Y   O F   A N Y   K I N D ,   E X P R E S S   O R   I M P L I E D ,   I N C L U D I N G   B U T   N O T   L I M I T E D   T O   A N Y   W A R R A N T I E S   O F   M E R C H A N T A B I L I T Y ,   F I T N E S S   F O R   A   P A R T I C U L A R   P U R P O S E   A N D   N O N I N F R I N G E M E N T   O F   C O P Y R I G H T ,   P A T E N T ,   T R A D E M A R K ,   O R   O T H E R   R I G H T .   I N   N O   E V E N T   S H A L L   B I T S T R E A M   O R   T H E   G N O M E   F O U N D A T I O N   B E   L I A B L E   F O R   A N Y   C L A I M ,   D A M A G E S   O R   O T H E R   L I A B I L I T Y ,   I N C L U D I N G   A N Y   G E N E R A L ,   S P E C I A L ,   I N D I R E C T ,   I N C I D E N T A L ,   O R   C O N S E Q U E N T I A L   D A M A G E S ,   W H E T H E R   I N   A N   A C T I O N   O F   C O N T R A C T ,   T O R T   O R   O T H E R W I S E ,   A R I S I N G   F R O M ,   O U T   O F   T H E   U S E   O R   I N A B I L I T Y   T O   U S E   T H E   F O N T   S O F T W A R E   O R   F R O M   O T H E R   D E A L I N G S   I N   T H E   F O N T   S O F T W A R E . 
+ 
+ E x c e p t   a s   c o n t a i n e d   i n   t h i s   n o t i c e ,   t h e   n a m e s   o f   G n o m e ,   t h e   G n o m e   F o u n d a t i o n ,   a n d   B i t s t r e a m   I n c . ,   s h a l l   n o t   b e   u s e d   i n   a d v e r t i s i n g   o r   o t h e r w i s e   t o   p r o m o t e   t h e   s a l e ,   u s e   o r   o t h e r   d e a l i n g s   i n   t h i s   F o n t   S o f t w a r e   w i t h o u t   p r i o r   w r i t t e n   a u t h o r i z a t i o n   f r o m   t h e   G n o m e   F o u n d a t i o n   o r   B i t s t r e a m   I n c . ,   r e s p e c t i v e l y .   F o r   f u r t h e r   i n f o r m a t i o n ,   c o n t a c t :   f o n t s   a t   g n o m e   d o t   o r g .   
+ h t t p : / / d e j a v u . s o u r c e f o r g e . n e t / w i k i / i n d e x . p h p / L i c e n s e         ÿ~ Z                    A    
+                 $ % & ' ( ) * , - / 0 1 2 3 5 6 7 8 9 : D E F G H I J K L M N O P Q R S U V W X Y Z [ \ ‹ ¬
+endstream
+endobj
+9 0 obj
+<< /Ascent 759
+/CapHeight 759
+/Descent -240
+/Flags 5
+/FontBBox [-558 -374 717 1028]
+/FontFile2 8 0 R
+/FontName /06d787+DejaVuSansMonoPowerline
+/ItalicAngle 0
+/StemV 0
+/Type /FontDescriptor
+/XHeight 0
+>>
+endobj
+10 0 obj
+<< /Length 561
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+  /Registry (Adobe) def
+  /Ordering (UCS) def
+  /Supplement 0 def
+end def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<00><CA>
+endcodespacerange
+10 beginbfrange
+<27><2A><0027>
+<2C><2E><002c>
+<30><35><0030>
+<37><3A><0037>
+<41><47><0041>
+<49><4A><0049>
+<4C><50><004c>
+<52><57><0052>
+<61><70><0061>
+<72><79><0072>
+endbfrange
+3 beginbfchar
+<20><0020>
+<A9><00a9>
+<CA><00a0>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+11 0 obj
+[602 0 0 0 0 0 0 602 602 602 602 0 602 602 602 0 602 602 602 602 602 602 0 602 602 602 602 0 0 0 0 0 0 602 602 602 602 602 602 602 0 602 602 0 602 602 602 602 602 0 602 602 602 602 602 602 0 0 0 0 0 0 0 0 0 602 602 602 602 602 602 602 602 602 602 602 602 602 602 602 602 0 602 602 602 602 602 602 602 602 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 602 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 602]
+endobj
+12 0 obj
+<< /Length 12216
+/Length1 12216
+>>
+stream
+     €  POS/2iøoõ  X   Vcmap   ¼  cvt é—  
+˜  0fpgm[kß  Ğ   ¬glyfğâi"  Ğ  \headÅ7   Ü   6hhea×[     $hmtxs   °   loca & Ô  È   maxpu Â  8    nameô'  ,  !ZpostrËvÎ  /ˆ   -prep:ÇÀ  |      ^¸‡§w‚_<õŸ     ÕB´~    ÕB´~ %ş–hğ              mş  Ñ   ih                             ™   W      Ñ   3™  3™  × f  	               PfEd @   !şšmã          Ñ hÑ  Ñ %                                                                                                                                                                                                                                                                             · , °%Id°@QX ÈY!-,°%Id°@QX ÈY!-,  ° P°y ¸ÿÿPXY°°%°%#á ° P°y ¸ÿÿPXY°°%á-,KPX ¸EDY!-,°%E`D-,KSX°%°%EDY!!-,ED-,°%°%I°%°%I`° ch ŠŠ#:Še:-¹€²”]A –  €  ş  ş    ş  ş  š  ş ²ëGA% }  %  2 
+ – 	 ş    ş  %  ş    %  ş @Yşşşı}üşûşú2ù»ø}÷öŒ÷ş÷ÀöõYöŒö€õô&õYõ@ô&óò/óúò/ñşğşï2îí–ìëGìşì¸ÿÑ@ÿëGêédê–édèşçæçşæåşäkãşâ»áàáúàß–ŞşİşÜÛÜşÛÚ–ÙØÙşØØ×}Ö:ÕÕ:ÔşÓÒ
+ÓşÒ
+ÑşĞşÏŠÏÎÍşÌ–Ë‹%ËşÊşÉ}ÈşÇşÆşÅšÄşÃşÂşÁşÀÀ¿¾½»¾ş½¼]½»½€¼»%¼]¼@»%ºş¹–¸A·ş¶A¶úµš´ş³d²d±°¯ş®ş@ı­ş¬ş«ªş©¨©2¨§¦§(¦¥¤-¥}¤-£ş¢ş¡ş Ÿ dŸŸ
+œş›š›şš™˜.™ş˜.—A—––•»–ş•”]•»•€”%”]”@“ş’ş‘%‘»%‹%AŒ‹%Œd‹Š‹%Š‰şˆş‡ş†…†ş…„şƒş‚B‚Sş€x~}ş~}}|ş{zşwşvşutuu¸ @ÚttÀss@rşqşpşonSo–nm(nSm(lşk2jşi2húg»fşeşdşcbcşb baş`ş_ş^Z^]d\È[Z[ZYşXWşVşUU2TşSşRşQ}PşONşM-MşL»K(JIJ7ICIHEHşGCGdFEF»EDCD7CBCC¸@@	BABB¸ @	A@AA¸À@	@?@@¸€@	?	??¸@@d>ş=-=ú<ş;(:ş9B9d818K7ş6-6ş5K404K303ş2B2ş1-10/-/.	.»-,--¸€@	,,,¸@@–+*%+ş*	*%):)ş(ş'ş&%B%E$#ş""ş! -!} -KBşşş şşşBF-B- Bş-B¸ @	¸À@	
+¸€@		
+¸@´	¸ @7ş
+	
+ş	ş-ş:ú-: - ¸d…+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++  ¸ Ë ¸ Ë ª‘ ¸ f   ¸ ‡      ¸ Ã Ë  Ë ¸ ¸Ë‰º Ë ¦ ü Ë ƒ ò
+Ç7 ƒ ¾   X! Ë  œ   ç u¼ Ó É Û uç9º ËÓ !ß ¸ ‰     ¾ ‰ Ã¾ {¾Xm ¤®   { ¸o { ¸R  ÍÑ   Í ‡ ‡ “ ¤ o Í Ë ¸ ƒ‘ İ ´ ‹ ô ˜é Z ´ º Å! ş    Õ ö ª=f ‹ Å  š šƒ Õ s 
+ ş áÕ+ ¤ ´ œ   b œÕ˜ ‡ÕÕğ ¤   ¸#Ó ¸ Ë ¦¼1N Ó
+ { T\qÛ…#wé  ` j ÏÕ # fy```{   {w`ª ébø {! Å œ {   ´RNNÑ f œ œ f œ  f œ  Íú ƒ ‘şHF?  {L ˜ ¢   ' o   o5 j o { ª ª -–{ ö ª3= œf‹ ö Í oD 7 f î …´  } sÕ      & & ®  hş–h¤   ¼    ¶ƒ /ÄÔì1 ÔìÔì0!%!!h üsüåş–øòr)     %ÿã%ğ 3 p@< ç1&ç³ ²—(#³²
+—–#™43('1)-& -2'-4ÔÄÄ2ìÄ2Ä99999999991 äôìôìÆ2îöîî2Õ<î20 32.#"!!!!3267#" #73&'&54767#7Ó0ßT“JBŸN’®á1şFi1şÓ®“OCH”Uâşí,®1u¦1´!(*Ï=DĞÌl-.&nËÑC>Ï*( n-/l           _          _        }                Ÿ        ½        É        ç        ø      	“       4
+¨  	   ¾
+Ü  	  <š  	  Ö  	  <Ş  	  <  	  V  	  "n  	  :  	 &Ê  	  hğCopyright (c) 2003 by Bitstream, Inc. All Rights Reserved.
+DejaVu changes are in public domain
+DejaVu Sans Mono for PowerlineBookDejaVu Sans Mono for PowerlineDejaVu Sans Mono for PowerlineVersion 2.3744b6cc+DejaVuSansMonoPowerlineDejaVu fonts teamhttp://dejavu.sourceforge.netFonts are (c) Bitstream (see below). DejaVu changes are in public domain.
+
+Bitstream Vera Fonts Copyright
+------------------------------
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the fonts accompanying this license ("Fonts") and associated documentation files (the "Font Software"), to reproduce and distribute the Font Software, including without limitation the rights to use, copy, merge, publish, distribute, and/or sell copies of the Font Software, and to permit persons to whom the Font Software is furnished to do so, subject to the following conditions:
+
+The above copyright and trademark notices and this permission notice shall be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular the designs of glyphs or characters in the Fonts may be modified and additional glyphs or  or characters may be added to the Fonts, only if the fonts are renamed to names not containing either the words "Bitstream" or the word "Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font Software that has been modified and is distributed under the "Bitstream Vera" names.
+
+The Font Software may be sold as part of a larger software package but no copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome Foundation, and Bitstream Inc., shall not be used in advertising or otherwise to promote the sale, use or other dealings in this Font Software without prior written authorization from the Gnome Foundation or Bitstream Inc., respectively. For further information, contact: fonts at gnome dot org. 
+http://dejavu.sourceforge.net/wiki/index.php/License C o p y r i g h t   ( c )   2 0 0 3   b y   B i t s t r e a m ,   I n c .   A l l   R i g h t s   R e s e r v e d . 
+ D e j a V u   c h a n g e s   a r e   i n   p u b l i c   d o m a i n 
+ D e j a V u   S a n s   M o n o   f o r   P o w e r l i n e B o o k D e j a V u   S a n s   M o n o   f o r   P o w e r l i n e D e j a V u   S a n s   M o n o   f o r   P o w e r l i n e V e r s i o n   2 . 3 7 D e j a V u   f o n t s   t e a m h t t p : / / d e j a v u . s o u r c e f o r g e . n e t F o n t s   a r e   ( c )   B i t s t r e a m   ( s e e   b e l o w ) .   D e j a V u   c h a n g e s   a r e   i n   p u b l i c   d o m a i n . 
+ 
+ B i t s t r e a m   V e r a   F o n t s   C o p y r i g h t 
+ - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+ 
+ C o p y r i g h t   ( c )   2 0 0 3   b y   B i t s t r e a m ,   I n c .   A l l   R i g h t s   R e s e r v e d .   B i t s t r e a m   V e r a   i s   a   t r a d e m a r k   o f   B i t s t r e a m ,   I n c . 
+ 
+ P e r m i s s i o n   i s   h e r e b y   g r a n t e d ,   f r e e   o f   c h a r g e ,   t o   a n y   p e r s o n   o b t a i n i n g   a   c o p y   o f   t h e   f o n t s   a c c o m p a n y i n g   t h i s   l i c e n s e   ( " F o n t s " )   a n d   a s s o c i a t e d   d o c u m e n t a t i o n   f i l e s   ( t h e   " F o n t   S o f t w a r e " ) ,   t o   r e p r o d u c e   a n d   d i s t r i b u t e   t h e   F o n t   S o f t w a r e ,   i n c l u d i n g   w i t h o u t   l i m i t a t i o n   t h e   r i g h t s   t o   u s e ,   c o p y ,   m e r g e ,   p u b l i s h ,   d i s t r i b u t e ,   a n d / o r   s e l l   c o p i e s   o f   t h e   F o n t   S o f t w a r e ,   a n d   t o   p e r m i t   p e r s o n s   t o   w h o m   t h e   F o n t   S o f t w a r e   i s   f u r n i s h e d   t o   d o   s o ,   s u b j e c t   t o   t h e   f o l l o w i n g   c o n d i t i o n s : 
+ 
+ T h e   a b o v e   c o p y r i g h t   a n d   t r a d e m a r k   n o t i c e s   a n d   t h i s   p e r m i s s i o n   n o t i c e   s h a l l   b e   i n c l u d e d   i n   a l l   c o p i e s   o f   o n e   o r   m o r e   o f   t h e   F o n t   S o f t w a r e   t y p e f a c e s . 
+ 
+ T h e   F o n t   S o f t w a r e   m a y   b e   m o d i f i e d ,   a l t e r e d ,   o r   a d d e d   t o ,   a n d   i n   p a r t i c u l a r   t h e   d e s i g n s   o f   g l y p h s   o r   c h a r a c t e r s   i n   t h e   F o n t s   m a y   b e   m o d i f i e d   a n d   a d d i t i o n a l   g l y p h s   o r     o r   c h a r a c t e r s   m a y   b e   a d d e d   t o   t h e   F o n t s ,   o n l y   i f   t h e   f o n t s   a r e   r e n a m e d   t o   n a m e s   n o t   c o n t a i n i n g   e i t h e r   t h e   w o r d s   " B i t s t r e a m "   o r   t h e   w o r d   " V e r a " . 
+ 
+ T h i s   L i c e n s e   b e c o m e s   n u l l   a n d   v o i d   t o   t h e   e x t e n t   a p p l i c a b l e   t o   F o n t s   o r   F o n t   S o f t w a r e   t h a t   h a s   b e e n   m o d i f i e d   a n d   i s   d i s t r i b u t e d   u n d e r   t h e   " B i t s t r e a m   V e r a "   n a m e s . 
+ 
+ T h e   F o n t   S o f t w a r e   m a y   b e   s o l d   a s   p a r t   o f   a   l a r g e r   s o f t w a r e   p a c k a g e   b u t   n o   c o p y   o f   o n e   o r   m o r e   o f   t h e   F o n t   S o f t w a r e   t y p e f a c e s   m a y   b e   s o l d   b y   i t s e l f . 
+ 
+ T H E   F O N T   S O F T W A R E   I S   P R O V I D E D   " A S   I S " ,   W I T H O U T   W A R R A N T Y   O F   A N Y   K I N D ,   E X P R E S S   O R   I M P L I E D ,   I N C L U D I N G   B U T   N O T   L I M I T E D   T O   A N Y   W A R R A N T I E S   O F   M E R C H A N T A B I L I T Y ,   F I T N E S S   F O R   A   P A R T I C U L A R   P U R P O S E   A N D   N O N I N F R I N G E M E N T   O F   C O P Y R I G H T ,   P A T E N T ,   T R A D E M A R K ,   O R   O T H E R   R I G H T .   I N   N O   E V E N T   S H A L L   B I T S T R E A M   O R   T H E   G N O M E   F O U N D A T I O N   B E   L I A B L E   F O R   A N Y   C L A I M ,   D A M A G E S   O R   O T H E R   L I A B I L I T Y ,   I N C L U D I N G   A N Y   G E N E R A L ,   S P E C I A L ,   I N D I R E C T ,   I N C I D E N T A L ,   O R   C O N S E Q U E N T I A L   D A M A G E S ,   W H E T H E R   I N   A N   A C T I O N   O F   C O N T R A C T ,   T O R T   O R   O T H E R W I S E ,   A R I S I N G   F R O M ,   O U T   O F   T H E   U S E   O R   I N A B I L I T Y   T O   U S E   T H E   F O N T   S O F T W A R E   O R   F R O M   O T H E R   D E A L I N G S   I N   T H E   F O N T   S O F T W A R E . 
+ 
+ E x c e p t   a s   c o n t a i n e d   i n   t h i s   n o t i c e ,   t h e   n a m e s   o f   G n o m e ,   t h e   G n o m e   F o u n d a t i o n ,   a n d   B i t s t r e a m   I n c . ,   s h a l l   n o t   b e   u s e d   i n   a d v e r t i s i n g   o r   o t h e r w i s e   t o   p r o m o t e   t h e   s a l e ,   u s e   o r   o t h e r   d e a l i n g s   i n   t h i s   F o n t   S o f t w a r e   w i t h o u t   p r i o r   w r i t t e n   a u t h o r i z a t i o n   f r o m   t h e   G n o m e   F o u n d a t i o n   o r   B i t s t r e a m   I n c . ,   r e s p e c t i v e l y .   F o r   f u r t h e r   i n f o r m a t i o n ,   c o n t a c t :   f o n t s   a t   g n o m e   d o t   o r g .   
+ h t t p : / / d e j a v u . s o u r c e f o r g e . n e t / w i k i / i n d e x . p h p / L i c e n s e         ÿ~ Z                       Euro   
+endstream
+endobj
+13 0 obj
+<< /Ascent 759
+/CapHeight 759
+/Descent -240
+/Flags 5
+/FontBBox [-558 -374 717 1028]
+/FontFile2 12 0 R
+/FontName /44b6cc+DejaVuSansMonoPowerline
+/ItalicAngle 0
+/StemV 0
+/Type /FontDescriptor
+/XHeight 0
+>>
+endobj
+14 0 obj
+<< /Length 376
+>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+  /Registry (Adobe) def
+  /Ordering (UCS) def
+  /Supplement 0 def
+end def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<00><21>
+endcodespacerange
+1 beginbfrange
+<20><21>[<0020><20ac>]
+endbfrange
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+15 0 obj
+[602 602]
+endobj
+xref
+0 16
+0000000000 65535 f 
+0000000015 00000 n 
+0000000109 00000 n 
+0000000158 00000 n 
+0000000215 00000 n 
+0000007698 00000 n 
+0000007976 00000 n 
+0000008153 00000 n 
+0000008330 00000 n 
+0000030218 00000 n 
+0000030436 00000 n 
+0000031049 00000 n 
+0000031537 00000 n 
+0000043822 00000 n 
+0000044042 00000 n 
+0000044470 00000 n 
+trailer
+<< /Info 1 0 R
+/Root 2 0 R
+/Size 16
+>>
+startxref
+44496
+%%EOF

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -1,9 +1,11 @@
 empty_import:
+  raw_type: csv
   account: depository
   created_at: <%= 1.minute.ago %>
 
 completed_import:
   account: depository
+  raw_type: csv
   column_mappings:
     date: date
     name: name

--- a/test/fixtures/pdf_regexes.yml
+++ b/test/fixtures/pdf_regexes.yml
@@ -1,0 +1,7 @@
+awesome_bank_pdf_regex:
+  family: dylan_family
+  name: Awesome Bank Pdf Regex
+  transaction_line_regex_str: '(?<date>\w{3}\s\d\d?\,\s\d{4})\s+(?<name>.+?(?=\s{4}\s*))\s+\S(?<amount>(\d?\d?\d\,)*(\d?\d?\d\.\d\d))\s+\S(?<balance>(\d?\d?\d\,)*(\d?\d?\d\.\d\d))'
+  metadata_regex_str: '.*Account transactions from (?<start_date>\w+\s\d\d?\,\s\d{4}) to (?<end_date>\w+\s\d\d?\,\s\d{4}).*'
+  pdf_transaction_date_format: "%b %-d, %Y"
+  pdf_range_date_format: "%B %-d,%Y"

--- a/test/models/pdf_regex_test.rb
+++ b/test/models/pdf_regex_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PdfRegexTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/imports_test.rb
+++ b/test/system/imports_test.rb
@@ -150,6 +150,46 @@ class ImportsTest < ApplicationSystemTestCase
     assert_selector "h1", text: "Imports"
   end
 
+  test "can perform import by PDF upload" do
+    trigger_import_from_settings
+    verify_import_modal
+
+    within "#modal" do
+      click_link "New import from PDF"
+    end
+
+    # 1) Create import step
+    assert_selector "h1", text: "New import"
+
+    within "form" do
+      select "Checking Account", from: "import_account_id"
+      select "Awesome Bank Pdf Regex", from: "import_pdf_regex_id"
+    end
+
+    click_button "Next"
+
+    find(".raw-file-drop-box").drop File.join(file_fixture_path, "transactions.pdf")
+    assert_selector "div.pdf-preview", text: "transactions.pdf"
+
+    click_button "Next"
+
+    # 3) Configure step
+    assert_selector "h1", text: "Configure import"
+
+    click_button "Next"
+
+    # 4) Clean step
+    assert_selector "h1", text: "Clean import"
+
+    click_link "Next"
+
+    # 5) Confirm step
+    assert_selector "h1", text: "Confirm import"
+    assert_selector "#new_account_entry", count: 3
+    click_button "Import 3 transactions"
+    assert_selector "h1", text: "Imports"
+  end
+
   private
 
     def trigger_import_from_settings


### PR DESCRIPTION
Adds ability to parse pdf files from banks and credit cards

- Is behind a feature flag because its not clear that handling pdfs would be safe
- Also storing regexes from users into database is not that safe.
- Added a requirement: active record encryption to be set. Because of potencial PII in pdfs

Anyway, it looks like this:

<img width="992" alt="2" src="https://github.com/user-attachments/assets/2292d9a0-0936-4775-b78d-b19c260191eb">

<img width="982" alt="3" src="https://github.com/user-attachments/assets/c74cd665-d8b4-4f6d-9ff3-b26cb827bceb">

<img width="979" alt="4" src="https://github.com/user-attachments/assets/ae3cb3cd-210e-4358-a25b-557b2ad55f3e">

<img width="804" alt="5" src="https://github.com/user-attachments/assets/29412229-6e80-4e6a-a0f8-5f8a740b21ef">

<img width="764" alt="6" src="https://github.com/user-attachments/assets/a7269dd5-a8d4-4943-bda9-b45b434e1207">

<img width="699" alt="7" src="https://github.com/user-attachments/assets/194ae2d9-2fc1-4a53-87b1-5250fc34e851">

<img width="728" alt="8" src="https://github.com/user-attachments/assets/78f3964d-c6ec-40c1-88b5-ac545bd72b95">

<img width="834" alt="9" src="https://github.com/user-attachments/assets/0bba5552-ff67-4677-bb33-faa88e11c215">

<img width="868" alt="10" src="https://github.com/user-attachments/assets/25c23537-dbea-4c77-93f5-39c0fc29fdbf">

<img width="938" alt="11" src="https://github.com/user-attachments/assets/5244fe8f-eb63-40f5-876c-eefc45d2f6d7">
