### PR TITLE
Fix budget money formatting

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -10,7 +10,7 @@ class Budget < ApplicationRecord
 
   monetize :budgeted_spending, :expected_income, :allocated_spending,
            :actual_spending, :available_to_spend, :available_to_allocate,
-           :estimated_spending, :estimated_income, :actual_income
+           :estimated_spending, :estimated_income, :actual_income, :remaining_expected_income
 
   class << self
     def for_date(date)
@@ -19,12 +19,13 @@ class Budget < ApplicationRecord
 
     def find_or_bootstrap(family, date: Date.current)
       Budget.transaction do
-        budget = Budget.find_or_create_by(
+        budget = Budget.find_or_create_by!(
           family: family,
           start_date: date.beginning_of_month,
-          end_date: date.end_of_month,
-          currency: family.currency
-        )
+          end_date: date.end_of_month
+        ) do |b|
+          b.currency = family.currency
+        end
 
         budget.sync_budget_categories
 

--- a/app/views/budget_categories/_budget_category_form.html.erb
+++ b/app/views/budget_categories/_budget_category_form.html.erb
@@ -8,7 +8,7 @@
   <div class="text-sm mr-3">
     <p class="text-gray-900 font-medium mb-0.5"><%= budget_category.category.name %></p>
 
-    <p class="text-gray-500"><%= format_money(budget_category.category.avg_monthly_total, precision: 0) %>/m average</p>
+    <p class="text-gray-500"><%= format_money(Money.new(budget_category.category.avg_monthly_total, budget_category.currency), precision: 0) %>/m average</p>
   </div>
 
   <div class="ml-auto">

--- a/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
+++ b/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
@@ -7,14 +7,14 @@
 
   <div class="text-sm mr-3">
     <p class="text-gray-900 font-medium mb-0.5"><%= budget_category.category.name %></p>
-    <p class="text-gray-500"><%= format_money(budget_category.category.avg_monthly_total, precision: 0) %>/m average</p>
+    <p class="text-gray-500"><%= format_money(Money.new(budget_category.category.avg_monthly_total, budget_category.category.family.currency), precision: 0) %>/m average</p>
   </div>
 
   <div class="ml-auto">
     <div class="form-field w-[120px]">
       <div class="flex items-center">
         <span class="text-gray-400 text-sm mr-2">$</span>
-        <%= text_field_tag :uncategorized, budget_category.budgeted_spending, autocomplete: "off", class: "form-field__input text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none", disabled: true %>
+        <%= text_field_tag :uncategorized, budget_category.budgeted_spending_money, autocomplete: "off", class: "form-field__input text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none", disabled: true %>
       </div>
     </div>
   </div>

--- a/app/views/budgets/_budget_donut.html.erb
+++ b/app/views/budgets/_budget_donut.html.erb
@@ -9,7 +9,7 @@
         </div>
 
         <div class="text-3xl font-medium <%= budget.available_to_spend.negative? ? "text-red-500" : "text-gray-900" %>">
-          <%= format_money(budget.actual_spending) %>
+          <%= format_money(budget.actual_spending_money) %>
         </div>
 
         <%= link_to edit_budget_path(budget), class: "btn btn--secondary flex items-center gap-1 mt-2" do %>

--- a/app/views/budgets/_budgeted_summary.html.erb
+++ b/app/views/budgets/_budgeted_summary.html.erb
@@ -22,9 +22,9 @@
         <p class="text-gray-500"><%= format_money(budget.actual_income_money) %> earned</p>
         <p class="font-medium">
           <% if budget.remaining_expected_income.negative? %>
-            <span class="text-green-500"><%= format_money(budget.remaining_expected_income.abs) %> over</span>
+            <span class="text-green-500"><%= format_money(budget.remaining_expected_income_money.abs) %> over</span>
           <% else %>
-            <span class="text-gray-900"><%= format_money(budget.remaining_expected_income) %> left</span>
+            <span class="text-gray-900"><%= format_money(budget.remaining_expected_income_money) %> left</span>
           <% end %>
         </p>
       </div>

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -12,8 +12,7 @@
         <%= form.fields_for :family do |family_form| %>
           <%= family_form.select :currency,
             currencies_for_select.map { |currency| [ "#{currency.name} (#{currency.iso_code})", currency.iso_code ] },
-            { label: t(".currency") },
-            { data: { auto_submit_form_target: "auto" } } %>
+            { label: t(".currency") }, disabled: true %>
 
           <%= family_form.select :locale,
             language_options,


### PR DESCRIPTION
This PR fixes a few cases where budgets are not displaying values in the family currency.

In addition, this PR disables the ability for the user to change their family currency after onboarding:

- Changing family currency requires all accounts, transactions, and budgets to be converted to the new currency
- We will need a "migration" flow in the future (see #1627) to allow the user to switch family currency, which will includes several bulk updates to their data.  For now, to avoid confusion, disabling currency changes is the most straightforward option.