### PR TITLE
Fix the value shown on a balance update transaction

### DIFF
--- a/app/views/account/valuations/show.html.erb
+++ b/app/views/account/valuations/show.html.erb
@@ -40,7 +40,8 @@
           <%= f.money_field :amount,
                 label: t(".amount"),
                 auto_submit: true,
-                disable_currency: true %>
+                disable_currency: true,
+                value: entry.amount.abs %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
I noticed today that when editing a balance update transaction the amount shown didn't respect the currency steps. After some playing around and looking at the normal transaction (which worked correctly), I believe this fix is appropriate. I tested this locally and it works great (I tested USD and JPY for different precision values from currencies.yml)

This is where I saw the `value` field for the `money_field` of a normal transaction: https://github.com/maybe-finance/maybe/blob/56ab092f6b89fa4873d97c285811b137c3918717/app/views/account/transactions/show.html.erb#L57

Before/After:
<p>
<img width="280" alt="image" src="https://github.com/user-attachments/assets/feeaf669-70db-42c2-9e5c-c53b31b748d2">
<img width="280" alt="image" src="https://github.com/user-attachments/assets/817101f7-57f0-43a9-9460-e3fd33d2e2b3">
</p>
Fixes #1447
