### PR TITLE
Update snapshot_account_transactions to only give transactions by filtering on entryable_type

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -110,6 +110,7 @@ class Family < ApplicationRecord
                       )
                       .where("account_entries.date >= ?", period.date_range.begin)
                       .where("account_entries.date <= ?", period.date_range.end)
+                      .where("account_entries.entryable_type = 'Account::Transaction'")
                       .where("transfers.id IS NULL")
                       .group("accounts.id")
                       .having("SUM(ABS(account_entries.amount)) > 0")


### PR DESCRIPTION
Add where statement to account_transactions overview to only give transactions and not valuations

fixes: #1628 