### PR TITLE
Fix: make date format year consistent overall #1712

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,20 +1,6 @@
 module ApplicationHelper
   include Pagy::Frontend
 
-  def date_format_options
-    [
-      [ "DD-MM-YYYY", "%d-%m-%Y" ],
-      [ "DD.MM.YYYY", "%d.%m.%Y" ],
-      [ "MM-DD-YYYY", "%m-%d-%Y" ],
-      [ "YYYY-MM-DD", "%Y-%m-%d" ],
-      [ "DD/MM/YYYY", "%d/%m/%Y" ],
-      [ "YYYY/MM/DD", "%Y/%m/%d" ],
-      [ "MM/DD/YYYY", "%m/%d/%Y" ],
-      [ "D/MM/YYYY", "%e/%m/%Y" ],
-      [ "YYYY.MM.DD", "%Y.%m.%d" ]
-    ]
-  end
-
   def icon(key, size: "md", color: "current")
     render partial: "shared/icon", locals: { key:, size:, color: }
   end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -1,7 +1,17 @@
 class Family < ApplicationRecord
   include Plaidable, Syncable
 
-  DATE_FORMATS = [ "%m-%d-%Y", "%d.%m.%Y", "%d-%m-%Y", "%Y-%m-%d", "%d/%m/%Y", "%Y/%m/%d", "%m/%d/%Y", "%e/%m/%Y", "%Y.%m.%d" ]
+  DATE_FORMATS = [
+    [ "MM-DD-YYYY", "%m-%d-%Y" ],
+    [ "DD.MM.YYYY", "%d.%m.%Y" ],
+    [ "DD-MM-YYYY", "%d-%m-%Y" ],
+    [ "YYYY-MM-DD", "%Y-%m-%d" ],
+    [ "DD/MM/YYYY", "%d/%m/%Y" ],
+    [ "YYYY/MM/DD", "%Y/%m/%d" ],
+    [ "MM/DD/YYYY", "%m/%d/%Y" ],
+    [ "D/MM/YYYY", "%e/%m/%Y" ],
+    [ "YYYY.MM.DD", "%Y.%m.%d" ]
+  ].freeze
 
   include Providable
 
@@ -21,7 +31,7 @@ class Family < ApplicationRecord
   has_many :budget_categories, through: :budgets
 
   validates :locale, inclusion: { in: I18n.available_locales.map(&:to_s) }
-  validates :date_format, inclusion: { in: DATE_FORMATS }
+  validates :date_format, inclusion: { in: DATE_FORMATS.map(&:last) }
 
   def sync_data(start_date: nil)
     update!(last_synced_at: Time.current)

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -8,7 +8,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
-    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true, disabled: import.complete? %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format")}, label: true, required: true, disabled: import.complete? %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -8,7 +8,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], { label: true }, required: true, disabled: import.complete? %>
+    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -8,7 +8,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
-    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true %>
+    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true, disabled: import.complete? %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -8,7 +8,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true, disabled: import.complete? %>
-    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format")}, label: true, required: true, disabled: import.complete? %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label")}, label: true, required: true, disabled: import.complete? %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format")}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YY", "%d.%m.%y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
+    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YYYY", "%d.%m.%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YYYY", "%d.%m.%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
+    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format")}, label: true, required: true %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label")}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format")}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YY", "%d.%m.%y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
+    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YYYY", "%d.%m.%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, [["DD-MM-YYYY", "%d-%m-%Y"], ["DD.MM.YYYY", "%d.%m.%Y"], ["MM-DD-YYYY", "%m-%d-%Y"], ["YYYY-MM-DD", "%Y-%m-%d"], ["DD/MM/YYYY", "%d/%m/%Y"], ["YYYY/MM/DD", "%Y/%m/%d"], ["MM/DD/YYYY", "%m/%d/%Y"]], label: true, required: true %>
+    <%= form.select :date_format, date_format_options, { label: t(".date_format"), required: true}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -3,7 +3,7 @@
 <%= styled_form_with model: @import, url: import_configuration_path(@import), scope: :import, method: :patch, class: "space-y-2" do |form| %>
   <div class="flex items-center gap-2">
     <%= form.select :date_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Date" }, required: true %>
-    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format")}, label: true, required: true %>
+    <%= form.select :date_format, Family::DATE_FORMATS, { label: t(".date_format_label")}, label: true, required: true %>
   </div>
 
   <div class="flex items-center gap-2">

--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -72,7 +72,7 @@
             { data: { action: "onboarding#setCurrency" } } %>
 
             <%= family_form.select :date_format,
-            date_format_options,
+            Family::DATE_FORMATS,
             { label: t(".date_format"), required: true, selected: params[:date_format] || @user.family.date_format },
             { data: { action: "onboarding#setDateFormat" } } %>
 

--- a/app/views/settings/preferences/show.html.erb
+++ b/app/views/settings/preferences/show.html.erb
@@ -25,7 +25,7 @@
             { data: { auto_submit_form_target: "auto" } } %>
 
           <%= family_form.select :date_format,
-            date_format_options,
+            Family::DATE_FORMATS,
             { label: t(".date_format") },
             { data: { auto_submit_form_target: "auto" } } %>
 

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -8,6 +8,13 @@ en:
           details.
         title: Clean your data
     configurations:
+      date_format_label: &date_format_label Date format
+      trade_import:
+        date_format_label: *date_format_label
+      mint_import:
+        date_format_label: *date_format_label
+      transaction_import:
+        date_format_label: *date_format_label
       show:
         description: Select the columns that correspond to each field in your CSV.
         title: Configure your import

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -8,13 +8,12 @@ en:
           details.
         title: Clean your data
     configurations:
-      date_format_label: &date_format_label Date format
       trade_import:
-        date_format_label: *date_format_label
+        date_format_label: Date format
       mint_import:
-        date_format_label: *date_format_label
+        date_format_label: Date format
       transaction_import:
-        date_format_label: *date_format_label
+        date_format_label: Date format
       show:
         description: Select the columns that correspond to each field in your CSV.
         title: Configure your import


### PR DESCRIPTION
Fixes simple year formatting, making it consistent everywhere
Fixes : https://github.com/maybe-finance/maybe/issues/1712
Before:
![image](https://github.com/user-attachments/assets/027ed25d-ead3-4f95-9754-101995b808c3)
After:
![Unsaved Image 1](https://github.com/user-attachments/assets/219e9755-4957-402e-9ee8-53b62b4f1413)
