### PR TITLE
Add basic self hosted onboarding

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -17,7 +17,11 @@ module Authentication
       if user = User.find_by(id: session[:user_id])
         Current.user = user
       else
-        redirect_to new_session_url
+        if self_hosted_first_login?
+          redirect_to new_registration_url
+        else
+          redirect_to new_session_url
+        end
       end
     end
 
@@ -35,5 +39,9 @@ module Authentication
 
     def set_last_login_at
       Current.user.update(last_login_at: DateTime.now)
+    end
+
+    def self_hosted_first_login?
+      Rails.application.config.app_mode.self_hosted? && User.count.zero?
     end
 end

--- a/app/controllers/concerns/invitable.rb
+++ b/app/controllers/concerns/invitable.rb
@@ -7,6 +7,10 @@ module Invitable
 
   private
     def invite_code_required?
-      ENV["REQUIRE_INVITE_CODE"] == "true"
+      self_hosted? ? Setting.require_invite_for_signup : ENV["REQUIRE_INVITE_CODE"] == "true"
+    end
+
+    def self_hosted?
+      Rails.application.config.app_mode.self_hosted?
     end
 end

--- a/app/controllers/concerns/self_hostable.rb
+++ b/app/controllers/concerns/self_hostable.rb
@@ -2,11 +2,15 @@ module SelfHostable
   extend ActiveSupport::Concern
 
   included do
-    helper_method :self_hosted?
+    helper_method :self_hosted?, :self_hosted_first_login?
   end
 
   private
     def self_hosted?
       Rails.configuration.app_mode.self_hosted?
+    end
+
+    def self_hosted_first_login?
+      self_hosted? && User.count.zero?
     end
 end

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -6,6 +6,7 @@ class Demo::Generator
   end
 
   def reset_and_clear_data!
+    reset_settings!
     clear_data!
     create_user!
 
@@ -14,6 +15,7 @@ class Demo::Generator
 
   def reset_data!
     Family.transaction do
+      reset_settings!
       clear_data!
       create_user!
 
@@ -52,10 +54,15 @@ class Demo::Generator
     end
 
     def clear_data!
+      InviteCode.destroy_all
       User.find_by_email("user@maybe.local")&.destroy
       ExchangeRate.destroy_all
       Security.destroy_all
       Security::Price.destroy_all
+    end
+
+    def reset_settings!
+      Setting.destroy_all
     end
 
     def create_user!

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -7,7 +7,7 @@
     <h2 class="font-bold text-xl"><%= t(".welcome_title") %></h2>
     <p class="text-gray-500 text-sm"><%= t(".welcome_body") %></p>
   </div>
-<% end%>
+<% end %>
 
 <%= styled_form_with model: @user, url: registration_path, class: "space-y-4" do |form| %>
   <%= auth_messages form %>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -1,6 +1,14 @@
 <%
   header_title t(".title")
 %>
+
+<% if self_hosted_first_login? %>
+  <div class="fixed inset-0 w-full h-fit bg-gray-25 p-5 border-b border-alpha-black-200 flex flex-col gap-3 items-center text-center mb-12">
+    <h2 class="font-bold text-xl"><%= t(".welcome_title") %></h2>
+    <p class="text-gray-500 text-sm"><%= t(".welcome_body") %></p>
+  </div>
+<% end%>
+
 <%= styled_form_with model: @user, url: registration_path, class: "space-y-4" do |form| %>
   <%= auth_messages form %>
   <%= form.email_field :email, autofocus: false, autocomplete: "email", required: "required", placeholder: "you@example.com", label: true %>

--- a/config/locales/views/registrations/en.yml
+++ b/config/locales/views/registrations/en.yml
@@ -14,5 +14,6 @@ en:
       success: You have signed up successfully.
     new:
       title: Create an account
+      welcome_body: To get started, you must sign up for a new account.  You will
+        then be able to configure additional settings within the app.
       welcome_title: Welcome to Self Hosted Maybe!
-      welcome_body: To get started, you must sign up for a new account.  You will then be able to configure additional settings within the app.

--- a/config/locales/views/registrations/en.yml
+++ b/config/locales/views/registrations/en.yml
@@ -14,3 +14,5 @@ en:
       success: You have signed up successfully.
     new:
       title: Create an account
+      welcome_title: Welcome to Self Hosted Maybe!
+      welcome_body: To get started, you must sign up for a new account.  You will then be able to configure additional settings within the app.


### PR DESCRIPTION
Up to this point, self hosted apps have had a generic auth page when they boot up the app for the first time.

#1163 introduced invite codes for self hosted instances which enabled users to block signups to their Maybe app and allow new registrations via invite codes.

This PR puts some final touches on a basic onboarding flow for self hosted users:

- Fixes issue where registrations page didn't respect the `Setting.require_invite_for_signup` setting
- Adds welcome message and redirects to registration when self hosted instance first boots up

https://github.com/user-attachments/assets/e4da9fdd-a76f-4ed0-8430-b86e71dbf320


