### PR TITLE
Fix currency formatting for 0 values

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,7 +26,7 @@ class PagesController < ApplicationController
 
     # TODO: Placeholders for trendlines
     placeholder_series_data = 10.times.map do |i|
-      { date: Date.current - i.days, value: Money.new(0) }
+      { date: Date.current - i.days, value: Money.new(0, Current.family.currency) }
     end
     @investing_series = TimeSeries.new(placeholder_series_data)
   end

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -129,17 +129,21 @@ class Account::Entry < ApplicationRecord
     end
 
     def income_total(currency = "USD")
-      without_transfers.account_transactions.includes(:entryable)
+      total = without_transfers.account_transactions.includes(:entryable)
         .where("account_entries.amount <= 0")
                        .map { |e| e.amount_money.exchange_to(currency, date: e.date, fallback_rate: 0) }
                        .sum
+
+      Money.new(total, currency)
     end
 
     def expense_total(currency = "USD")
-      without_transfers.account_transactions.includes(:entryable)
+      total = without_transfers.account_transactions.includes(:entryable)
                        .where("account_entries.amount > 0")
                        .map { |e| e.amount_money.exchange_to(currency, date: e.date, fallback_rate: 0) }
                        .sum
+
+      Money.new(total, currency)
     end
 
     def search(params)

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -8,7 +8,11 @@ class Loan < ApplicationRecord
     annual_rate = interest_rate / 100.0
     monthly_rate = annual_rate / 12.0
 
-    payment = (account.original_balance.amount * monthly_rate * (1 + monthly_rate)**term_months) / ((1 + monthly_rate)**term_months - 1)
+    if monthly_rate.zero?
+      payment = account.original_balance.amount / term_months
+    else
+      payment = (account.original_balance.amount * monthly_rate * (1 + monthly_rate)**term_months) / ((1 + monthly_rate)**term_months - 1)
+    end
 
     Money.new(payment.round, account.currency)
   end


### PR DESCRIPTION
When income / expense summed to 0, no `Money` object was returned; making the currency wrong for non-USD accounts.