### PR TITLE
Fix: breaking change after bumping hotwire-livereload to 2.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development, :test do
 end
 
 group :development do
-  gem "hotwire-livereload"
+  gem "hotwire-livereload", github: "kirillplatonov/hotwire-livereload"
   gem "letter_opener"
   gem "ruby-lsp-rails"
   gem "web-console"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/kirillplatonov/hotwire-livereload.git
+  revision: 4ff247dd3e6b57abe439e240de676a4f48e875e7
+  specs:
+    hotwire-livereload (2.0.0)
+      actioncable (>= 7.0.0)
+      listen (>= 3.0.0)
+      railties (>= 7.0.0)
+
+GIT
   remote: https://github.com/maybe-finance/lucide-rails.git
   revision: 272e5fb8418ea458da3995d6abe0ba0ceee9c9f0
   specs:
@@ -185,10 +194,6 @@ GEM
       thor (>= 1.0.0)
     hashdiff (1.1.1)
     highline (3.0.1)
-    hotwire-livereload (2.0.0)
-      actioncable (>= 7.0.0)
-      listen (>= 3.0.0)
-      railties (>= 7.0.0)
     hotwire_combobox (0.3.2)
       rails (>= 7.0.7.2)
       stimulus-rails (>= 1.2)
@@ -495,7 +500,7 @@ DEPENDENCIES
   faraday-multipart
   faraday-retry
   good_job
-  hotwire-livereload
+  hotwire-livereload!
   hotwire_combobox
   i18n-tasks
   image_processing (>= 1.2)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,14 +6,13 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": Rails.env.production? ? "reload" : "" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": Rails.env.production? ? "reload" : ""  %>
 
     <%= javascript_include_tag "https://cdn.plaid.com/link/v2/stable/link-initialize.js" %>
     <%= combobox_style_tag %>
 
     <%= javascript_importmap_tags %>
-    <%= hotwire_livereload_tags if Rails.env.development? %>
     <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 
     <meta name="viewport"


### PR DESCRIPTION
Merging #1582 broke app. This PR fixes it by incorporating braking changes. 