### PR TITLE
Exclude inactive accounts from net-worth calculation and from sidebar

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -19,7 +19,7 @@ class PagesController < ApplicationController
     @top_earners = snapshot_account_transactions[:top_earners]
     @top_savers = snapshot_account_transactions[:top_savers]
 
-    @accounts = Current.family.accounts
+    @accounts = Current.family.accounts.active
     @account_groups = @accounts.by_group(period: @period, currency: Current.family.currency)
     @transaction_entries = Current.family.entries.account_transactions.limit(6).reverse_chronological
 

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -52,7 +52,7 @@ module AccountsHelper
   end
 
   def account_groups(period: nil)
-    assets, liabilities = Current.family.accounts.by_group(currency: Current.family.currency, period: period || Period.last_30_days).values_at(:assets, :liabilities)
+    assets, liabilities = Current.family.accounts.active.by_group(currency: Current.family.currency, period: period || Period.last_30_days).values_at(:assets, :liabilities)
     [ assets.children.sort_by(&:name), liabilities.children.sort_by(&:name) ].flatten
   end
 


### PR DESCRIPTION
Fix #1419