### PR TITLE
Lazy load synth logos

### DIFF
--- a/app/views/account/holdings/_holding.html.erb
+++ b/app/views/account/holdings/_holding.html.erb
@@ -3,7 +3,7 @@
 <%= turbo_frame_tag dom_id(holding) do %>
   <div class="grid grid-cols-12 items-center text-gray-900 text-sm font-medium p-4">
     <div class="col-span-4 flex items-center gap-4">
-      <%= image_tag "https://logo.synthfinance.com/ticker/#{holding.ticker}", class: "w-9 h-9 rounded-full" %>
+      <%= image_tag "https://logo.synthfinance.com/ticker/#{holding.ticker}", class: "w-9 h-9 rounded-full", loading: "lazy" %>
 
       <div class="space-y-0.5">
         <%= link_to holding.name, account_holding_path(holding), data: { turbo_frame: :drawer }, class: "hover:underline" %>

--- a/app/views/account/holdings/show.html.erb
+++ b/app/views/account/holdings/show.html.erb
@@ -6,7 +6,7 @@
         <%= tag.p @holding.ticker, class: "text-sm text-gray-500" %>
       </div>
 
-      <%= image_tag "https://logo.synthfinance.com/ticker/#{@holding.ticker}", class: "w-9 h-9 rounded-full" %>
+      <%= image_tag "https://logo.synthfinance.com/ticker/#{@holding.ticker}", loading: "lazy", class: "w-9 h-9 rounded-full" %>
     </header>
 
     <details class="group space-y-2" open>

--- a/app/views/account/transactions/_transaction.html.erb
+++ b/app/views/account/transactions/_transaction.html.erb
@@ -13,7 +13,7 @@
     <div class="max-w-full">
       <%= content_tag :div, class: ["flex items-center gap-2"] do %>
         <% if transaction.merchant&.icon_url %>
-          <%= image_tag transaction.merchant.icon_url, class: "w-6 h-6 rounded-full" %>
+          <%= image_tag transaction.merchant.icon_url, class: "w-6 h-6 rounded-full", loading: "lazy" %>
         <% else %>
           <%= render "shared/circle_logo", name: entry.display_name, size: "sm" %>
         <% end %>

--- a/app/views/plaid_items/_plaid_item.html.erb
+++ b/app/views/plaid_items/_plaid_item.html.erb
@@ -8,7 +8,7 @@
 
         <div class="flex items-center justify-center h-8 w-8 bg-blue-600/10 rounded-full bg-black/5">
           <% if plaid_item.logo.attached? %>
-            <%= image_tag plaid_item.logo, class: "rounded-full h-full w-full" %>
+            <%= image_tag plaid_item.logo, class: "rounded-full h-full w-full", loading: "lazy" %>
           <% else %>
             <div class="flex items-center justify-center">
               <%= tag.p plaid_item.name.first.upcase, class: "text-blue-600 text-xs font-medium" %>


### PR DESCRIPTION
By lazy-loading Synth logos, the `/transactions` page mentioned in #1670 loads a lot quicker as some logos were taking upwards of 4s to load.