### PR TITLE
Add translate pt br

### DIFF
--- a/app/views/transactions/_header.html.erb
+++ b/app/views/transactions/_header.html.erb
@@ -1,5 +1,5 @@
 <header class="flex justify-between items-center text-gray-900 font-medium">
-  <h1 class="text-xl">Transactions</h1>
+  <h1 class="text-xl"><%= t(".index") %></h1>
   <div class="flex items-center gap-5">
     <div class="flex items-center gap-2">
       <%= contextual_menu do %>
@@ -18,7 +18,7 @@
 
       <%= link_to new_transaction_path, class: "rounded-lg bg-gray-900 text-white flex items-center gap-1 justify-center hover:bg-gray-700 px-3 py-2", data: { turbo_frame: :modal } do %>
         <%= lucide_icon("plus", class: "w-5 h-5") %>
-        <p class="text-sm font-medium">New transaction</p>
+        <p class="text-sm font-medium"><%= t(".new") %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/transactions/_summary.html.erb
+++ b/app/views/transactions/_summary.html.erb
@@ -1,17 +1,17 @@
 <%# locals: (totals:) %>
 <div class="grid grid-cols-3 bg-white rounded-xl border border-alpha-black-25 shadow-xs divide-x divide-alpha-black-100">
   <div class="p-4 space-y-2">
-    <p class="text-sm text-gray-500">Total transactions</p>
+    <p class="text-sm text-gray-500"><%= t(".total_transactions") %></p>
     <p class="text-gray-900 font-medium text-xl" id="total-transactions"><%= totals[:count] %></p>
   </div>
   <div class="p-4 space-y-2">
-    <p class="text-sm text-gray-500">Income</p>
+    <p class="text-sm text-gray-500"><%= t(".income") %></p>
     <p class="text-gray-900 font-medium text-xl" id="total-income">
       <%= format_money totals[:income] %>
     </p>
   </div>
   <div class="p-4 space-y-2">
-    <p class="text-sm text-gray-500">Expenses</p>
+    <p class="text-sm text-gray-500"><%= t(".expenses") %></p>
     <p class="text-gray-900 font-medium text-xl" id="total-expense">
       <%= format_money totals[:expense] %>
     </p>

--- a/config/locales/views/account/transactions/pt-BR.yml
+++ b/config/locales/views/account/transactions/pt-BR.yml
@@ -1,0 +1,43 @@
+---
+en:
+  account:
+    transactions:
+      index:
+        new: Nova transação
+        no_transactions: Ainda não há transações para esta conta.
+        transaction: transação
+        transactions: Transações
+      selection_bar:
+        mark_transfers: Marcar como transferências?
+        mark_transfers_confirm: Marcar como transferências
+        mark_transfers_message: Ao marcar transações como transferências, elas não serão
+          mais incluídas nos cálculos de receitas ou despesas.
+      show:
+        account_label: Conta
+        amount: Valor
+        category_label: Categoria
+        category_placeholder: Selecione uma categoria
+        date_label: Data
+        delete: Excluir
+        delete_subtitle: Isso exclui permanentemente a transação, afeta seus saldos históricos
+          e não pode ser desfeito.
+        delete_title: Excluir transação
+        details: Detalhes
+        exclude_subtitle: Isso exclui a transação de quaisquer recursos ou análises no aplicativo.
+        exclude_title: Excluir transação
+        merchant_label: Estabelecimento
+        merchant_placeholder: Selecione um estabelecimento
+        name_label: Nome
+        nature: Tipo
+        note_label: Observações
+        note_placeholder: Digite uma observação
+        overview: Visão geral
+        settings: Configurações
+        tags_label: Tags
+      transaction:
+        remove_transfer: Remover transferência
+        remove_transfer_body: Isso removerá a transferência desta transação
+        remove_transfer_confirm: Confirmar
+      update:
+        success: Transação atualizada com sucesso.
+

