### PR TITLE
Preserve pagination on entry updates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -166,4 +166,24 @@ module ApplicationHelper
 
     cookies[:admin] == "true"
   end
+
+  def custom_pagy_url_for(pagy, page, current_path: nil)
+    if current_path.blank?
+      pagy_url_for(pagy, page)
+    else
+      uri = URI.parse(current_path)
+      params = URI.decode_www_form(uri.query || "").to_h
+
+      # Delete existing page param if it exists
+      params.delete("page")
+      # Add new page param unless it's page 1
+      params["page"] = page unless page == 1
+
+      if params.empty?
+        uri.path
+      else
+        "#{uri.path}?#{URI.encode_www_form(params)}"
+      end
+    end
+  end
 end

--- a/app/models/concerns/providable.rb
+++ b/app/models/concerns/providable.rb
@@ -23,10 +23,8 @@ module Providable
     end
 
     def synth_provider
-      @synth_provider ||= begin
-        api_key = self_hosted? ? Setting.synth_api_key : ENV["SYNTH_API_KEY"]
-        api_key.present? ? Provider::Synth.new(api_key) : nil
-      end
+      api_key = self_hosted? ? Setting.synth_api_key : ENV["SYNTH_API_KEY"]
+      api_key.present? ? Provider::Synth.new(api_key) : nil
     end
 
     private

--- a/app/views/account/entries/index.html.erb
+++ b/app/views/account/entries/index.html.erb
@@ -84,7 +84,7 @@
           </div>
 
           <div class="p-4 bg-white rounded-bl-lg rounded-br-lg">
-            <%= render "pagination", pagy: @pagy %>
+            <%= render "pagination", pagy: @pagy, current_path: account_path(@account, page: params[:page]) %>
           </div>
         </div>
       <% end %>

--- a/app/views/accounts/show/_activity.html.erb
+++ b/app/views/accounts/show/_activity.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (account:) %>
 
-<%= turbo_frame_tag dom_id(account, :entries), src: account_entries_path(account_id: account.id) do %>
+<%= turbo_frame_tag dom_id(account, :entries), src: account_entries_path(account_id: account.id, page: params[:page]) do %>
   <%= render "account/entries/loading" %>
 <% end %>

--- a/app/views/application/_pagination.html.erb
+++ b/app/views/application/_pagination.html.erb
@@ -1,9 +1,11 @@
-<%# locals: (pagy:) %>
+<%# locals: (pagy:, current_path: nil) %>
 <nav class="flex w-full items-center justify-between">
   <div class="flex items-center gap-1">
     <div>
       <% if pagy.prev %>
-        <%= link_to pagy_url_for(pagy, pagy.prev), class: "inline-flex items-center p-2 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+        <%= link_to custom_pagy_url_for(pagy, pagy.prev, current_path: current_path), 
+              class: "inline-flex items-center p-2 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700",
+              data: (current_path ? { turbo_frame: "_top" } : {}) do %>
           <%= lucide_icon("chevron-left", class: "w-5 h-5 text-gray-500") %>
         <% end %>
       <% else %>
@@ -15,11 +17,15 @@
     <div class="rounded-xl p-1 bg-gray-25">
       <% pagy.series.each do |series_item| %>
         <% if series_item.is_a?(Integer) %>
-          <%= link_to pagy_url_for(pagy, series_item), class: "rounded-md px-2 py-1 inline-flex items-center text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+          <%= link_to custom_pagy_url_for(pagy, series_item, current_path: current_path), 
+                class: "rounded-md px-2 py-1 inline-flex items-center text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700",
+                data: (current_path ? { turbo_frame: "_top" } : {}) do %>
             <%= series_item %>
           <% end %>
         <% elsif series_item.is_a?(String) %>
-          <%= link_to pagy_url_for(pagy, series_item), class: "rounded-md px-2 py-1 bg-white border border-alpha-black-25 shadow-xs inline-flex items-center text-sm font-medium text-gray-900" do %>
+          <%= link_to custom_pagy_url_for(pagy, series_item, current_path: current_path), 
+                class: "rounded-md px-2 py-1 bg-white border border-alpha-black-25 shadow-xs inline-flex items-center text-sm font-medium text-gray-900",
+                data: (current_path ? { turbo_frame: "_top" } : {}) do %>
             <%= series_item %>
           <% end %>
         <% elsif series_item == :gap %>
@@ -29,7 +35,9 @@
     </div>
     <div>
       <% if pagy.next %>
-        <%= link_to pagy_url_for(pagy, pagy.next), class: "inline-flex items-center p-2 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700" do %>
+        <%= link_to custom_pagy_url_for(pagy, pagy.next, current_path: current_path), 
+              class: "inline-flex items-center p-2 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700",
+              data: (current_path ? { turbo_frame: "_top" } : {}) do %>
           <%= lucide_icon("chevron-right", class: "w-5 h-5 text-gray-500") %>
         <% end %>
       <% else %>
@@ -40,16 +48,16 @@
     </div>
   </div>
   <div class="flex items-center gap-4">
-    <%= form_with url: url_for,
+    <%= form_with url: custom_pagy_url_for(pagy, pagy.page, current_path: current_path),
                 method: :get,
                 class: "flex items-center gap-4",
                 data: { controller: "auto-submit-form" } do |f| %>
-    <%= f.label :per_page, t(".rows_per_page"), class: "text-sm text-gray-500" %>
-    <%= f.select :per_page,
+      <%= f.label :per_page, t(".rows_per_page"), class: "text-sm text-gray-500" %>
+      <%= f.select :per_page,
                  options_for_select(["10", "20", "30", "50"], pagy.limit),
                  {},
                  class: "py-1.5 pr-8 text-sm text-gray-900 font-medium border border-gray-200 rounded-lg focus:border-gray-900 focus:ring-gray-900 focus-visible:ring-gray-900",
                  data: { "auto-submit-form-target": "auto" } %>
-  <% end %>
+    <% end %>
   </div>
 </nav>


### PR DESCRIPTION
Fixes #1562 

This is far from a perfect solution to a tricky problem.

On the account page, we are rendering the "Activity View" inside a turbo frame.  Within that Turbo frame, we have the pagination controls.  By default, clicking a new page will update the query param _within the frame_ by default, which means that when the Transaction drawer is closed (and the page auto-refreshes to reload the list), the page that was changed within the turbo frame is not preserved because the top-level page is not aware of it.

There are two potential solutions I can think of, which I've chosen the 1st for simplicity:

1. Pass the `params[:page]` down into the Turbo frame and use a custom URL pagination helper for pagination controls that is aware of the top-level page we're currently on.
2. Stop refreshing the page when editing drawers are closed
  a. Since editing a transaction/trade/balance affects the _entire_ Account history, we're simply refreshing the page entirely rather than attempting to apply Turbo stream updates to the affected parts (most of the page)
  b. If we removed this behavior, the user would not see their most recent edits in the activity list, which I think is less ideal than this page refresh

Keeping the entry lists / pagination params synced while editing in the drawer is something we'll have to address with more precision at a later date, but think this is a decent tradeoff for now to keep things as simple as possible.