### PR TITLE
Adjust queues to prioritize account syncs, handle missing current day values

### DIFF
--- a/app/jobs/auto_upgrade_job.rb
+++ b/app/jobs/auto_upgrade_job.rb
@@ -1,5 +1,5 @@
 class AutoUpgradeJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_low
 
   def perform(*args)
     raise_if_disabled

--- a/app/jobs/destroy_job.rb
+++ b/app/jobs/destroy_job.rb
@@ -1,5 +1,5 @@
 class DestroyJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_low
 
   def perform(model)
     model.destroy

--- a/app/jobs/enrich_data_job.rb
+++ b/app/jobs/enrich_data_job.rb
@@ -1,5 +1,5 @@
 class EnrichDataJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_high
 
   def perform(account)
     account.enrich_data

--- a/app/jobs/fetch_security_info_job.rb
+++ b/app/jobs/fetch_security_info_job.rb
@@ -1,5 +1,5 @@
 class FetchSecurityInfoJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_low
 
   def perform(security_id)
     return unless Security.security_info_provider.present?

--- a/app/jobs/import_job.rb
+++ b/app/jobs/import_job.rb
@@ -1,5 +1,5 @@
 class ImportJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_medium
 
   def perform(import)
     import.publish

--- a/app/jobs/sync_job.rb
+++ b/app/jobs/sync_job.rb
@@ -1,5 +1,5 @@
 class SyncJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_medium
 
   def perform(sync)
     sync.perform

--- a/app/jobs/user_purge_job.rb
+++ b/app/jobs/user_purge_job.rb
@@ -1,5 +1,5 @@
 class UserPurgeJob < ApplicationJob
-  queue_as :default
+  queue_as :latency_low
 
   def perform(user)
     user.purge

--- a/app/models/time_series.rb
+++ b/app/models/time_series.rb
@@ -37,6 +37,14 @@ class TimeSeries
       series: self
   end
 
+  def empty?
+    values.empty?
+  end
+
+  def has_current_day_value?
+    values.any? { |v| v.date == Date.current }
+  end
+
   # `as_json` returns the data shape used by D3 charts
   def as_json
     {

--- a/app/views/accounts/chart.html.erb
+++ b/app/views/accounts/chart.html.erb
@@ -17,15 +17,19 @@
   </div>
 
   <div class="h-64">
-    <% if series %>
+    <% if series.has_current_day_value? %>
       <div
         id="lineChart"
         class="w-full h-full"
         data-controller="time-series-chart"
         data-time-series-chart-data-value="<%= series.to_json %>"></div>
+    <% elsif series.empty? %>
+      <div class="w-full h-full flex items-center justify-center">
+        <p class="text-gray-500 text-sm">No data available for the selected period.</p>
+      </div>
     <% else %>
       <div class="w-full h-full flex items-center justify-center">
-        <p class="text-gray-500">No data available for the selected period.</p>
+        <p class="text-gray-500 text-sm animate-pulse">Calculating latest balance data...</p>
       </div>
     <% end %>
   </div>

--- a/app/views/pages/dashboard/_net_worth_chart.html.erb
+++ b/app/views/pages/dashboard/_net_worth_chart.html.erb
@@ -1,12 +1,16 @@
 <%# locals: (series:) %>
-<% if series %>
+<% if series.has_current_day_value? %>
   <div
     id="netWorthChart"
     class="w-full flex-1 min-h-52"
     data-controller="time-series-chart"
     data-time-series-chart-data-value="<%= series.to_json %>"></div>
+<% elsif series.empty? %>
+  <div class="w-full h-full flex items-center justify-center">
+    <p class="text-gray-500 text-sm">No data available for the selected period.</p>
+  </div>
 <% else %>
   <div class="w-full h-full flex items-center justify-center">
-    <p class="text-gray-500">No data available for the selected period.</p>
+    <p class="text-gray-500 text-sm animate-pulse">Calculating latest balance data...</p>
   </div>
 <% end %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,8 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  # 3 connections for Puma, 8 for GoodJob (in async mode, the default for self-hosters) = 11 connections
+  pool: <%= ENV.fetch("DB_POOL_SIZE") { 11 } %>
   host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
   port: <%= ENV.fetch("DB_PORT") { "5432" } %>
   user: <%= ENV.fetch("POSTGRES_USER") { nil } %>

--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -11,6 +11,14 @@ Rails.application.configure do
     }
   end
 
+  # 5 queue threads + 3 for job listener, cron, executor = 8 threads allocated
+  config.queues = {
+    "latency_low" => { max_threads: 1, priority: 10 }, # ~30s jobs
+    "latency_low,latency_medium" => { max_threads: 2, priority: 5 }, # ~1-2 min jobs
+    "latency_low,latency_medium,latency_high" => { max_threads: 1, priority: 1 }, # ~5+ min jobs
+    "*" => { max_threads: 1, priority: 0 } # fallback queue
+  }
+
   # Auth for jobs admin dashboard
   ActiveSupport.on_load(:good_job_application_controller) do
     before_action do


### PR DESCRIPTION
There have been several complaints in #1524 of how certain account graphs do not include the latest day's balance.  While I have not been able to reproduce this, I think a potential cause is self-hosted queues skipping the background jobs that generate the balances.

**Insufficient DB connections**

Currently, we are running self-hosted GoodJob jobs in `async` mode, which means the queue is running in the same process as the web server.  This is sufficient for most self hosted instances since the number of requests to the server are very low (~1-5 total users).

That said, when in `async` mode, the _required_ DB pool size increases:

- 3 connections for the Puma web server
- 5 connections for GoodJob queue threads
- 3 connections for GoodJob listener, cron, and executor

This means we need `11` total DB connections to support a self hosted instance.  My _guess_ is that the missing / sporadic graph balances is a result of jobs exhausting the connection pool, timing out, and not syncing the latest balances.

This PR increases the _default_ DB pool size to `11` to accommodate this.

If running GoodJob in `external` mode (default for production, and used for our hosted instance), each process requires a different number of DB connections:

```bash
DB_POOL_SIZE=8 bundle exec good_job start
DB_POOL_SIZE=3 bundle exec rails server
```

**Loading data state**

To further protect against the case where an account is missing / not properly syncing the latest balances, I have added a "loading" state to the graphs to let the user know that we're still calculating the latest balances.

In an ideal state, this _shouldn't_ be shown often because we have logic to sync user accounts immediately when they login.  The thinking here is that we'd rather show "loading" than an invalid balance graph that leads a user to think their finances are something different than they actually are.

![CleanShot 2025-01-24 at 13 24 48](https://github.com/user-attachments/assets/38e4c186-7719-4687-87e0-e9473f5c22bf)

**Queue latencies**

In addition to the above changes, I have implemented 3 queues based on latency:

- `latency_low` - jobs that take ~30 seconds or less
- `latency_medium` - jobs that take 1-2 minutes (i.e. Sync accounts job)
- `latency_high` - jobs that take 5+ minutes (i.e. EnrichDataJob)

This should drastically speed up account syncs by offloading the expensive and slow EnrichDataJob to a separate worker pool entirely.