### PR TITLE
Sort currencies by name as a second order

### DIFF
--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -23,7 +23,7 @@ module FormsHelper
   end
 
   def currencies_for_select
-    Money::Currency.all_instances.sort_by(&:priority)
+    Money::Currency.all_instances.sort_by { |currency| [ currency.priority, currency.name ] }
   end
 
   private


### PR DESCRIPTION
The currency sorting is very chaotic only relying on the "priority"
<img width="403" alt="Screenshot 2024-09-30 at 6 30 10 PM" src="https://github.com/user-attachments/assets/682c1701-25e2-4f9a-9a15-0ed5a612d576">
so I've also set the "name" as a second order parameter
<img width="435" alt="Screenshot 2024-09-30 at 6 30 32 PM" src="https://github.com/user-attachments/assets/598ad7c4-bf28-4be6-8cc4-40579d9862f2">
