### PR TITLE
Adds condition to skip link to transaction form if it's not editable

### DIFF
--- a/app/views/account/transactions/_transaction.html.erb
+++ b/app/views/account/transactions/_transaction.html.erb
@@ -17,7 +17,7 @@
         </div>
 
         <div class="truncate text-gray-900">
-          <% if entry.new_record? %>
+          <% if entry.new_record? || !editable %>
             <%= content_tag :p, entry.name %>
           <% else %>
             <%= link_to entry_name(entry),


### PR DESCRIPTION
### Why?

Fixes https://github.com/maybe-finance/maybe/issues/1386

On the home page there is a list of recent transactions. None of these transactions have a checkbox. If a transaction is edited it then gets a checkbox, which doesn't have any options once selected

### What?

* I display the title of the transaction as a link only if it's editable.

More discussion in https://github.com/maybe-finance/maybe/pull/1391

### What should we test?
* When editing a transaction from the recent transactions list, the updated row should no longer have a checkbox.
* When editing a transaction from the transactions list, the updated row should still have a checkbox.