### PR TITLE
fix: Save completely allocated budget

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -150,7 +150,7 @@ class Budget < ApplicationRecord
   end
 
   def allocations_valid?
-    initialized? && available_to_allocate.positive? && allocated_spending > 0
+    initialized? && available_to_allocate >= 0 && allocated_spending > 0
   end
 
   # =============================================================================


### PR DESCRIPTION
I noticed that when I completely budgeted I couldn't save the budget.

Previously, the logic only allowed positive values, which caused issues when handling fully allocated budgets or edge cases where no funds were left to distribute.