### PR TITLE
Use account currency instead of hardcoded USD

### DIFF
--- a/app/views/account/trades/_form.html.erb
+++ b/app/views/account/trades/_form.html.erb
@@ -28,7 +28,7 @@
       </div>
 
       <div data-trade-form-target="priceInput">
-        <%= form.money_field :price, label: t(".price"), currency_value_override: "USD", disable_currency: true %>
+        <%= form.money_field :price, label: t(".price"), currency_value_override: @account.currency, disable_currency: true %>
       </div>
     </div>
 


### PR DESCRIPTION
Currently USD is hardcoded. Causing it be shown on UI even when User Default currency or Account currency is not USD.