### PR TITLE
fix: use correct delimiter on credit card zero values

### DIFF
--- a/app/views/accounts/accountables/credit_card/_overview.html.erb
+++ b/app/views/accounts/accountables/credit_card/_overview.html.erb
@@ -10,7 +10,7 @@
   <% end %>
 
   <%= summary_card title: t(".minimum_payment") do %>
-    <%= format_money(account.credit_card.minimum_payment_money) || Money.new(0, account.currency) %>
+    <%= format_money(account.credit_card.minimum_payment_money || Money.new(0, account.currency)) %>
   <% end %>
 
   <%= summary_card title: t(".apr") do %>
@@ -22,6 +22,6 @@
   <% end %>
 
   <%= summary_card title: t(".annual_fee") do %>
-    <%= format_money(account.credit_card.annual_fee_money) || Money.new(0, account.currency) %>
+    <%= format_money(account.credit_card.annual_fee_money || Money.new(0, account.currency)) %>
   <% end %>
 </div>


### PR DESCRIPTION
After recent fixes, the credit card view displays 0 by default on Minimum Payment and Annual Fee. However, the format is wrong. On zero values, the two digits after the delimiter are the decimals, and this is the current behaviour on other sections, like the dashboard.

For example, this is correct:
![image](https://github.com/user-attachments/assets/8f979aff-129e-4cbb-b527-79ab71c3f1d6)
But this is not:
![image](https://github.com/user-attachments/assets/0c46085e-1993-48d7-8232-cda5fc5dfed0)

This PR resolves this issue, the credit card Minimum Payment and Annual Fee now display the correct delimiter on empty values:
![image](https://github.com/user-attachments/assets/0b57d4e2-7baa-401f-92e9-69db5fb5a442)

I haven't seen any issues related to this, so I can't link one.

First time contributing and first time using ruby, I'll be happy to hear about your feedback.

Cheers.