### PR TITLE
Omit trend if zero in sidebar

### DIFF
--- a/app/views/accounts/_account_list.html.erb
+++ b/app/views/accounts/_account_list.html.erb
@@ -39,8 +39,9 @@
         </div>
         <div class="flex flex-col ml-auto font-medium text-right">
           <p><%= format_money account.balance_money %></p>
-          <div class="flex items-center gap-1">
-            <%=
+          <% unless account_value_node.series.trend.direction.flat?%>
+            <div class="flex items-center gap-1">
+              <%=
               tag.div(
                 id: dom_id(account, :list_sparkline),
                 class: "h-3 w-8 ml-auto",
@@ -53,9 +54,10 @@
                 }
               )
             %>
-            <% styles = trend_styles(account_value_node.series.trend) %>
-            <span class="text-xs <%= styles[:text_class] %>"><%= sprintf("%+.2f", account_value_node.series.trend.percent) %>%</span>
-          </div>
+              <% styles = trend_styles(account_value_node.series.trend) %>
+              <span class="text-xs <%= styles[:text_class] %>"><%= sprintf("%+.2f", account_value_node.series.trend.percent) %>%</span>
+            </div>
+          <% end %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/accounts/_account_list.html.erb
+++ b/app/views/accounts/_account_list.html.erb
@@ -39,7 +39,7 @@
         </div>
         <div class="flex flex-col ml-auto font-medium text-right">
           <p><%= format_money account.balance_money %></p>
-          <% unless account_value_node.series.trend.direction.flat?%>
+          <% unless account_value_node.series.trend.direction.flat? %>
             <div class="flex items-center gap-1">
               <%=
               tag.div(
@@ -53,7 +53,7 @@
                   "time-series-chart-use-tooltip-value": false
                 }
               )
-            %>
+              %>
               <% styles = trend_styles(account_value_node.series.trend) %>
               <span class="text-xs <%= styles[:text_class] %>"><%= sprintf("%+.2f", account_value_node.series.trend.percent) %>%</span>
             </div>


### PR DESCRIPTION
Design fixes for `v0.2.0-alpha` release, removes trend if it's zero in sidebar to match official design spec:

![CleanShot 2024-09-13 at 11 15 07@2x](https://github.com/user-attachments/assets/fdf95922-a165-4a90-92e3-cb804ea19f41)