--- a/config/locales/views/accounts/pt-BR.yml
+++ b/config/locales/views/accounts/pt-BR.yml
@@ -1,0 +1,180 @@
+---
+pt-BR:
+  accounts:
+    account:
+      has_issues: Problema detectado.
+      troubleshoot: Solucionar problema
+    account_list:
+      new_account: Novo %{type}
+    accountables:
+      credit_card:
+        form:
+          annual_fee: Taxa anual
+          annual_fee_placeholder: '99'
+          apr: Taxa de juros
+          apr_placeholder: '15,99'
+          available_credit: Crédito disponível
+          available_credit_placeholder: '10000'
+          expiration_date: Data de validade
+          minimum_payment: Pagamento mínimo
+          minimum_payment_placeholder: '100'
+        overview:
+          amount_owed: Valor devido
+          annual_fee: Taxa anual
+          apr: Taxa de juros
+          available_credit: Crédito disponível
+          expiration_date: Data de validade
+          minimum_payment: Pagamento mínimo
+          unknown: Desconhecido
+      depository:
+        form:
+          none: Nenhum
+          prompt: Selecione um subtipo
+      investment:
+        form:
+          none: Nenhum
+          prompt: Selecione um subtipo
+        tooltip:
+          cash: Dinheiro
+          holdings: Investimentos
+          total_value_tooltip: O valor total é a soma do saldo em dinheiro e o valor dos seus investimentos, menos empréstimos de margem.
+      loan:
+        form:
+          interest_rate: Taxa de juros
+          interest_rate_placeholder: '5,25'
+          rate_type: Tipo de taxa
+          term_months: Prazo (meses)
+          term_months_placeholder: '360'
+        overview:
+          interest_rate: Taxa de juros
+          monthly_payment: Pagamento mensal
+          not_applicable: N/A
+          original_principal: Principal original
+          remaining_principal: Principal restante
+          term: Prazo
+          type: Tipo
+          unknown: Desconhecido
+      property:
+        form:
+          additional_info: Informações adicionais
+          area_unit: Unidade de área
+          area_value: Valor da área
+          city: Cidade
+          country: País
+          line1: Endereço linha 1
+          line2: Endereço linha 2
+          optional: opcional
+          postal_code: CEP
+          state: Estado
+          year_built: Ano de construção
+        overview:
+          living_area: Área útil
+          market_value: Valor de mercado
+          purchase_price: Preço de compra
+          trend: Tendência
+          unknown: Desconhecido
+          year_built: Ano de construção
+      vehicle:
+        form:
+          make: Marca
+          make_placeholder: Toyota
+          mileage: Quilometragem
+          mileage_placeholder: '15000'
+          mileage_unit: Unidade
+          model: Modelo
+          model_placeholder: Camry
+          year: Ano
+          year_placeholder: '2023'
+        overview:
+          current_price: Preço atual
+          make_model: Marca e modelo
+          mileage: Quilometragem
+          purchase_price: Preço de compra
+          trend: Tendência
+          unknown: Desconhecido
+          year: Ano
+    create:
+      success: Nova conta criada com sucesso
+    destroy:
+      success: Conta excluída com sucesso
+    edit:
+      edit: Editar %{account}
+    empty:
+      empty_message: Adicione uma conta via conexão, importação ou inserção manual.
+      new_account: Nova conta
+      no_accounts: Nenhuma conta ainda
+    form:
+      accountable_type: Tipo de conta
+      balance: Saldo atual
+      institution: Instituição financeira
+      mode: Modo de rastreamento de valor
+      mode_prompt: Selecione um modo
+      name_label: Nome da conta
+      name_placeholder: Exemplo de nome da conta
+      type_prompt: Selecione um tipo
+      ungrouped: "(nenhum)"
+    header:
+      accounts: Contas
+      manage: Gerenciar contas
+      new: Nova conta
+    index:
+      accounts: Contas
+      add_institution: Adicionar instituição
+      new_account: Nova conta
+    institution_accounts:
+      add_account_to_institution: Adicionar nova conta
+      confirm_accept: Excluir instituição
+      confirm_body: Não se preocupe, nenhuma das contas dentro desta instituição será afetada por esta exclusão. As contas serão desagrupadas e todos os dados históricos permanecerão intactos.
+      confirm_title: Excluir instituição financeira?
+      delete: Excluir instituição
+      edit: Editar instituição
+      has_issues: Problema detectado, verifique as contas
+      new_account: Adicionar conta
+      status: Última sincronização há %{last_synced_at}
+      status_never: Requer sincronização de dados
+      syncing: Sincronizando...
+    institutionless_accounts:
+      other_accounts: Outras contas
+    menu:
+      confirm_accept: Excluir "%{name}"
+      confirm_body_html: "<p>Ao excluir esta conta, você apagará seu histórico de valores, afetando vários aspectos de sua conta geral. Esta ação terá um impacto direto nos seus cálculos de patrimônio líquido e nos gráficos da conta.</p><br /> <p>Após a exclusão, não será possível restaurar as informações da conta, pois você precisará adicioná-la como uma nova conta.</p>"
+      confirm_title: Excluir conta?
+      edit: Editar
+      import: Importar transações
+    new:
+      connected_entry: Vincular conta com segurança via Plaid (em breve)
+      csv_entry: Importar CSV de contas
+      manual_entry: Inserir conta manualmente
+      title: Adicionar uma conta
+    show:
+      cash: Dinheiro
+      holdings: Investimentos
+      no_change: Sem alteração
+      overview: Visão geral
+      total_owed: Total devido
+      total_value: Valor total
+      trades: Transações
+      transactions: Transações
+      value: Valor
+    summary:
+      new: Novo
+      no_assets: Nenhum ativo encontrado
+      no_assets_description: Adicione um ativo via conexão, importação ou inserção manual.
+      no_liabilities: Nenhum passivo encontrado
+      no_liabilities_description: Adicione um passivo via conexão, importação ou inserção manual.
+    sync_all:
+      success: Contas adicionadas à fila de sincronização com sucesso.
+    sync_all_button:
+      sync: Sincronizar tudo
+    update:
+      success: Conta atualizada
+  credit_cards:
+    create:
+      success: Cartão de crédito criado com sucesso
+    update:
+      success: Cartão de crédito atualizado com sucesso
+  loans:
+    create:
+      success: Empréstimo criado com sucesso
+    update:
+      success: Empréstimo atualizado com sucesso

