### PR TITLE
Align cascade delete behavior for transfers

### DIFF
--- a/db/migrate/20250120210449_align_transfer_cascade_behavior.rb
+++ b/db/migrate/20250120210449_align_transfer_cascade_behavior.rb
@@ -1,0 +1,14 @@
+class AlignTransferCascadeBehavior < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :transfers, :account_transactions, column: :inflow_transaction_id
+    remove_foreign_key :transfers, :account_transactions, column: :outflow_transaction_id
+  
+    add_foreign_key :transfers, :account_transactions,
+                    column: :inflow_transaction_id,
+                    on_delete: :cascade
+  
+    add_foreign_key :transfers, :account_transactions,
+                    column: :outflow_transaction_id,
+                    on_delete: :cascade
+  end
+end

--- a/db/migrate/20250120210449_align_transfer_cascade_behavior.rb
+++ b/db/migrate/20250120210449_align_transfer_cascade_behavior.rb
@@ -2,11 +2,11 @@ class AlignTransferCascadeBehavior < ActiveRecord::Migration[7.2]
   def change
     remove_foreign_key :transfers, :account_transactions, column: :inflow_transaction_id
     remove_foreign_key :transfers, :account_transactions, column: :outflow_transaction_id
-  
+
     add_foreign_key :transfers, :account_transactions,
                     column: :inflow_transaction_id,
                     on_delete: :cascade
-  
+
     add_foreign_key :transfers, :account_transactions,
                     column: :outflow_transaction_id,
                     on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_10_012347) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_20_210449) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -696,7 +696,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_10_012347) do
   add_foreign_key "sessions", "users"
   add_foreign_key "taggings", "tags"
   add_foreign_key "tags", "families"
-  add_foreign_key "transfers", "account_transactions", column: "inflow_transaction_id"
-  add_foreign_key "transfers", "account_transactions", column: "outflow_transaction_id"
+  add_foreign_key "transfers", "account_transactions", column: "inflow_transaction_id", on_delete: :cascade
+  add_foreign_key "transfers", "account_transactions", column: "outflow_transaction_id", on_delete: :cascade
   add_foreign_key "users", "families"
 end


### PR DESCRIPTION
While #1644 addressed the cascade logic for deleting transactions that belong to a transfer, certain bulk operations like `account.destroy` where there are many associated transfers results in foreign key violations.  This PR aligns the DB cascade behavior with our `dependent: :destroy` behavior within the Account::Transaction model.