### PR TITLE
Only build armv7 on official releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: ${{ startsWith(github.ref, 'refs/tags/v') && 'linux/amd64,linux/arm64,linux/arm/v7' || 'linux/amd64,linux/arm64' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false


### PR DESCRIPTION
We currently build Docker images for `linux/arm/v7`, which allows support for some of the older Raspberry Pi models and a few other devices.

This build consumes a _large majority_ of our build minutes and has recently started causing some sporadic segfault/memory errors on GH actions.

This PR makes a change that only builds the `arm/v7` image for each release.  Given that most Pis are 64bit at this point, this is a tradeoff that we have to make to optimize for faster builds and getting fixes out to users quicker.