### PR TITLE
Skip account valuation on entry balance_after_entry

### DIFF
--- a/app/helpers/account/entries_helper.rb
+++ b/app/helpers/account/entries_helper.rb
@@ -14,9 +14,9 @@ module Account::EntriesHelper
 
   def entries_by_date(entries, selectable: true, totals: false)
     entries.group_by(&:date).map do |date, grouped_entries|
-      # Valuations always go first, then sort by created_at
+      # Valuations always go first, then sort by created_at desc
       sorted_entries = grouped_entries.sort_by do |entry|
-        [ entry.account_valuation? ? 0 : 1, entry.created_at ]
+        [ entry.account_valuation? ? 0 : 1, -entry.created_at.to_i ]
       end
 
       content = capture do

--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -60,6 +60,8 @@ class Account::Entry < ApplicationRecord
     else
       new_balance = prior_balance
       entries_on_entry_date.each do |e|
+        next if e.account_valuation?
+
         change = e.amount
         change = account.liability? ? change : -change
         new_balance += change
@@ -79,7 +81,7 @@ class Account::Entry < ApplicationRecord
   end
 
   def entries_on_entry_date
-    account.entries.where(date: date).order(created_at: :desc)
+    account.entries.where(date: date).order(created_at: :asc)
   end
 
   class << self

--- a/test/models/account/entry_test.rb
+++ b/test/models/account/entry_test.rb
@@ -99,4 +99,15 @@ class Account::EntryTest < ActiveSupport::TestCase
     assert create_transaction(amount: -10).inflow?
     assert create_transaction(amount: 10).outflow?
   end
+
+  test "balance_after_entry skips account valuations" do
+    family = families(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+
+    new_valuation = create_valuation(account: account, amount: 1)
+    transaction = create_transaction(date: new_valuation.date, account: account, amount: -100)
+
+
+    assert_equal Money.new(100), transaction.balance_after_entry
+  end
 end


### PR DESCRIPTION
### Why?
Partially Fixes [1418](https://github.com/maybe-finance/maybe/issues/1418)

When creating a transaction after an account valuation, the latter should not be considered in the calculation of the balance of the entry.

### What?
Change the entry model in order to skip the account valuation amount in the balance_after_entry
![image](https://github.com/user-attachments/assets/3b3739ab-63f2-4c09-923b-6fe05562db43)

### What should we test?
Create an account valuation and a transaction after, and ensure the account valuation is not part of the calculation of the balance_after_entry within the context of the transaction.

### Pending
There is another error related with [Issue 1418](https://github.com/maybe-finance/maybe/issues/1418), related to the way in which the amount of an account valuation is calculated, which in turn can cause the incorrect icon to be displayed.

Paired with @nicogaldamez 