### PR TITLE
Feature: Add support for customized synth URL from env variable

### DIFF
--- a/app/models/provider/synth.rb
+++ b/app/models/provider/synth.rb
@@ -174,7 +174,7 @@ class Provider::Synth
     SecurityInfoResponse = Struct.new :info, :success?, :error, :raw_response, keyword_init: true
 
     def base_url
-      "https://api.synthfinance.com"
+      ENV["SYNTH_URL"] || "https://api.synthfinance.com"
     end
 
     def app_name


### PR DESCRIPTION
Usage:

```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: maybe
spec:
  template:
    spec:
      containers:
      - name: maybe
        image: evlos/maybe:latest
        env:
        - name: SYNTH_URL
          value: http://192.168.233.107:30800
```
