### PR TITLE
Fix incorrect partial sync balance generation

### DIFF
--- a/app/models/account/balance/syncer.rb
+++ b/app/models/account/balance/syncer.rb
@@ -14,7 +14,8 @@ class Account::Balance::Syncer
 
       if daily_balances.any?
         account.reload
-        account.update! balance: daily_balances.select { |db| db.currency == account.currency }.last&.balance
+        last_balance = daily_balances.select { |db| db.currency == account.currency }.last&.balance
+        account.update! balance: last_balance
       end
     end
   rescue Money::ConversionError => e
@@ -102,7 +103,7 @@ class Account::Balance::Syncer
     end
 
     def find_prior_balance
-      account.balances.where("date < ?", sync_start_date).order(date: :desc).first&.balance
+      account.balances.where(currency: account.currency).where("date < ?", sync_start_date).order(date: :desc).first&.balance
     end
 
     def net_entry_flows(entries, target_currency = account.currency)


### PR DESCRIPTION
For partial syncs, when searching for the "last synced balance", we were not filtering on currency.

Because of this, for _foreign currency accounts_ in _some cases_, we were fetching the "converted" balance, causing the bug described in #1204 