### PR TITLE
fix: amend inputs on loan, c.c., vehicle, and property partials

### DIFF
--- a/app/views/accounts/accountables/_credit_card.html.erb
+++ b/app/views/accounts/accountables/_credit_card.html.erb
@@ -9,7 +9,7 @@
 
       <div class="flex items-center gap-2">
         <%= credit_card_form.number_field :minimum_payment, label: t(".minimum_payment"), placeholder: t(".minimum_payment_placeholder"), min: 0 %>
-        <%= credit_card_form.number_field :apr, label: t(".apr"), placeholder: t(".apr_placeholder"), min: 0, step: 0.1 %>
+        <%= credit_card_form.number_field :apr, label: t(".apr"), placeholder: t(".apr_placeholder"), min: 0, step: 0.01 %>
       </div>
 
       <div class="flex items-center gap-2">

--- a/app/views/accounts/accountables/_credit_card.html.erb
+++ b/app/views/accounts/accountables/_credit_card.html.erb
@@ -4,17 +4,17 @@
   <div class="space-y-2">
     <%= f.fields_for :accountable do |credit_card_form| %>
       <div class="flex items-center gap-2">
-        <%= credit_card_form.text_field :available_credit, label: t(".available_credit"), placeholder: t(".available_credit_placeholder") %>
+        <%= credit_card_form.number_field :available_credit, label: t(".available_credit"), placeholder: t(".available_credit_placeholder"), min: 0 %>
       </div>
 
       <div class="flex items-center gap-2">
-        <%= credit_card_form.text_field :minimum_payment, label: t(".minimum_payment"), placeholder: t(".minimum_payment_placeholder") %>
-        <%= credit_card_form.text_field :apr, label: t(".apr"), placeholder: t(".apr_placeholder") %>
+        <%= credit_card_form.number_field :minimum_payment, label: t(".minimum_payment"), placeholder: t(".minimum_payment_placeholder"), min: 0  %>
+        <%= credit_card_form.number_field :apr, label: t(".apr"), placeholder: t(".apr_placeholder"), min: 0, step: 0.1 %>
       </div>
 
       <div class="flex items-center gap-2">
         <%= credit_card_form.date_field :expiration_date, label: t(".expiration_date") %>
-        <%= credit_card_form.text_field :annual_fee, label: t(".annual_fee"), placeholder: t(".annual_fee_placeholder") %>
+        <%= credit_card_form.number_field :annual_fee, label: t(".annual_fee"), placeholder: t(".annual_fee_placeholder"), min: 0  %>
       </div>
     <% end %>
   </div>

--- a/app/views/accounts/accountables/_credit_card.html.erb
+++ b/app/views/accounts/accountables/_credit_card.html.erb
@@ -8,13 +8,13 @@
       </div>
 
       <div class="flex items-center gap-2">
-        <%= credit_card_form.number_field :minimum_payment, label: t(".minimum_payment"), placeholder: t(".minimum_payment_placeholder"), min: 0  %>
+        <%= credit_card_form.number_field :minimum_payment, label: t(".minimum_payment"), placeholder: t(".minimum_payment_placeholder"), min: 0 %>
         <%= credit_card_form.number_field :apr, label: t(".apr"), placeholder: t(".apr_placeholder"), min: 0, step: 0.1 %>
       </div>
 
       <div class="flex items-center gap-2">
         <%= credit_card_form.date_field :expiration_date, label: t(".expiration_date") %>
-        <%= credit_card_form.number_field :annual_fee, label: t(".annual_fee"), placeholder: t(".annual_fee_placeholder"), min: 0  %>
+        <%= credit_card_form.number_field :annual_fee, label: t(".annual_fee"), placeholder: t(".annual_fee_placeholder"), min: 0 %>
       </div>
     <% end %>
   </div>

--- a/app/views/accounts/accountables/_loan.html.erb
+++ b/app/views/accounts/accountables/_loan.html.erb
@@ -4,7 +4,7 @@
   <div class="space-y-2">
     <%= f.fields_for :accountable do |loan_form| %>
       <div class="flex items-center gap-2">
