### PR TITLE
Fix crypto.randomUUID errors when adding holdings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,9 @@ gem "lucide-rails", github: "maybe-finance/lucide-rails"
 # Hotwire
 gem "stimulus-rails"
 gem "turbo-rails"
-gem "hotwire_combobox"
+
+# Temporary pin to commit to fix crypto.randomUUID() errors.  Revert this when the change has been released.
+gem "hotwire_combobox", github: "josefarias/hotwire_combobox", ref: "b827048a8305e1115d5f96931ba1c9750d1e59fc"
 
 # Background Jobs
 gem "good_job"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,15 @@
 GIT
+  remote: https://github.com/josefarias/hotwire_combobox.git
+  revision: b827048a8305e1115d5f96931ba1c9750d1e59fc
+  ref: b827048a8305e1115d5f96931ba1c9750d1e59fc
+  specs:
+    hotwire_combobox (0.3.2)
+      platform_agent (>= 1.0.1)
+      rails (>= 7.0.7.2)
+      stimulus-rails (>= 1.2)
+      turbo-rails (>= 1.2)
+
+GIT
   remote: https://github.com/maybe-finance/lucide-rails.git
   revision: 272e5fb8418ea458da3995d6abe0ba0ceee9c9f0
   specs:
@@ -194,10 +205,6 @@ GEM
       actioncable (>= 7.0.0)
       listen (>= 3.0.0)
       railties (>= 7.0.0)
-    hotwire_combobox (0.3.2)
-      rails (>= 7.0.7.2)
-      stimulus-rails (>= 1.2)
-      turbo-rails (>= 1.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     i18n-tasks (1.0.14)
@@ -311,6 +318,9 @@ GEM
     plaid (35.1.0)
       faraday (>= 1.0.1, < 3.0)
       faraday-multipart (>= 1.0.1, < 2.0)
+    platform_agent (1.0.1)
+      activesupport (>= 5.2.0)
+      useragent (~> 0.16.3)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -530,7 +540,7 @@ DEPENDENCIES
   faraday-retry
   good_job
   hotwire-livereload
-  hotwire_combobox
+  hotwire_combobox!
   i18n-tasks
   image_processing (>= 1.2)
   importmap-rails


### PR DESCRIPTION
As described in #1768 and #1657, adding holdings on self hosted instances that are not run over `https` is not possible due to the usage of `crypto.randomUUID()` in the `hotwire_combobox` gem.  

This PR _temporarily_ pins the `hotwire_combobox` gem to the commit where this has been resolved.

We will upgrade to the official gem again once this is released.