### PR TITLE
fix for semi-colon separated CSVs

### DIFF
--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -32,7 +32,7 @@ class Import::UploadsController < ApplicationController
       require "csv"
 
       begin
-        csv = CSV.parse(str || "", headers: true)
+        csv = CSV.parse(str || "", headers: true, col_sep: upload_params[:col_sep])
         return false if csv.headers.empty?
         return false if csv.count == 0
         true


### PR DESCRIPTION
Fix for this issue: https://github.com/maybe-finance/maybe/issues/1462

`csv_valid?` wasn't using the submitted `col_sep` argument, so semi-colon separated CSVs were failing to be validated.