### PR TITLE
Fix: Incorrect Currency Assignment for Stock Prices (#1623)

### DIFF
--- a/app/models/provider/synth.rb
+++ b/app/models/provider/synth.rb
@@ -59,7 +59,7 @@ class Provider::Synth
         {
           date: price.dig("date"),
           price: price.dig("close")&.to_f || price.dig("open")&.to_f,
-          currency: price.dig("currency") || "USD"
+          currency: body.dig("currency") || "USD"
         }
       end
     end


### PR DESCRIPTION
Fixes #1623

### **Issue Description**  
Stocks from non-USD markets (such as Saudi and Indian stock exchanges) were incorrectly assigned USD as their currency, which distorted portfolio calculations. The issue was due to the application extracting the currency from the `prices` array instead of the main response object.  

### **Root Cause**  
The application was fetching stock price data from Synth Finance's **"Open/Close Prices"** API, but it incorrectly attempted to extract the currency from within each price entry under `prices[]`, even though the API returns the correct currency in the main object under `currency`. This caused the system to default to "USD" when currency information was missing at the price level.  

### **Solution**  
- Updated the currency assignment logic to fetch it from the main response object (`body.dig("currency")`) instead of from the price entry.  
- Ensured that the currency field is correctly set for all fetched stock prices.  

### **Impact**
✅ Fixes incorrect currency assignment for stock prices in non-USD markets.  
✅ Prevents miscalculations of portfolio value due to incorrect currency conversion.  
✅ Ensures compatibility with Synth Finance’s API response structure.  

### **Testing**
- Verified that stocks from Saudi and Indian markets now display correct currency values.  
- Confirmed that existing USD-based stocks remain unaffected.  
