### PR TITLE
Set 3000 as the default web port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Custom port config
 # For users who have other applications listening at 3000, this allows them to set a value puma will listen to.
-PORT=
+PORT=3000
 
 # Exchange Rate API
 # This is used to convert between different currencies in the app. We use Synth, which is a Maybe product. You can sign up for a free account at synthfinance.com.


### PR DESCRIPTION
Having by default `PORT=` only assigns to that variable `0`, which is interpreted by puma to start the web app in a random port when `bin/dev` is called. 
Also `export`ing the port in this file is useless, as in the foreman context, it's eventually overriden by the settings of your default `.env` file that has just been copied from `.env.example`.