### PR TITLE
Minor improvements to categories & changelog pages

### DIFF
--- a/app/models/provider/github.rb
+++ b/app/models/provider/github.rb
@@ -47,6 +47,8 @@ class Provider::Github
         if release
           {
             avatar: release.author.avatar_url,
+            # this is the username, it would be nice to get the full name
+            username: release.author.login,
             name: release.name,
             published_at: release.published_at,
             body: Octokit.markdown(release.body, mode: "gfm", context: repo)

--- a/app/views/categories/_badge.html.erb
+++ b/app/views/categories/_badge.html.erb
@@ -2,9 +2,10 @@
 <% category ||= null_category %>
 
 <div>
-  <span class="flex items-center gap-1 text-sm font-medium rounded-full px-1.5 py-1 border border-alpha-black-25"
+  <span class="flex items-center gap-1 text-sm font-medium rounded-full px-1.5 py-1 border"
         style="
           background-color: color-mix(in srgb, <%= category.color %> 5%, white);
+          border-color: color-mix(in srgb, <%= category.color %> 25%, white);
           color: <%= category.color %>;">
     <%= category.name %>
   </span>

--- a/app/views/categories/_badge.html.erb
+++ b/app/views/categories/_badge.html.erb
@@ -5,7 +5,7 @@
   <span class="flex items-center gap-1 text-sm font-medium rounded-full px-1.5 py-1 border"
         style="
           background-color: color-mix(in srgb, <%= category.color %> 5%, white);
-          border-color: color-mix(in srgb, <%= category.color %> 25%, white);
+          border-color: color-mix(in srgb, <%= category.color %> 30%, white);
           color: <%= category.color %>;">
     <%= category.name %>
   </span>

--- a/app/views/pages/changelog.html.erb
+++ b/app/views/pages/changelog.html.erb
@@ -12,7 +12,7 @@
             <%= image_tag @release_notes[:avatar], class: "rounded-full w-full h-full object-cover" %>
           </div>
           <div>
-            <div class="text-gray-900 font-medium text-sm"><%= @release_notes[:name] %></div>
+            <a class="text-gray-900 font-medium text-sm" href="https://github.com/<%= @release_notes[:username] %>"><%= "@#{@release_notes[:username]}" %></a>
             <div class="text-gray-500 text-sm"><%= @release_notes[:published_at].strftime("%B %d, %Y") %></div>
           </div>
         </div>


### PR DESCRIPTION
Hey there!

I’m testing the hosted version of Maybe, and a few things bothered me regarding the UI.

The grey border around the badges for the categories feels *wrong*. I’ve updated this to match the colour of the badge instead.

Before:

<img width="437" alt="Screenshot 2024-10-09 at 21 38 30" src="https://github.com/user-attachments/assets/5debadb1-ff80-483c-9e25-7e03b2c3d70f">

After:

<img width="456" alt="Screenshot 2024-10-09 at 21 38 55" src="https://github.com/user-attachments/assets/d6a8ca68-b41b-4d7f-9f06-406306f36750">

It also feels a bit wrong to see the name of the changelog update instead of the person who created the release.

Before:

<img width="459" alt="Screenshot 2024-10-09 at 21 42 09" src="https://github.com/user-attachments/assets/df0e1eeb-083d-47e3-accb-32e83b015136">

After:

<img width="439" alt="Screenshot 2024-10-09 at 21 41 31" src="https://github.com/user-attachments/assets/f438d91a-3260-412f-b134-c2a194f99dec">
