### PR TITLE
Handle missing weekend stock prices in sync process

### DIFF
--- a/app/models/account/holding/syncer.rb
+++ b/app/models/account/holding/syncer.rb
@@ -48,7 +48,9 @@ class Account::Holding::Syncer
                              end
 
                              ticker_start_dates.each do |ticker, date|
-                               prices[ticker] = Security::Price.find_prices(ticker: ticker, start_date: date, end_date: Date.current)
+                               fetched_prices = Security::Price.find_prices(ticker: ticker, start_date: date, end_date: Date.current)
+                               gapfilled_prices = Gapfiller.new(fetched_prices, start_date: date, end_date: Date.current, cache: false).run
+                               prices[ticker] = gapfilled_prices
                              end
 
                              prices

--- a/app/models/gapfiller.rb
+++ b/app/models/gapfiller.rb
@@ -1,0 +1,44 @@
+class Gapfiller
+  attr_reader :series
+
+  def initialize(series, start_date:, end_date:, cache:)
+    @series = series
+    @date_range = start_date..end_date
+    @cache = cache
+  end
+
+  def run
+    gapfilled_records = []
+
+    date_range.each do |date|
+      record = @series.find { |r| r.date == date }
+
+      if should_gapfill?(date, record)
+        prev_record = gapfilled_records.last || @series.find { |r| r.date < date }&.last
+
+        if prev_record
+          new_record = create_gapfilled_record(prev_record, date)
+          gapfilled_records << new_record
+        end
+      else
+        gapfilled_records << record if record
+      end
+    end
+
+    gapfilled_records
+  end
+
+  private
+    attr_reader :date_range, :cache
+
+    def should_gapfill?(date, record)
+      record.nil? || date.on_weekend?
+    end
+
+    def create_gapfilled_record(prev_record, date)
+      new_record = prev_record.class.new(prev_record.attributes.except("id", "created_at", "updated_at"))
+      new_record.date = date
+      new_record.save! if cache
+      new_record
+    end
+end

--- a/app/models/gapfiller.rb
+++ b/app/models/gapfiller.rb
@@ -11,10 +11,10 @@ class Gapfiller
     gapfilled_records = []
 
     date_range.each do |date|
-      record = @series.find { |r| r.date == date }
+      record = series.find { |r| r.date == date }
 
       if should_gapfill?(date, record)
-        prev_record = gapfilled_records.last || @series.find { |r| r.date < date }&.last
+        prev_record = gapfilled_records.find { |r| r.date == date - 1.day }
 
         if prev_record
           new_record = create_gapfilled_record(prev_record, date)
@@ -32,7 +32,7 @@ class Gapfiller
     attr_reader :date_range, :cache
 
     def should_gapfill?(date, record)
-      record.nil? || date.on_weekend?
+      date.on_weekend? && record.nil?
     end
 
     def create_gapfilled_record(prev_record, date)

--- a/app/models/issue/prices_missing.rb
+++ b/app/models/issue/prices_missing.rb
@@ -3,11 +3,11 @@ class Issue::PricesMissing < Issue
 
   after_initialize :initialize_missing_prices
 
-  validates :missing_prices, presence: true
+  validates :missing_prices, presence: true, allow_blank: true
 
   def append_missing_price(ticker, date)
     missing_prices[ticker] ||= []
-    missing_prices[ticker] << date
+    missing_prices[ticker] << date unless missing_prices[ticker].include?(date.to_s)
   end
 
   def stale?

--- a/app/models/security/price.rb
+++ b/app/models/security/price.rb
@@ -27,7 +27,6 @@ class Security::Price < ApplicationRecord
   end
 
   private
-
     def upcase_ticker
       self.ticker = ticker.upcase
     end

--- a/test/models/account/holding/syncer_test.rb
+++ b/test/models/account/holding/syncer_test.rb
@@ -94,19 +94,24 @@ class Account::Holding::SyncerTest < ActiveSupport::TestCase
 
   # It is common for data providers to not provide prices for weekends, so we need to carry the last observation forward
   test "uses locf gapfilling when price is missing" do
+    friday = Date.new(2024, 9, 27) # A known Friday
+    saturday = friday + 1.day # weekend
+    sunday = saturday + 1.day # weekend
+    monday = sunday + 1.day # known Monday
+
     # Prices should be gapfilled like this: 210, 210, 210, 220
-    amzn = create_security("AMZN", prices: [
-      { date: 3.days.ago.to_date, price: 210 },
-      { date: Date.current, price: 220 }
+    tm = create_security("TM", prices: [
+      { date: friday, price: 210 },
+      { date: monday, price: 220 }
     ])
 
-    create_trade(amzn, account: @account, qty: 10, date: 3.days.ago.to_date)
+    create_trade(tm, account: @account, qty: 10, date: friday)
 
     expected = [
-      { ticker: "AMZN", qty: 10, price: 210, amount: 10 * 210, date: 3.days.ago.to_date },
-      { ticker: "AMZN", qty: 10, price: 210, amount: 10 * 210, date: 2.days.ago.to_date },
-      { ticker: "AMZN", qty: 10, price: 210, amount: 10 * 210, date: 1.day.ago.to_date },
-      { ticker: "AMZN", qty: 10, price: 220, amount: 10 * 220, date: Date.current }
+      { ticker: "TM", qty: 10, price: 210, amount: 10 * 210, date: friday },
+      { ticker: "TM", qty: 10, price: 210, amount: 10 * 210, date: saturday },
+      { ticker: "TM", qty: 10, price: 210, amount: 10 * 210, date: sunday },
+      { ticker: "TM", qty: 10, price: 220, amount: 10 * 220, date: monday }
     ]
 
     run_sync_for(@account)

--- a/test/models/security/price_test.rb
+++ b/test/models/security/price_test.rb
@@ -95,4 +95,29 @@ class Security::PriceTest < ActiveSupport::TestCase
       assert_equal [], Security::Price.find_prices(ticker: "NVDA", start_date: 10.days.ago.to_date, end_date: Date.current)
     end
   end
+
+  test "uses locf gapfilling for weekends when price is missing" do
+    friday = Date.new(2024, 10, 4) # A known Friday
+    saturday = friday + 1.day # weekend
+    sunday = saturday + 1.day # weekend
+    monday = sunday + 1.day # known Monday
+
+    Security::Price.create!(ticker: "TM", date: friday, price: 100)
+    Security::Price.create!(ticker: "TM", date: monday, price: 110)
+
+    # Data provider doesn't return weekend prices
+    @provider.expects(:fetch_security_prices)
+             .with(ticker: "TM", start_date: saturday, end_date: sunday)
+             .returns(OpenStruct.new(success?: false))
+             .once
+
+    expected_prices = [
+      Security::Price.new(ticker: "TM", date: friday, price: 100).price,
+      Security::Price.new(ticker: "TM", date: saturday, price: 100).price,
+      Security::Price.new(ticker: "TM", date: sunday, price: 100).price,
+      Security::Price.new(ticker: "TM", date: monday, price: 110).price
+    ]
+
+    assert_equal expected_prices, Security::Price.find_prices(ticker: "TM", start_date: friday, end_date: monday).map(&:price)
+  end
 end


### PR DESCRIPTION
There are a few different areas that we could potentially solve this issue: 

1. At the provider level (not a good option since we can't always control what the provider returns)
2. At the base model level (i.e. `Security::Price.find_prices`)
3. At the sync model level (i.e. `Account::Holding::Syncer`)

To keep the gapfill logic isolated from the base model, I've added a `Gapfiller` class that operates on the fetched prices directly in the sync process.