### PR TITLE
Revert "Do not show registation link when REQUIRE_INVITE_CODE=true (#…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -154,8 +154,4 @@ module ApplicationHelper
               .map { |_currency, money| format_money(money) }
               .join(separator)
   end
-
-  def invite_code_required?
-    ENV["REQUIRE_INVITE_CODE"] == "true"
-  end
 end

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -8,11 +8,9 @@
       </h2>
 
       <% if controller_name == "sessions" %>
-        <% unless invite_code_required? %>
-          <p class="mt-2 text-sm text-center text-gray-600">
-            <%= t(".or") %> <%= link_to t(".sign_up"), new_registration_path, class: "font-medium text-gray-600 hover:text-gray-400 transition" %>
-          </p>
-        <% end %>
+        <p class="mt-2 text-sm text-center text-gray-600">
+          <%= t(".or") %> <%= link_to t(".sign_up"), new_registration_path, class: "font-medium text-gray-600 hover:text-gray-400 transition" %>
+        </p>
       <% elsif controller_name == "registrations" %>
         <p class="mt-2 text-sm text-center text-gray-600">
           <%= t(".or") %> <%= link_to t(".sign_in"), new_session_path, class: "font-medium text-gray-600 hover:text-gray-400 transition" %>


### PR DESCRIPTION
Realized after merging the previous logic that we actually _do_ want to show the register link even if invites are enabled.

`REQUIRE_INVITE_CODE` is the sole determinant of whether someone can freely sign up or not.  We'll use #1152 to handle a more "official" way for self-hosters to turn signups off.