### PR TITLE
Make encryption config optional for self hosting users

### DIFF
--- a/app/controllers/concerns/store_location.rb
+++ b/app/controllers/concerns/store_location.rb
@@ -18,6 +18,8 @@ private
     if request.fullpath == session[:return_to]
       session.delete(:return_to)
       redirect_to fallback_path
+    else
+      head :not_found
     end
   end
 

--- a/app/controllers/concerns/store_location.rb
+++ b/app/controllers/concerns/store_location.rb
@@ -5,6 +5,8 @@ module StoreLocation
     helper_method :previous_path
     before_action :store_return_to
     after_action :clear_previous_path
+
+    rescue_from ActiveRecord::RecordNotFound, with: :handle_not_found
   end
 
   def previous_path
@@ -12,6 +14,12 @@ module StoreLocation
   end
 
 private
+  def handle_not_found
+    if request.fullpath == session[:return_to]
+      session.delete(:return_to)
+      redirect_to fallback_path
+    end
+  end
 
   def store_return_to
     if params[:return_to].present?

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -1,7 +1,10 @@
 class PlaidItem < ApplicationRecord
   include Plaidable, Syncable
 
-  encrypts :access_token, deterministic: true
+  if Rails.application.credentials.active_record_encryption.present?
+    encrypts :access_token, deterministic: true
+  end
+
   validates :name, :access_token, presence: true
 
   before_destroy :remove_plaid_item

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,10 @@ module Maybe
     config.i18n.fallbacks = true
 
     config.app_mode = (ENV["SELF_HOSTED"] == "true" || ENV["SELF_HOSTING_ENABLED"] == "true" ? "self_hosted" : "managed").inquiry
+
+    # Self hosters can optionally set their own encryption keys if they want to use ActiveRecord encryption.
+    if Rails.application.credentials.active_record_encryption.present?
+      config.active_record.encryption = Rails.application.credentials.active_record_encryption
+    end
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,6 +94,4 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
-
-  config.active_record.encryption = Rails.application.credentials.active_record_encryption
 end


### PR DESCRIPTION
In the context of the Maybe app, the encryption module is used in a very narrow scope—for properly storing access tokens for Plaid Items.

Given that self hosters will generally not be managing their own Plaid setup, they will not need the encryption module for a functioning app.  The configuration for this module adds quite a bit of overhead to the initial setup for self hosters, so this PR makes it entirely optional.  We can adjust this in the future if encryption becomes mandatory for self hosters, but I do not foresee that becoming an issue for quite some time.