--- a/config/locales/views/categories/pt-BR.yml
+++ b/config/locales/views/categories/pt-BR.yml
@@ -1,0 +1,22 @@
+---
+pt-BR:
+  categories:
+    category:
+      delete: Excluir categoria
+      edit: Editar categoria
+    create:
+      success: Nova categoria de transação criada com sucesso
+    edit:
+      edit: Editar categoria
+    form:
+      placeholder: Nome da categoria
+    index:
+      categories: Categorias
+      empty: Nenhuma categoria encontrada
+      new: Nova categoria
+    menu:
+      loading: Carregando...
+    new:
+      new_category: Nova categoria
+    update:
+      success: Categoria de transação atualizada com sucesso

--- a/config/locales/views/category/deletions/pt-BR.yml
+++ b/config/locales/views/category/deletions/pt-BR.yml
@@ -1,0 +1,15 @@
+---
+pt-BR:
+  category:
+    deletions:
+      create:
+        success: Categoria de transação excluída com sucesso
+      new:
+        category: Categoria
+        delete_and_leave_uncategorized: Excluir "%{category_name}" e deixar não categorizado
+        delete_and_recategorize: Excluir "%{category_name}" e atribuir nova categoria
+        delete_category: Excluir categoria?
+        explanation: Ao excluir esta categoria, todas as transações que possuem a categoria "%{category_name}" 
+          serão descategorizadas. Em vez de deixá-las não categorizadas, você 
+          também pode atribuir uma nova categoria abaixo.
+        replacement_category_prompt: Selecione a categoria

