### PR TITLE
Auto naming of Transfer Transaction

### DIFF
--- a/app/controllers/account/transfers_controller.rb
+++ b/app/controllers/account/transfers_controller.rb
@@ -14,8 +14,7 @@ class Account::TransfersController < ApplicationController
     @transfer = Account::Transfer.build_from_accounts from_account, to_account, \
                                              date: transfer_params[:date],
                                              amount: transfer_params[:amount].to_d,
-                                             currency: transfer_params[:currency],
-                                             name: transfer_params[:name]
+                                             currency: transfer_params[:currency]
 
     if @transfer.save
       @transfer.entries.each(&:sync_account_later)

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -28,8 +28,6 @@ class Account::Entry < ApplicationRecord
       .where("er.rate IS NOT NULL OR account_entries.currency = ?", currency)
   }
 
-  before_save :assign_transfer_name, if: -> { marked_as_transfer && transfer.present? }
-
   def sync_account_later
     if destroyed?
       sync_start_date = previous_entry&.date
@@ -224,9 +222,5 @@ class Account::Entry < ApplicationRecord
         current: amount_money,
         previous: previous_entry&.amount_money,
         favorable_direction: account.favorable_direction
-    end
-
-    def assign_transfer_name
-      self.name = transfer.name
     end
 end

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -28,6 +28,8 @@ class Account::Entry < ApplicationRecord
       .where("er.rate IS NOT NULL OR account_entries.currency = ?", currency)
   }
 
+  before_save :assign_transfer_name, if: -> { marked_as_transfer && transfer.present? }
+
   def sync_account_later
     if destroyed?
       sync_start_date = previous_entry&.date
@@ -222,5 +224,9 @@ class Account::Entry < ApplicationRecord
         current: amount_money,
         previous: previous_entry&.amount_money,
         favorable_direction: account.favorable_direction
+    end
+
+    def assign_transfer_name
+      self.name = transfer.name
     end
 end

--- a/app/models/account/transfer.rb
+++ b/app/models/account/transfer.rb
@@ -43,12 +43,12 @@ class Account::Transfer < ApplicationRecord
   end
 
   class << self
-    def build_from_accounts(from_account, to_account, date:, amount:, currency:, name:)
+    def build_from_accounts(from_account, to_account, date:, amount:, currency:)
       outflow = from_account.entries.build \
         amount: amount.abs,
         currency: from_account.currency,
         date: date,
-        name: name,
+        name: "Transfer to #{to_account.name}",
         marked_as_transfer: true,
         entryable: Account::Transaction.new
 
@@ -56,7 +56,7 @@ class Account::Transfer < ApplicationRecord
         amount: amount.abs * -1,
         currency: from_account.currency,
         date: date,
-        name: name,
+        name: "Transfer from #{from_account.name}",
         marked_as_transfer: true,
         entryable: Account::Transaction.new
 

--- a/app/views/account/transfers/_form.html.erb
+++ b/app/views/account/transfers/_form.html.erb
@@ -26,7 +26,6 @@
   </section>
 
   <section class="space-y-2">
-    <%= f.text_field :name, value: transfer.name, label: t(".description"), placeholder: t(".description_placeholder"), required: true %>
     <%= f.collection_select :from_account_id, Current.family.accounts.alphabetically, :id, :name, { prompt: t(".select_account"), label: t(".from") }, required: true %>
     <%= f.collection_select :to_account_id, Current.family.accounts.alphabetically, :id, :name, { prompt: t(".select_account"), label: t(".to") }, required: true %>
     <%= f.money_field :amount, label: t(".amount"), required: true, hide_currency: true %>

--- a/config/locales/views/account/transfers/en.yml
+++ b/config/locales/views/account/transfers/en.yml
@@ -9,8 +9,6 @@ en:
       form:
         amount: Amount
         date: Date
-        description: Description
-        description_placeholder: Transfer from Checking to Savings
         expense: Expense
         from: From
         income: Income

--- a/test/system/transfers_test.rb
+++ b/test/system/transfers_test.rb
@@ -17,7 +17,6 @@ class TransfersTest < ApplicationSystemTestCase
     click_on "Transfer"
     assert_text "New transfer"
 
-    fill_in "Description", with: "Transfer txn name"
     select checking_name, from: "From"
     select savings_name, from: "To"
     fill_in "account_transfer[amount]", with: 500


### PR DESCRIPTION
#### Why?
- Fixes #1384 

#### What?
- Removed the Description field from the transfer form.
- Removed redundant locale to fix the test
- Started saving Account::Entry name as  `Transfer from {from_account} to {to_account}` .Earlier it was saved as `Transfer from Originator to Receiver` or whatever user inputs in the Transfer form.

#### Probable Concerns
- After removing the description field from the transfer form, there is a slight UI shift when moving from expense form to the Transfer form, I am not fixing this in this PR though

https://github.com/user-attachments/assets/344791ae-16b0-4034-9cbc-4100b4837282
- This change might be needing a test case, though I am not so familiar with the testing part and also not able to find any instructions in the README.