### PR TITLE
Calculates trend based on previous transaction's balance on the same date

### DIFF
--- a/app/models/account/entry.rb
+++ b/app/models/account/entry.rb
@@ -15,6 +15,7 @@ class Account::Entry < ApplicationRecord
   validates :date, comparison: { greater_than: -> { min_supported_date } }
 
   scope :chronological, -> { order(:date, :created_at) }
+  scope :not_account_valuations, -> { where.not(entryable_type: "Account::Valuation") }
   scope :reverse_chronological, -> { order(date: :desc, created_at: :desc) }
   scope :without_transfers, -> { where(marked_as_transfer: false) }
   scope :with_converted_amount, ->(currency) {
@@ -54,6 +55,13 @@ class Account::Entry < ApplicationRecord
     account.balances.find_by(date: date - 1)&.balance || 0
   end
 
+  def prior_entry_balance
+    entries_on_entry_date
+      .not_account_valuations
+      .last
+      &.balance_after_entry || 0
+  end
+
   def balance_after_entry
     if account_valuation?
       Money.new(amount, currency)
@@ -75,7 +83,7 @@ class Account::Entry < ApplicationRecord
   def trend
     TimeSeries::Trend.new(
       current: balance_after_entry,
-      previous: Money.new(prior_balance, currency),
+      previous: Money.new(prior_entry_balance, currency),
       favorable_direction: account.favorable_direction
     )
   end

--- a/test/models/account/entry_test.rb
+++ b/test/models/account/entry_test.rb
@@ -110,4 +110,15 @@ class Account::EntryTest < ActiveSupport::TestCase
 
     assert_equal Money.new(100), transaction.balance_after_entry
   end
+
+  test "prior_entry_balance returns last transaction entry balance" do
+    family = families(:empty)
+    account = family.accounts.create! name: "Test", balance: 0, currency: "USD", accountable: Depository.new
+
+    new_valuation = create_valuation(account: account, amount: 1)
+    transaction = create_transaction(date: new_valuation.date, account: account, amount: -100)
+
+
+    assert_equal Money.new(100), transaction.prior_entry_balance
+  end
 end


### PR DESCRIPTION
### Why?

- Balance was calculated using the previous date's balance instead of the previous transaction's balance.
- Fixes #1418

### What?

Add a new method to the `Entry` model to calculate the balance based on the last entry's balance from the same day

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/ead7db10-3fe2-4fc8-824e-573870c5acc4">


### What should we test?

Create two entries: an account valuation and an expense (or income) on the same day. The account valuation entry's trend and amount should use the balance of the other entry instead of the previous day's balance.


Paired with @bruno-costanzo 