--- a/config/locales/views/category/dropdowns/pt-BR.yml
+++ b/config/locales/views/category/dropdowns/pt-BR.yml
@@ -1,0 +1,12 @@
+---
+pt-BR:
+  category:
+    dropdowns:
+      row:
+        delete: Excluir categoria
+        edit: Editar categoria
+      show:
+        add_new: Adicionar nova
+        clear: Limpar
+        no_categories: Nenhuma categoria encontrada
+        search_placeholder: Procurar

--- a/config/locales/views/layout/pt-BR.yml
+++ b/config/locales/views/layout/pt-BR.yml
@@ -1,0 +1,21 @@
+---
+pt-BR:
+  layouts:
+    auth:
+      existing_account: Já tem uma conta?
+      no_account: Novo no Maybe?
+      sign_in: Entrar
+      sign_up: Criar conta
+      your_account: Sua conta
+    footer:
+      privacy_policy: Política de Privacidade
+      terms_of_service: Termos de Serviço
+    issues:
+      action: Como resolver este problema
+      description: Descrição do Problema
+    sidebar:
+      accounts: Contas
+      dashboard: Painel
+      new_account: Nova conta
+      portfolio: Portfólio
+      transactions: Transações

--- a/config/locales/views/merchants/pt-BR.yml
+++ b/config/locales/views/merchants/pt-BR.yml
@@ -1,0 +1,26 @@
+---
+pt-BR:
+  merchants:
+    create:
+      success: Novo estabelecimento criado com sucesso
+    destroy:
+      success: Estabelecimento excluído com sucesso
+    edit:
+      title: Editar estabelecimento
+    form:
+      name_placeholder: Nome do estabelecimento
+    index:
+      empty: Nenhum estabelecimento ainda
+      new: Novo estabelecimento
+      title: Estabelecimentos
+    merchant:
+      confirm_accept: Excluir estabelecimento
+      confirm_body: Tem certeza que deseja excluir este estabelecimento? A remoção deste
+        estabelecimento irá desvincular todas as transações associadas e pode afetar seus relatórios.
+      confirm_title: Excluir estabelecimento?
+      delete: Excluir estabelecimento
+      edit: Editar estabelecimento
+    new:
+      title: Novo estabelecimento
+    update:
+      success: Estabelecimento atualizado com sucesso

--- a/config/locales/views/pages/pt-BR.yml
+++ b/config/locales/views/pages/pt-BR.yml
@@ -1,0 +1,23 @@
+---
+pt-BR:
+  pages:
+    changelog:
+      title: O que há de novo
+    dashboard:
+      allocation_chart:
+        assets: Ativos
+        debts: Dívidas
+      fallback_greeting: Bem-vindo de volta, amigo
+      greeting: Bem-vindo de volta, %{name}
+      import: Importar
+      income: Renda
+      investing: Investimento (em breve...)
+      net_worth: Patrimônio líquido
+      new: Nova conta
+      no_transactions: Você não tem transações recentes
+      savings_rate: Taxa de poupança
+      spending: Gastos
+      subtitle: Aqui está o que está acontecendo hoje
+      title: Dashboard
+      transactions: Transações recentes
+      view_all: Ver tudo

--- a/config/locales/views/settings/hostings/pt-BR.yml
+++ b/config/locales/views/settings/hostings/pt-BR.yml
@@ -1,0 +1,39 @@
+---
+pt-BR:
+  settings:
+    hostings:
+      invite_code_settings:
+        description: Todo novo usuário que ingressa na sua instância do Maybe só pode
+          fazê-lo através de um código de convite
+        generate_tokens: Gerar novo código
+        generated_tokens: Códigos gerados
+        title: Exigir código de convite para novos cadastros
+      provider_settings:
+        description: Configurar definições para seu provedor de hospedagem
+        render_deploy_hook_label: URL do Hook de Deploy do Render
+        render_deploy_hook_placeholder: https://api.render.com/deploy/srv-xyz...
+        title: Configurações do Provedor
+      show:
+        general: Configurações Gerais
+        invites: Códigos de Convite
+        title: Auto-Hospedagem
+      synth_settings:
+        api_calls_used: "%{used} / %{limit} chamadas de API utilizadas (%{percentage})"
+        description: Insira a chave de API fornecida pelo Synth
+        label: Chave de API
+        placeholder: Digite sua chave de API aqui
+        plan: "plano %{plan}"
+        title: Configurações do Synth
+      update:
+        failure: Valor de configuração inválido
+        success: Configurações atualizadas
+      upgrade_settings:
+        description: Configure como seu aplicativo recebe atualizações
+        latest_commit_description: Atualizar automaticamente para o último commit (instável)
+        latest_commit_title: Último Commit
+        latest_release_description: Atualizar automaticamente para a versão mais recente
+          (estável)
+        latest_release_title: Última Versão
+        manual_description: Você controla quando baixar e instalar atualizações
+        manual_title: Manual
+        title: Atualização Automática

