### PR TITLE
Fixes: Sidebar only displays cash balance for investment accounts, not full value

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -47,7 +47,7 @@ class Account < ApplicationRecord
             accounts.each do |account|
               group.add_value_node(
                 account,
-                account.balance_money.exchange_to(currency, fallback_rate: 0),
+                account.value,
                 account.series(period: period, currency: currency)
               )
             end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -109,7 +109,7 @@ class Family < ApplicationRecord
   end
 
   def assets
-    Money.new(accounts.active.assets.map { |account| account.balance_money.exchange_to(currency, fallback_rate: 0) }.sum, currency)
+    Money.new(accounts.active.assets.map { |account| account.value }.sum, currency)
   end
 
   def liabilities

--- a/app/views/accounts/_account_list.html.erb
+++ b/app/views/accounts/_account_list.html.erb
@@ -40,7 +40,7 @@
           <% end %>
         </div>
         <div class="flex flex-col items-end font-medium text-right ml-auto">
-          <p><%= format_money account.balance_money %></p>
+          <p><%= format_money account.value %></p>
           <div class="flex items-center gap-1">
             <div class="h-3 w-8">
               <%= render "shared/sparkline", series: account_value_node.series, id: dom_id(account, :list_sparkline) %>


### PR DESCRIPTION
fixes #1369 

PR fixes current issue with sidebar only showing cash value and not full account value.

<img width="864" alt="Screenshot 2024-11-08 at 3 20 44 PM" src="https://github.com/user-attachments/assets/a3553f61-523e-4fae-a9de-ee8db8824ea2">
