### PR TITLE
Adds a common DE date format

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,7 @@ module ApplicationHelper
   def date_format_options
     [
       [ "DD-MM-YYYY", "%d-%m-%Y" ],
+      [ "DD.MM.YY", "%d.%m.%Y" ],
       [ "MM-DD-YYYY", "%m-%d-%Y" ],
       [ "YYYY-MM-DD", "%Y-%m-%d" ],
       [ "DD/MM/YYYY", "%d/%m/%Y" ],

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
+    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YY", "%d.%m.%y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
+    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YY", "%d.%m.%y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">


### PR DESCRIPTION
## Overview

This PR introduces a new date format which is very frequent in Germany Bank exports.
`DD.MM.YY`

Example of a popular Germany Bank
![Screenshot 2024-11-10 at 21 00 45](https://github.com/user-attachments/assets/8bc85ec1-a005-4d77-8621-011efe6312ba)


## Changes

- Adds a new date format to import configuration


![Screenshot 2024-11-10 at 20 59 29](https://github.com/user-attachments/assets/75a23752-36e5-4339-963e-e928c0f10b27)