--- a/config/locales/views/settings/pt-BR.yml
+++ b/config/locales/views/settings/pt-BR.yml
@@ -1,0 +1,64 @@
+---
+pt-BR:
+  settings:
+    billings:
+      show:
+        manage_subscription_button: Gerenciar assinatura
+        page_title: Faturamento
+        subscribe_button: Assinar
+        subscription_subtitle: Gerencie sua assinatura e detalhes de faturamento
+        subscription_title: Gerenciar assinatura
+    nav:
+      accounts_label: Contas
+      billing_label: Faturamento
+      categories_label: Categorias
+      feedback_label: Feedback
+      general_section_title: Geral
+      imports_label: Importações
+      logout: Sair
+      merchants_label: Comerciantes
+      other_section_title: Mais
+      preferences_label: Preferências
+      profile_label: Conta
+      self_hosting_label: Auto-hospedagem
+      tags_label: Tags
+      transactions_section_title: Transações
+      whats_new_label: Novidades
+    nav_link_large:
+      next: Próximo
+      previous: Voltar
+    preferences:
+      show:
+        country: País
+        currency: Moeda
+        date_format: Formato de data
+        general_subtitle: Configure suas preferências
+        general_title: Geral
+        language: Idioma
+        page_title: Preferências
+        theme_dark: Escuro
+        theme_light: Claro
+        theme_subtitle: Escolha um tema preferido para o aplicativo (em breve...)
+        theme_system: Sistema
+        theme_title: Tema
+    profiles:
+      show:
+        confirm_delete:
+          body: Tem certeza de que deseja excluir sua conta permanentemente? Esta ação é irreversível.
+          title: Excluir conta?
+        danger_zone_title: Zona de perigo
+        delete_account: Excluir conta
+        delete_account_warning: Excluir sua conta removerá permanentemente todos os seus dados e não poderá ser desfeito.
+        first_name: Primeiro nome
+        household_form_input_placeholder: Insira o nome da família
+        household_form_label: Nome da família
+        household_subtitle: Convide membros da família, parceiros e outras pessoas. Os convidados podem fazer login em sua casa e acessar suas contas compartilhadas.
+        household_title: Família
+        last_name: Último nome
+        page_title: Conta
+        profile_subtitle: Personalize como você aparece no Maybe
+        profile_title: Perfil
+        save: Salvar
+      user_avatar_field:
+        accepted_formats: JPG ou PNG. 5MB max.
+        choose: Escolher

--- a/config/locales/views/shared/pt-BR.yml
+++ b/config/locales/views/shared/pt-BR.yml
@@ -1,0 +1,24 @@
+---
+pt-BR:
+  shared:
+    confirm_modal:
+      accept: Confirmar
+      body_html: "<p>Você não poderá desfazer essa decisão</p>"
+      cancel: Cancelar
+      title: Tem certeza?
+    money_field:
+      label: Quantia
+    no_account_empty_state:
+      new_account: Nova conta
+      no_account_subtitle: Como nenhuma conta foi adicionada, não há dados para exibir. Adicione suas primeiras contas para começar a visualizar os dados do painel.
+      no_account_title: Ainda não há contas
+    subscribe_prompt:
+      guarantee: Somos pessoas razoáveis aqui. Se você não estiver satisfeito ou algo não funcionar, nós o reembolsaremos com prazer.
+      subscribe: Atualizar sua conta
+      subtitle: Para continuar usando o Maybe, assine!
+      title: Atualizar
+    upgrade_notification:
+      app_upgraded: O aplicativo foi atualizado para %{version}.
+      dismiss: Dismiss
+      new_version_available: Uma nova versão do Maybe está disponível para atualização.
+      upgrade_now: Atualizar agora

