### PR TITLE
Bug: Edited transactions on the home page get a checkbox

### DIFF
--- a/app/controllers/account/transactions_controller.rb
+++ b/app/controllers/account/transactions_controller.rb
@@ -16,7 +16,9 @@ class Account::TransactionsController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to account_entry_path(@account, @entry), notice: t(".success") }
-      format.turbo_stream { render turbo_stream: turbo_stream.replace(@entry) }
+      format.turbo_stream {
+        render turbo_stream: turbo_stream.replace(@entry, partial: @entry.to_partial_path, locals: { entry: @entry, **partial_options })
+      }
     end
   end
 
@@ -53,5 +55,15 @@ class Account::TransactionsController < ApplicationController
                 permitted_params[:amount] = amount_value
               end
             end
+    end
+
+    def partial_options
+      params
+        .require(:partial_options)
+        .permit(:selectable)
+        .to_h
+        .each_with_object({}) do |(k, v), acc|
+          acc[k.to_sym] = v
+        end
     end
 end

--- a/app/views/account/transactions/_transaction.html.erb
+++ b/app/views/account/transactions/_transaction.html.erb
@@ -1,6 +1,8 @@
 <%# locals: (entry:, selectable: true, editable: true, short: false, show_tags: false, **opts) %>
 <% transaction, account = entry.account_transaction, entry.account %>
 
+<% selectable = ActiveModel::Type::Boolean.new.cast(selectable) %>
+
 <div class="grid grid-cols-12 items-center text-gray-900 text-sm font-medium p-4">
   <% name_col_span = unconfirmed_transfer?(entry) ? "col-span-10" : short ? "col-span-6" : "col-span-4" %>
   <div class="pr-10 flex items-center gap-4 <%= name_col_span %>">
@@ -21,7 +23,7 @@
             <%= content_tag :p, entry.name %>
           <% else %>
             <%= link_to entry_name(entry),
-                        account_entry_path(account, entry),
+                        account_entry_path(account, entry, selectable:),
                         data: { turbo_frame: "drawer", turbo_prefetch: false },
                         class: "hover:underline hover:text-gray-800" %>
           <% end %>

--- a/app/views/account/transactions/show.html.erb
+++ b/app/views/account/transactions/show.html.erb
@@ -31,6 +31,9 @@
               url: account_transaction_path(account, entry),
               class: "space-y-2",
               data: { controller: "auto-submit-form" } do |f| %>
+
+          <%= hidden_field_tag :partial_options_selectable, params[:selectable], name: 'partial_options[selectable]' %>
+
           <%= f.text_field :name,
                 label: t(".name_label"),
                 "data-auto-submit-form-target": "auto" %>


### PR DESCRIPTION
### Why?

* Fixes #1386 
On the home page there is a list of recent transactions. None of these transactions have a checkbox. If a transaction is edited it then gets a checkbox, which doesn't have any options once selected

### What?

* I added a parameter to the transaction form to specify whether the corresponding row returned by the Turbo Stream response should include a checkbox or not.

### What should we test?
* When editing a transaction from the recent transactions list, the updated row should no longer have a checkbox.
* When editing a transaction from the transactions list, the updated row should still have a checkbox.
