### PR TITLE
Don't refresh page when transaction details are edited

### DIFF
--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -22,6 +22,10 @@ module Syncable
     raise NotImplementedError, "Subclasses must implement the `sync_data` method"
   end
 
+  def post_sync
+    # no-op, syncable can optionally provide implementation
+  end
+
   def sync_error
     latest_sync.error
   end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -32,6 +32,10 @@ class Family < ApplicationRecord
     end
   end
 
+  def post_sync
+    broadcast_refresh
+  end
+
   def syncing?
     super || accounts.manual.any?(&:syncing?) || plaid_items.any?(&:syncing?)
   end

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -42,6 +42,10 @@ class PlaidItem < ApplicationRecord
     end
   end
 
+  def post_sync
+    family.broadcast_refresh
+  end
+
   def destroy_later
     update!(scheduled_for_deletion: true)
     DestroyJob.perform_later(self)


### PR DESCRIPTION
When users edit transactions or trades, we trigger an "account sync" so that the historical graph and other account details reflect the updates that were made.

The sync process previously triggered a global page refresh when it completed to ensure the user is seeing updated data.

While this PR is not a perfect solution (some parts of the page will require a refresh after editing), it offers a much better user experience while editing individual transactions (while preserving the sync trigger).

Additionally, this provides a more flexible interface for different _types_ of syncs to run code after the sync has succeeded/failed:

```rb
  def perform
    start!

    begin
      syncable.sync_data(start_date: start_date)
      complete!
    rescue StandardError => error
      fail! error
      raise error if Rails.env.development?
    ensure
       # Syncable can optionally implement this method to run code after the sync regardless of the sync's outcome
       syncable.post_sync
    end
  end
```