### PR TITLE
Allow inline account creation when importing CSV

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -71,10 +71,10 @@ class Import < ApplicationRecord
       {
         account: row[account_col_label].to_s,
         date: row[date_col_label].to_s,
-        qty: row[qty_col_label].to_s,
+        qty: sanitize_number(row[qty_col_label]).to_s,
         ticker: row[ticker_col_label].to_s,
-        price: row[price_col_label].to_s,
-        amount: row[amount_col_label].to_s,
+        price: sanitize_number(row[price_col_label]).to_s,
+        amount: sanitize_number(row[amount_col_label]).to_s,
         currency: (row[currency_col_label] || default_currency).to_s,
         name: (row[name_col_label] || default_row_name).to_s,
         category: row[category_col_label].to_s,
@@ -137,5 +137,10 @@ class Import < ApplicationRecord
         col_sep: col_sep,
         converters: [ ->(str) { str&.strip } ]
       )
+    end
+
+    def sanitize_number(value)
+      return "" if value.nil?
+      value.gsub(/[^\d.]/, "")
     end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -113,6 +113,10 @@ class Import < ApplicationRecord
     cleaned? && mappings.all?(&:valid?)
   end
 
+  def requires_account?
+    family.accounts.empty? && mappings.accounts.where(key: "").any?
+  end
+
   private
     def import!
       # no-op, subclasses can implement for customization of algorithm

--- a/app/views/import/cleans/show.html.erb
+++ b/app/views/import/cleans/show.html.erb
@@ -23,7 +23,7 @@
     <div class="bg-white border border-alpha-black-100 rounded-lg p-3 flex items-center justify-between">
       <div class="flex items-center gap-2">
         <%= lucide_icon "alert-triangle", class: "w-4 h-4 text-red-500" %>
-        <p class="text-red-500">You have errors in your data</p>
+        <p class="text-red-500 text-sm"><%= t(".errors_notice") %></p>
       </div>
 
       <div class="flex justify-center">

--- a/app/views/import/confirms/_mappings.html.erb
+++ b/app/views/import/confirms/_mappings.html.erb
@@ -3,12 +3,20 @@
 <% mappings = mapping_class.for_import(import) %>
 <% is_last_step = step_idx == import.mapping_steps.count - 1 %>
 
+<% if import.requires_account? && mapping_class == Import::AccountMapping  %>
+  <div class="flex items-center justify-between p-4 mb-4 gap-4 text-gray-500 bg-red-100 border border-red-200 rounded-lg w-[650px]">
+    <%= tag.p t(".no_accounts"), class: "text-sm" %>
+
+    <%= link_to t(".create_account"), new_account_path, class: "btn btn--primary whitespace-nowrap", data: { turbo_frame: :modal } %>
+  </div>
+<% end %>
+
 <div class="space-y-4">
   <div class="bg-gray-25 rounded-xl p-1 space-y-1 w-[650px]">
     <div class="grid grid-cols-3 gap-2 text-xs font-medium text-gray-500 uppercase px-5 py-3">
-      <p>CSV <%= mapping_label(mapping_class) %></p>
-      <p>Maybe <%= mapping_label(mapping_class) %></p>
-      <p class="justify-self-end">Rows</p>
+      <p><%= t('.csv_mapping_label', mapping: mapping_label(mapping_class)) %></p>
+      <p><%= t('.maybe_mapping_label', mapping: mapping_label(mapping_class)) %></p>
+      <p class="justify-self-end"><%= t('.rows_label') %></p>
     </div>
 
     <div class="border border-alpha-black-25 rounded-md shadow-xs divide-y divide-alpha-black-100 text-sm">

--- a/app/views/import/confirms/_mappings.html.erb
+++ b/app/views/import/confirms/_mappings.html.erb
@@ -3,7 +3,7 @@
 <% mappings = mapping_class.for_import(import) %>
 <% is_last_step = step_idx == import.mapping_steps.count - 1 %>
 
-<% if import.requires_account? && mapping_class == Import::AccountMapping  %>
+<% if import.requires_account? && mapping_class == Import::AccountMapping %>
   <div class="flex items-center justify-between p-4 mb-4 gap-4 text-gray-500 bg-red-100 border border-red-200 rounded-lg w-[650px]">
     <%= tag.p t(".no_accounts"), class: "text-sm" %>
 
@@ -14,9 +14,9 @@
 <div class="space-y-4">
   <div class="bg-gray-25 rounded-xl p-1 space-y-1 w-[650px]">
     <div class="grid grid-cols-3 gap-2 text-xs font-medium text-gray-500 uppercase px-5 py-3">
-      <p><%= t('.csv_mapping_label', mapping: mapping_label(mapping_class)) %></p>
-      <p><%= t('.maybe_mapping_label', mapping: mapping_label(mapping_class)) %></p>
-      <p class="justify-self-end"><%= t('.rows_label') %></p>
+      <p><%= t(".csv_mapping_label", mapping: mapping_label(mapping_class)) %></p>
+      <p><%= t(".maybe_mapping_label", mapping: mapping_label(mapping_class)) %></p>
+      <p class="justify-self-end"><%= t(".rows_label") %></p>
     </div>
 
     <div class="border border-alpha-black-25 rounded-md shadow-xs divide-y divide-alpha-black-100 text-sm">

--- a/app/views/import/confirms/show.html.erb
+++ b/app/views/import/confirms/show.html.erb
@@ -28,6 +28,6 @@
   </div>
 </div>
 
-<div class="max-w-screen-md mx-auto flex justify-center">
+<div class="max-w-screen-md mx-auto flex flex-col items-center">
   <%= render partial: "import/confirms/mappings", locals: { import: @import, mapping_class: step_mapping_class, step_idx: step_idx } %>
 </div>

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -10,6 +10,14 @@ en:
         description: Select the columns that correspond to each field in your CSV.
         title: Configure your import
     confirms:
+      mappings:
+        create_account: Create account
+        csv_mapping_label: "%{mapping} in CSV"
+        maybe_mapping_label: "%{mapping} in Maybe"
+        no_accounts: You don't have any accounts yet. Please create an account that
+          we can use for (unassigned) rows in your CSV or go back to the Clean step
+          and provide an account name we can use.
+        rows_label: Rows
       show:
         account_mapping_description: Assign all of your imported file's accounts to
           Maybe's existing accounts.  You can also add new accounts or leave them

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -4,6 +4,7 @@ en:
     cleans:
       show:
         description: Edit your data in the table below.  Red cells are invalid.
+        errors_notice: You have errors in your data.  Hover over the error to see details.
         title: Clean your data
     configurations:
       show:


### PR DESCRIPTION
A few CSV import improvements:

- If user hasn't created any accounts before doing a CSV import, we allow them to create one inline so they don't have to exit the flow to do this
- Better parsing of raw CSV data (stripping non-numericals from amounts, etc.)
- Fixes #1289 for date validations