### PR TITLE
Add More Timelines

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -8,6 +8,18 @@ module AccountsHelper
 
     days_apart = (end_date - start_date).to_i
 
+    # Handle specific cases
+    if start_date == Date.current.beginning_of_week && end_date == Date.current
+      return "Current Week to Date (CWD)"
+    elsif start_date == Date.current.beginning_of_month && end_date == Date.current
+      return "Current Month to Date (MTD)"
+    elsif start_date == Date.current.beginning_of_quarter && end_date == Date.current
+      return "Current Quarter to Date (CQD)"
+    elsif start_date == Date.current.beginning_of_year && end_date == Date.current
+      return "Current Year to Date (YTD)"
+    end
+
+    # Default cases
     case days_apart
     when 1
       "vs. yesterday"
@@ -15,6 +27,8 @@ module AccountsHelper
       "vs. last week"
     when 30, 31
       "vs. last month"
+    when 90
+      "vs. last 3 months"
     when 365, 366
       "vs. last year"
     else

--- a/app/helpers/forms_helper.rb
+++ b/app/helpers/forms_helper.rb
@@ -18,9 +18,20 @@ module FormsHelper
   end
 
   def period_select(form:, selected:, classes: "border border-alpha-black-100 shadow-xs rounded-lg text-sm pr-7 cursor-pointer text-gray-900 focus:outline-none focus:ring-0")
-    periods_for_select = [ [ "7D", "last_7_days" ], [ "1M", "last_30_days" ], [ "1Y", "last_365_days" ] ]
+    periods_for_select = [
+      %w[CWD current_week], # Current Week to Date
+      %w[7D last_7_days],
+      %w[MTD current_month], # Month to Date
+      %w[1M last_30_days],
+      %w[CQD current_quarter], # Quarter to Date
+      %w[3M last_90_days],
+      %w[YTD current_year], # Year to Date
+      %w[1Y last_365_days]
+    ]
+
     form.select(:period, periods_for_select, { selected: selected }, class: classes, data: { "auto-submit-form-target": "auto" })
-  end
+end
+
 
   def currencies_for_select
     Money::Currency.all_instances.sort_by { |currency| [ currency.priority, currency.name ] }

--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -25,10 +25,15 @@ class Period
   end
 
   BUILTIN = [
-      new(name: "all", date_range: nil..Date.current),
-      new(name: "last_7_days", date_range: 7.days.ago.to_date..Date.current),
-      new(name: "last_30_days", date_range: 30.days.ago.to_date..Date.current),
-      new(name: "last_365_days", date_range: 365.days.ago.to_date..Date.current)
+    new(name: "all", date_range: nil..Date.current),
+    new(name: "current_week", date_range: Date.current.beginning_of_week..Date.current),
+    new(name: "last_7_days", date_range: 7.days.ago.to_date..Date.current),
+    new(name: "current_month", date_range: Date.current.beginning_of_month..Date.current),
+    new(name: "last_30_days", date_range: 30.days.ago.to_date..Date.current),
+    new(name: "current_quarter", date_range: Date.current.beginning_of_quarter..Date.current),
+    new(name: "last_90_days", date_range: 90.days.ago.to_date..Date.current),
+    new(name: "current_year", date_range: Date.current.beginning_of_year..Date.current),
+    new(name: "last_365_days", date_range: 365.days.ago.to_date..Date.current)
   ]
 
   INDEX = BUILTIN.index_by(&:name)


### PR DESCRIPTION
The current setup has a significant gap in its timeline options, jumping from 1 week to 1 month and then directly to 1 year. Introducing a 90-day (quarterly) period would bridge this gap effectively. A 90-day timeline is crucial, as it aligns with how people typically evaluate goals and progress on a quarterly basis. This addition would provide a more comprehensive range of timeframes for users to review and plan.