--- a/config/locales/views/transactions/en.yml
+++ b/config/locales/views/transactions/en.yml
@@ -38,6 +38,8 @@ en:
       edit_merchants: Edit merchants
       edit_tags: Edit tags
       import: Import
+      new: New transaction
+      index: Transactions
     index:
       transaction: transaction
     mark_transfers:
@@ -78,3 +80,7 @@ en:
         less_than: less than
     unmark_transfers:
       success: Transfer removed
+    summary:
+      total_transactions: Total transactions
+      income: Income
+      expenses: Expenses

--- a/config/locales/views/transactions/pt-BR.yml
+++ b/config/locales/views/transactions/pt-BR.yml
@@ -1,0 +1,86 @@
+---
+pt-BR:
+  transactions:
+    bulk_delete:
+      success: "%{count} transações excluídas"
+    bulk_edit:
+      cancel: Cancelar
+      category_label: Categoria
+      category_placeholder: Selecione uma categoria
+      date_label: Data
+      details: Detalhes
+      merchant_label: Estabelecimento
+      merchant_placeholder: Selecione um estabelecimento
+      note_label: Observações
+      note_placeholder: Digite uma observação que será aplicada às transações selecionadas
+      overview: Visão geral
+      save: Salvar
+    bulk_update:
+      success: "%{count} transações atualizadas"
+    create:
+      success: Nova transação criada com sucesso
+    form:
+      account: Conta
+      account_prompt: Selecione uma conta
+      amount: Valor
+      category: Categoria
+      category_prompt: Selecione uma categoria
+      date: Data
+      description: Descrição
+      description_placeholder: Descreva a transação
+      expense: Despesa
+      income: Receita
+      submit: Adicionar transação
+      transfer: Transferência
+    header:
+      edit_categories: Editar categorias
+      edit_imports: Editar importações
+      edit_merchants: Editar estabelecimentos
+      edit_tags: Editar tags
+      import: Importar
+      new: Nova transação
+      index: Transações
+    index:
+      transaction: transação
+    mark_transfers:
+      success: Marcada como transferência
+    new:
+      new_transaction: Nova transação
+    searches:
+      filters:
+        amount_filter:
+          equal_to: Igual a
+          greater_than: Maior que
+          less_than: Menor que
+          placeholder: '0'
+        badge:
+          expense: Despesa
+          income: Receita
+          on_or_after: em ou após %{date}
+          on_or_before: em ou antes de %{date}
+          transfer: Transferência
+        type_filter:
+          expense: Despesa
+          income: Receita
+          transfer: Transferência
+      menu:
+        account_filter: Conta
+        amount_filter: Valor
+        apply: Aplicar
+        cancel: Cancelar
+        category_filter: Categoria
+        clear_filters: Limpar filtros
+        date_filter: Data
+        merchant_filter: Estabelecimento
+        tag_filter: Tag
+        type_filter: Tipo
+      search:
+        equal_to: igual a
+        greater_than: maior que
+        less_than: menor que
+    unmark_transfers:
+      success: Transferência removida
+    summary:
+      total_transactions: Total de transações
+      income: Receita
+      expenses: Despesas


### PR DESCRIPTION
Add Brazilian Portuguese translation, creating all new pt-BR.yml translation files and keys on screens that do not have translation.
![Captura de tela de 2024-10-23 16-21-09](https://github.com/user-attachments/assets/3f8a2425-7dda-4770-9414-14e34ec8f0da)
