### PR TITLE
Do not raise on Plaid item not found exceptions for item deletions

### DIFF
--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -131,5 +131,7 @@ class PlaidItem < ApplicationRecord
 
     def remove_plaid_item
       plaid_provider.remove_item(access_token)
+    rescue StandardError => e
+      Rails.logger.warn("Failed to remove Plaid item #{id}: #{e.message}")
     end
 end

--- a/test/models/plaid_item_test.rb
+++ b/test/models/plaid_item_test.rb
@@ -18,4 +18,16 @@ class PlaidItemTest < ActiveSupport::TestCase
       @plaid_item.destroy
     end
   end
+
+  test "if plaid item not found, silently continues with deletion" do
+    @plaid_provider = mock
+
+    PlaidItem.stubs(:plaid_provider).returns(@plaid_provider)
+
+    @plaid_provider.expects(:remove_item).with(@plaid_item.access_token).raises(Plaid::ApiError.new("Item not found"))
+
+    assert_difference "PlaidItem.count", -1 do
+      @plaid_item.destroy
+    end
+  end
 end


### PR DESCRIPTION
If a user tries to delete a Plaid Item, we call `remove_item` so that we're not continuing to pay for this within Plaid per their best practices.

If the PlaidItem deletion fails _after_ this has been called and is tried _again_, we receive an `ITEM_NOT_FOUND` from Plaid (because it has already been removed).  This then prevents the user from fully deleting the item within Maybe, indefinitely.

This fix makes it so the item deletion is handled gracefully with a warning rather than throwing an exception.