### PR TITLE
Fixes issue with mapping values during the transactions import

### DIFF
--- a/app/javascript/controllers/auto_submit_form_controller.js
+++ b/app/javascript/controllers/auto_submit_form_controller.js
@@ -24,10 +24,33 @@ export default class extends Controller {
     });
   }
 
-  handleInput = () => {
+  handleInput = (event) => {
+    const target = event.target
+
     clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
       this.element.requestSubmit();
-    }, 500);
+    }, this.#debounceTimeout(target));
   };
+
+  #debounceTimeout(element) {
+    if(element.dataset.autosubmitDebounceTimeout) {
+      return parseInt(element.dataset.autosubmitDebounceTimeout);
+    }
+
+    const type = element.type || element.tagName;
+
+    switch (type.toLowerCase()) {
+      case 'input':
+      case 'textarea':
+        return 500;
+        break;
+      case 'select-one':
+      case 'select-multiple':
+        return 0;
+        break;
+      default:
+        return 500;
+    }
+  }
 }

--- a/test/system/imports_test.rb
+++ b/test/system/imports_test.rb
@@ -101,7 +101,6 @@ class ImportsTest < ApplicationSystemTestCase
       within(form) do
         select = form.find("select")
         select "Depository", from: select["id"]
-        sleep 1
       end
     end
 


### PR DESCRIPTION
### Why?

- Fixes #1317 

At the final step of a transactions import, the summary showing how many new items will be added displays numbers that don’t match the options selected in the previous steps.

I imported a CSV with 2 rows, mapped every category, tag, and account, but the summary shows that some of those items will be created.
If I go back to the mapping step, I can see that some of the selected options were cleared.

**The issue was caused by the debounce timeout in the auto-submit-form Stimulus controller. It waits 500ms to submit the form, so if you click the 'Next' button too quickly, the form doesn't get submitted, and the option isn't saved.**

### What?
I added a default debounce timeout that adjusts based on the element type, and also made it customizable by allowing a custom debounce timeout to be set through a data attribute

### What should we test?

Select an item during the mapping step when importing transactions and quickly move to the next step. At the final step of the import, you should now see a 0 next to Categories, Accounts, and Tags.

