### PR TITLE
Fix: Escape button not being handled on settings pages

### DIFF
--- a/app/views/settings/_nav.html.erb
+++ b/app/views/settings/_nav.html.erb
@@ -4,9 +4,9 @@
       <%= lucide_icon "chevron-left", class: "w-5 h-5 text-gray-500" %>
       <span>Back</span>
     <% end %>
-    <span data-controller="hotkey" data-hotkey="Escape" data-action="hotkey#navigateBack" class="uppercase bg-gray-100 rounded-sm px-1 py-0.5 text-xs text-gray-500 shadow-sm ml-1">
+    <button data-controller="hotkey" data-hotkey="Escape" data-action="hotkey#navigateBack" class="uppercase bg-gray-100 rounded-sm px-1 py-0.5 text-xs text-gray-500 shadow-sm ml-1 pointer-events-none">
       esc
-    </span>
+    </button>
   </div>
   <nav class="space-y-4">
     <section class="space-y-2">


### PR DESCRIPTION
### Describe the bug:
When you click `Escape` key while on settings page nothing happens

### To Reproduce:
1. Open Settings
2. Press `Escape` key

### Expected Behavior:
Settings should close on `Escape` key press.

### Alternate Solution:
Currently the `Escape` key takes you back one page in history. So if you are on another page in Settings, pressing `Escape` will simply take you back to the previous page and not outside Settings. Using `window.history.go()` or `window.history.pushState()` might be a better way to handle this scenario.