### PR TITLE
Hide currency for transfers

### DIFF
--- a/app/views/account/transfers/_form.html.erb
+++ b/app/views/account/transfers/_form.html.erb
@@ -29,7 +29,7 @@
     <%= f.text_field :name, value: transfer.name, label: t(".description"), placeholder: t(".description_placeholder"), required: true %>
     <%= f.collection_select :from_account_id, Current.family.accounts.alphabetically, :id, :name, { prompt: t(".select_account"), label: t(".from") }, required: true %>
     <%= f.collection_select :to_account_id, Current.family.accounts.alphabetically, :id, :name, { prompt: t(".select_account"), label: t(".to") }, required: true %>
-    <%= f.money_field :amount, :currency, label: t(".amount"), required: true %>
+    <%= f.money_field :amount, :currency, label: t(".amount"), required: true, hide_currency: true %>
     <%= f.date_field :date, value: transfer.date, label: t(".date"), required: true, max: Date.current %>
   </section>
 


### PR DESCRIPTION
Fixes #1250 

Currently, we're defaulting the currency of any transfer to equal the currency of the _originating account_.

While we will likely need to add more user control around this in the future, for now, I've hidden the currency control to avoid users thinking that this is configurable when it is not.