### PR TITLE
Refactor: Extract Reused String Literals to Constants

### DIFF
--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,4 +1,5 @@
 class AccountsController < ApplicationController
+  SUCCESS = ".success".freeze
   layout :with_sidebar
 
   include Filterable
@@ -41,7 +42,7 @@ class AccountsController < ApplicationController
 
   def update
     @account.update_with_sync!(account_params)
-    redirect_back_or_to account_path(@account), notice: t(".success")
+    redirect_back_or_to account_path(@account), notice: t(SUCCESS)
   end
 
   def create
@@ -53,12 +54,12 @@ class AccountsController < ApplicationController
                         start_balance: account_params[:start_balance]
     @account.sync_later
 
-    redirect_back_or_to account_path(@account), notice: t(".success")
+    redirect_back_or_to account_path(@account), notice: t(SUCCESS)
   end
 
   def destroy
     @account.destroy!
-    redirect_to accounts_path, notice: t(".success")
+    redirect_to accounts_path, notice: t(SUCCESS)
   end
 
   def sync
@@ -69,7 +70,7 @@ class AccountsController < ApplicationController
 
   def sync_all
     Current.family.accounts.active.sync
-    redirect_back_or_to accounts_path, notice: t(".success")
+    redirect_back_or_to accounts_path, notice: t(SUCCESS)
   end
 
   private

--- a/app/controllers/impersonation_sessions_controller.rb
+++ b/app/controllers/impersonation_sessions_controller.rb
@@ -1,40 +1,41 @@
 class ImpersonationSessionsController < ApplicationController
+  SUCCESS =".success".freeze
   before_action :require_super_admin!, only: [ :create, :join, :leave ]
   before_action :set_impersonation_session, only: [ :approve, :reject, :complete ]
 
   def create
     Current.true_user.request_impersonation_for(session_params[:impersonated_id])
-    redirect_to root_path, notice: t(".success")
+    redirect_to root_path, notice: t(SUCCESS)
   end
 
   def join
     @impersonation_session = Current.true_user.impersonator_support_sessions.find_by(id: params[:impersonation_session_id])
     Current.session.update!(active_impersonator_session: @impersonation_session)
-    redirect_to root_path, notice: t(".success")
+    redirect_to root_path, notice: t(SUCCESS)
   end
 
   def leave
     Current.session.update!(active_impersonator_session: nil)
-    redirect_to root_path, notice: t(".success")
+    redirect_to root_path, notice: t(SUCCESS)
   end
 
   def approve
     raise_unauthorized! unless @impersonation_session.impersonated == Current.true_user
 
     @impersonation_session.approve!
-    redirect_to root_path, notice: t(".success")
+    redirect_to root_path, notice: t(SUCCESS)
   end
 
   def reject
     raise_unauthorized! unless @impersonation_session.impersonated == Current.true_user
 
     @impersonation_session.reject!
-    redirect_to root_path, notice: t(".success")
+    redirect_to root_path, notice: t(SUCCESS)
   end
 
   def complete
     @impersonation_session.complete!
-    redirect_to root_path, notice: t(".success")
+    redirect_to root_path, notice: t(SUCCESS)
   end
 
   private

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -171,9 +171,6 @@ class Account::Entry < ApplicationRecord
         when "greater"
           query = query.where("ABS(account_entries.amount) > ?", params[:amount].to_f.abs)
         end
-        else
-          # Handle unexpected amount_operator values
-          raise ArgumentError, "Invalid amount_operator: #{params[:amount_operator]}"
       end
 
       if params[:accounts].present? || params[:account_ids].present?

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -171,6 +171,9 @@ class Account::Entry < ApplicationRecord
         when "greater"
           query = query.where("ABS(account_entries.amount) > ?", params[:amount].to_f.abs)
         end
+        else
+          # Handle unexpected amount_operator values
+          raise ArgumentError, "Invalid amount_operator: #{params[:amount_operator]}"
       end
 
       if params[:accounts].present? || params[:account_ids].present?

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  EMAIL="john@example.com".freeze
+  PASSWORD="password".freeze
   test "new" do
     get new_registration_url
     assert_response :success
@@ -8,9 +10,9 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
   test "create redirects to correct URL" do
     post registration_url, params: { user: {
-      email: "john@example.com",
-      password: "password",
-      password_confirmation: "password" } }
+      email: EMAIL,
+      password: PASSWORD,
+      password_confirmation: PASSWORD } }
 
     assert_redirected_to root_url
   end
@@ -18,9 +20,9 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   test "create seeds default transaction categories" do
     assert_difference "Category.count", Category::DEFAULT_CATEGORIES.size do
       post registration_url, params: { user: {
-      email: "john@example.com",
-      password: "password",
-      password_confirmation: "password" } }
+      email: EMAIL,
+      password: PASSWORD,
+      password_confirmation: PASSWORD } }
     end
   end
 
@@ -28,24 +30,24 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     with_env_overrides REQUIRE_INVITE_CODE: "true" do
       assert_no_difference "User.count" do
         post registration_url, params: { user: {
-          email: "john@example.com",
-          password: "password",
-          password_confirmation: "password" } }
+          email: EMAIL,
+          password: PASSWORD,
+          password_confirmation: PASSWORD } }
         assert_redirected_to new_registration_url
 
         post registration_url, params: { user: {
-          email: "john@example.com",
-          password: "password",
-          password_confirmation: "password",
+          email: EMAIL,
+          password: PASSWORD,
+          password_confirmation: PASSWORD,
           invite_code: "foo" } }
         assert_redirected_to new_registration_url
       end
 
       assert_difference "User.count", +1 do
         post registration_url, params: { user: {
-          email: "john@example.com",
-          password: "password",
-          password_confirmation: "password",
+          email: EMAIL,
+          password: PASSWORD,
+          password_confirmation: PASSWORD,
           invite_code: InviteCode.generate! } }
         assert_redirected_to root_url
       end


### PR DESCRIPTION
Just a quick cleanup based on some SonarQube suggestions—moved a bunch of repeated string literals to constants. Not the most exciting change, but it does help make the code a bit more manageable and avoids duplication.

No big functional changes here, just some housekeeping to keep things tidy :)