### PR TITLE
Allow custom column separator for CSV parsing in uploads controller

### DIFF
--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -32,7 +32,7 @@ class Import::UploadsController < ApplicationController
       require "csv"
 
       begin
-        csv = CSV.parse(str || "", headers: true)
+        csv = CSV.parse(str || "", headers: true, col_sep: upload_params[:col_sep])
         return false if csv.headers.empty?
         return false if csv.count == 0
         true

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -14,7 +14,8 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
   test "uploads valid csv by copy and pasting" do
     patch import_upload_url(@import), params: {
       import: {
-        raw_file_str: file_fixture("imports/valid.csv").read
+        raw_file_str: file_fixture("imports/valid.csv").read,
+        col_sep: ","
       }
     }
 
@@ -25,7 +26,8 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
   test "uploads valid csv by file" do
     patch import_upload_url(@import), params: {
       import: {
-        csv_file: file_fixture_upload("imports/valid.csv")
+        csv_file: file_fixture_upload("imports/valid.csv"),
+        col_sep: ","
       }
     }
 
@@ -36,7 +38,8 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
   test "invalid csv cannot be uploaded" do
     patch import_upload_url(@import), params: {
       import: {
-        csv_file: file_fixture_upload("imports/invalid.csv")
+        csv_file: file_fixture_upload("imports/invalid.csv"),
+        col_sep: ","
       }
     }
 


### PR DESCRIPTION
Fix for this issue: https://github.com/maybe-finance/maybe/issues/1462

`csv_valid?` wasn't using the submitted `col_sep` argument, so semicolon separated CSVs were failing to be validated.