### PR TITLE
Run PostgreSQL in a local docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: .setup
+
+COMPOSE_PROJECT_NAME ?= maybe
+LOCAL_DETACHED ?= true
+
+local: .setup
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		docker compose -f docker/docker-compose-local.yml up $(if $(filter true,$(LOCAL_DETACHED)),-d)
+
+stop_local:
+	COMPOSE_PROJECT_NAME=$(COMPOSE_PROJECT_NAME) \
+		docker compose -f docker/docker-compose-local.yml down
+
+.setup:
+	mkdir -p docker/tmp/postgres

--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ The instructions below are for developers to get started with contributing to th
 ### Requirements
 
 - Ruby 3.3.4
-- PostgreSQL >9.3 (ideally, latest stable version)
+- PostgreSQL >9.3 (ideally, latest stable version) or Docker to run PostgreSQL in a container
 
 After cloning the repo, the basic setup commands are:
 
 ```sh
 cd maybe
 cp .env.example .env
+# Make sure you have the local db running, either with PostgreSQL or in a Docker container with `make local`.
 bin/setup
 bin/dev
 

--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -1,0 +1,16 @@
+# https://docs.docker.com/compose/compose-file/
+
+services:
+  db:
+    image: postgres:16.3
+    volumes:
+      - maybe-pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: maybe_development
+
+volumes:
+  maybe-pgdata:


### PR DESCRIPTION
This PR adds minimal Docker setup to get PostgreSQL running inside a container.

The goal is to simplify the setup process, so anyone can do `make local`, `bin/setup`, `bin/dev` and get started with any code changes.