-        <%= loan_form.number_field :interest_rate, label: t(".interest_rate"), placeholder: t(".interest_rate_placeholder"), min: 0, step: 0.1 %>
+        <%= loan_form.number_field :interest_rate, label: t(".interest_rate"), placeholder: t(".interest_rate_placeholder"), min: 0, step: 0.01 %>
         <%= loan_form.select :rate_type, options_for_select([["Fixed", "fixed"], ["Variable", "variable"], ["Adjustable", "adjustable"]]), { label: t(".rate_type") } %>
       </div>
 

--- a/app/views/accounts/accountables/_loan.html.erb
+++ b/app/views/accounts/accountables/_loan.html.erb
@@ -4,7 +4,7 @@
   <div class="space-y-2">
     <%= f.fields_for :accountable do |loan_form| %>
       <div class="flex items-center gap-2">
-        <%= loan_form.text_field :interest_rate, label: t(".interest_rate"), placeholder: t(".interest_rate_placeholder") %>
+        <%= loan_form.number_field :interest_rate, label: t(".interest_rate"), placeholder: t(".interest_rate_placeholder"), min: 0, step: 0.1 %>
         <%= loan_form.select :rate_type, options_for_select([["Fixed", "fixed"], ["Variable", "variable"], ["Adjustable", "adjustable"]]), { label: t(".rate_type") } %>
       </div>
 

--- a/app/views/accounts/accountables/_property.html.erb
+++ b/app/views/accounts/accountables/_property.html.erb
@@ -8,8 +8,8 @@
   <div class="space-y-2">
     <%= f.fields_for :accountable do |af| %>
       <div class="flex gap-2">
-        <%= af.number_field :year_built, label: t(".year_built"), placeholder: 2005 %>
-        <%= af.number_field :area_value, label: t(".area_value"), placeholder: 2000 %>
+        <%= af.number_field :year_built, label: t(".year_built"), placeholder: 2005, min: 1700, max: Time.current.year %>
+        <%= af.number_field :area_value, label: t(".area_value"), placeholder: 2000, min: 1 %>
         <%= af.select :area_unit,
                   [["Square feet", "sqft"], ["Square meters", "sqm"]],
                   { label: t(".area_unit") } %>

--- a/app/views/accounts/accountables/_vehicle.html.erb
+++ b/app/views/accounts/accountables/_vehicle.html.erb
@@ -12,8 +12,8 @@
       </div>
 
       <div class="flex items-center gap-2">
-        <%= vehicle_form.text_field :year, label: t(".year"), placeholder: t(".year_placeholder") %>
-        <%= vehicle_form.text_field :mileage_value, label: t(".mileage"), placeholder: t(".mileage_placeholder") %>
+        <%= vehicle_form.number_field :year, label: t(".year"), placeholder: t(".year_placeholder"), min: 1900, max: Time.current.year %>
+        <%= vehicle_form.number_field :mileage_value, label: t(".mileage"), placeholder: t(".mileage_placeholder"), min: 0 %>
         <%= vehicle_form.select :mileage_unit,
                   [["Miles", "mi"], ["Kilometers", "km"]],
                   { label: t(".mileage_unit") } %>


### PR DESCRIPTION
It's currently possible to input text on some number values for loans, credit cards, vehicles, and property. When happens and the form is submitted, it is gracefully handled by setting the value to zero. 
This PR proposes that those inputs are number inputs, with appropriate min and step values. % values have a step of 0.1 and both % and currency inputs have a min of 0. This assumes that negative interest rates are VERY rare in personal finance. With that said, I am not sure if it makes sense to put in a negative balance, so I'll be expecting to hear your thoughts on that.
Ideally, these inputs should display the currency symbol or percentage symbol, but that isn't such a trivial change, so I left it out for now.

Looking forward to your feedback. Cheers!