### PR TITLE
Replaced Native Scrollbars with Tailwind Scrollbars on Windows

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -163,3 +163,19 @@
     background: #a6a6a6;
   }
 }
+
+/* Custom scrollbar implementation for Windows browsers */
+.windows {
+  ::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #d6d6d6;
+    border-radius: 10px;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #a6a6a6;
+  }  
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,12 +30,12 @@ class ApplicationController < ActionController::Base
     def detect_os
       user_agent = request.user_agent
       @os = case user_agent
-            when /Windows/i then "windows"
-            when /Macintosh/i then "mac"
-            when /Linux/i then "linux"
-            when /Android/i then "android"
-            when /iPhone|iPad/i then "ios"
-            else ""
-            end
+      when /Windows/i then "windows"
+      when /Macintosh/i then "mac"
+      when /Linux/i then "linux"
+      when /Android/i then "android"
+      when /iPhone|iPad/i then "ios"
+      else ""
+      end
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :require_upgrade?, :subscription_pending?
 
+  before_action :detect_os
+
   private
     def require_upgrade?
       return false if self_hosted?
@@ -23,5 +25,17 @@ class ApplicationController < ActionController::Base
       return "turbo_rails/frame" if turbo_frame_request?
 
       "with_sidebar"
+    end
+
+    def detect_os
+      user_agent = request.user_agent
+      @os = case user_agent
+            when /Windows/i then "windows"
+            when /Macintosh/i then "mac"
+            when /Linux/i then "linux"
+            when /Android/i then "android"
+            when /iPhone|iPad/i then "ios"
+            else ""
+            end
     end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="h-full" lang="en">
+<html class="h-full <%= @os %>" lang="en">
   <head>
     <title><%= content_for(:title) || "Maybe" %></title>
 


### PR DESCRIPTION
Continuing from #1439 

## Changes Made:
- Added a new `detect_os` function in [application_controller.rb](https://github.com/maybe-finance/maybe/compare/main...jestinjoshi:maybe:windows-scrollbar?expand=1#diff-766c34fd6533171eaf54300c153f89d6002c35c02cfc9c5b219251f85180ad07)
- The detected OS will be added as a class to the `html` tag
- Based on the added class, the scrollbar styling will be applied (can be scaled to other OS if required)