### PR TITLE
Reuse Correct Expense Total Calculation

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -113,7 +113,7 @@ class Budget < ApplicationRecord
   end
 
   def actual_spending
-    budget_categories.reject(&:subcategory?).sum(&:actual_spending)
+    expense_categories_with_totals.total_money.amount
   end
 
   def available_to_spend


### PR DESCRIPTION
fixes #1663 

## Root Cause:
* "Spent" and "Expenses" values on the budget page are being calculated by different functions
* The value under "Spent" is calculated with `budget.actual_spending`, which does not include Uncategorized spending
  * in #1663, notice that `62%` of the `$3007` is missing
  * was able to recreate this locally
![Screenshot 2025-01-26 110409](https://github.com/user-attachments/assets/993bf159-cbbe-407d-b128-90c006c504e9)

* This is because Uncategorized category is not present on the `budget_categories` array in the `budget` class
![Screenshot 2025-01-26 222721](https://github.com/user-attachments/assets/6d74c8ed-082d-4e11-bce7-fb844ed560fc)

## Proposed Fix:
* Reuse `expense_categories_with_totals.total_money` which already calculates monthly expense totals, including Uncategorized spending
* Convert `Money` to `amount` to stay consistent with expected return type of `actual_spending`

### Alternatively
Could fix by explicit inclusion of uncategorized expenses in `actual_spending`, but `expense_categories_with_totals.total_money` already calculates the desired value, and from the issue it seems we do expect the results to be the same, so I implemented the proposal above instead in this PR.

## Results
After implementing the fix, the totals are consistent
![Screenshot 2025-01-26 124105](https://github.com/user-attachments/assets/eb9a007b-00f4-47b9-98e2-45e4c01932dc)
