### PR TITLE
Feature | Filter on uncategorized transactions

### DIFF
--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -6,6 +6,6 @@ module CategoriesHelper
   end
 
   def family_categories
-    [null_category].concat(Current.family.categories.alphabetically)
+    [ null_category ].concat(Current.family.categories.alphabetically)
   end
 end

--- a/app/helpers/categories_helper.rb
+++ b/app/helpers/categories_helper.rb
@@ -4,4 +4,8 @@ module CategoriesHelper
       name: "Uncategorized",
       color: Category::UNCATEGORIZED_COLOR
   end
+
+  def family_categories
+    [null_category].concat(Current.family.categories.alphabetically)
+  end
 end

--- a/app/models/account/transaction.rb
+++ b/app/models/account/transaction.rb
@@ -14,7 +14,7 @@ class Account::Transaction < ApplicationRecord
     def search(params)
       query = all
       if params[:categories].present?
-        if params[:categories].exclude?('Uncategorized')
+        if params[:categories].exclude?("Uncategorized")
           query = query
                     .joins(:category)
                     .where(categories: { name: params[:categories] })

--- a/app/models/account/transaction.rb
+++ b/app/models/account/transaction.rb
@@ -13,7 +13,19 @@ class Account::Transaction < ApplicationRecord
   class << self
     def search(params)
       query = all
-      query = query.joins(:category).where(categories: { name: params[:categories] }) if params[:categories].present?
+      if params[:categories].present?
+        if params[:categories].exclude?('Uncategorized')
+          query = query
+                    .joins(:category)
+                    .where(categories: { name: params[:categories] })
+        else
+          query = query
+                    .left_joins(:category)
+                    .where(categories: { name: params[:categories] })
+                    .or(query.where(category_id: nil))
+        end
+      end
+
       query = query.joins(:merchant).where(merchants: { name: params[:merchants] }) if params[:merchants].present?
 
       if params[:tags].present?

--- a/app/views/transactions/searches/filters/_category_filter.html.erb
+++ b/app/views/transactions/searches/filters/_category_filter.html.erb
@@ -5,7 +5,7 @@
     <%= lucide_icon("search", class: "w-5 h-5 text-gray-500 absolute inset-y-0 left-2 top-1/2 transform -translate-y-1/2") %>
   </div>
   <div class="my-2" id="list" data-list-filter-target="list">
-    <% Current.family.categories.alphabetically.each do |category| %>
+    <% family_categories.each do |category| %>
       <div class="filterable-item flex items-center gap-2 p-2" data-filter-name="<%= category.name %>">
         <%= form.check_box :categories,
                            {

--- a/test/system/transactions_test.rb
+++ b/test/system/transactions_test.rb
@@ -6,7 +6,7 @@ class TransactionsTest < ApplicationSystemTestCase
 
     Account::Entry.delete_all # clean slate
 
-    create_transaction("one", 12.days.ago.to_date, 100)
+    @uncategorized_transaction = create_transaction("one", 12.days.ago.to_date, 100)
     create_transaction("two", 10.days.ago.to_date, 100)
     create_transaction("three", 9.days.ago.to_date, 100)
     create_transaction("four", 8.days.ago.to_date, 100)
@@ -59,6 +59,30 @@ class TransactionsTest < ApplicationSystemTestCase
       assert_text @transaction.account.name
       assert_text @transaction.account_transaction.category.name
     end
+  end
+
+  test "can filter uncategorized transactions" do
+    find("#transaction-filters-button").click
+
+    within "#transaction-filters-menu" do
+      click_button "Category"
+      check("Uncategorized")
+      click_button "Apply"
+    end
+
+    assert_selector "#" + dom_id(@uncategorized_transaction), count: 1
+    assert_no_selector("#" + dom_id(@transaction))
+
+    find("#transaction-filters-button").click
+
+    within "#transaction-filters-menu" do
+      click_button "Category"
+      check(@transaction.account_transaction.category.name)
+      click_button "Apply"
+    end
+
+    assert_selector "#" + dom_id(@transaction), count: 1
+    assert_selector "#" + dom_id(@uncategorized_transaction), count: 1
   end
 
   test "all filters work and empty state shows if no match" do


### PR DESCRIPTION
### Why?
- Related feature request: [Feature: filter on uncategorized transactions #1354](https://github.com/maybe-finance/maybe/issues/1354)
In the transaction index, in the filter by category, it is not possible to filter those transactions that do not have any assigned category.

### What?
- On the filter view side, the Uncategorized category was added among the options.
- In the model, the query is updated to be able to filter transactions without category.

### Test
When filtering only on uncategorized transactions, these should appear and those with a category should not appear. When adding a category, both those without and those with a category should appear.

### Screenshot
![image](https://github.com/user-attachments/assets/a332f4a7-6157-419b-9621-68832d80a6d4)
![image](https://github.com/user-attachments/assets/b22d2448-d5e0-445f-ba28-f1c16c672797)


co-author @nicogaldamez 