### PR TITLE
:memo: docs(self-hosting): Add deployment tutorial and link for Alibaba cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are 3 primary ways to use the Maybe app:
 
 1. Managed (easiest) - _coming soon..._
 2. [One-click deploy](docs/hosting/one-click-deploy.md)
+3. [One-click deploy with alibaba cloud](docs/hosting/one-click-deploy-alibaba-cloud.md)
 3. [Self-host with Docker](docs/hosting/docker.md)
 
 ## Local Development Setup

--- a/docs/hosting/one-click-deploy-alibaba-cloud.md
+++ b/docs/hosting/one-click-deploy-alibaba-cloud.md
@@ -1,0 +1,33 @@
+---
+title: Deploy Maybe on Alibaba Cloud
+description: Learn how to deploy the Maybe application on Alibaba Cloud, including clicking the deploy button, and other operations.
+tags:
+- Alibaba Cloud
+- Maybe
+- Alibaba Cloud Compute Nest
+---
+
+# Deploy Maybe with Alibaba Cloud
+
+If you want to deploy Maybe on Alibaba Cloud, you can follow the steps below:
+
+## Alibaba Cloud Deployment Process
+
+<Steps>
+
+### Prepare Your Alibaba Cloud Account
+Go to the [Alibaba Cloud official website](https://aliyun.com) to register for an account.  
+
+
+### One-click to deploy
+
+[![][deploy-button-image]][deploy-link]
+
+### Once deployed, you can start using it
+Based on the prompts in the deployment interface, fill in the necessary parameters, and once the deployment is successful, you can start using it.
+
+
+</Steps>
+
+[deploy-button-image]: https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest-en.svg
+[deploy-link]: https://computenest.console.aliyun.com/service/instance/create/default?type=user&ServiceName=Maybe%E7%A4%BE%E5%8C%BA%E7%89%88


### PR DESCRIPTION
Add deployment tutorial and link for Alibaba cloud
A more detailed deployment tutorial can be found in the official Alibaba Cloud interface for deploying Maybe.
As shown in the figure below.
![image](https://github.com/user-attachments/assets/6c21ae03-2723-4733-bcba-03db58eb511b)
