### PR TITLE
Feature: Add the ability to "revert" a CSV import

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,5 +1,5 @@
 class ImportsController < ApplicationController
-  before_action :set_import, only: %i[show publish destroy]
+  before_action :set_import, only: %i[show publish destroy revert]
 
   def publish
     @import.publish_later
@@ -29,6 +29,11 @@ class ImportsController < ApplicationController
     elsif !@import.publishable?
       redirect_to import_confirm_path(@import), alert: "Please finalize your mappings before proceeding."
     end
+  end
+
+  def revert
+    @import.revert_later
+    redirect_to imports_path, notice: "Import is reverting in the background."
   end
 
   def destroy

--- a/app/jobs/revert_import_job.rb
+++ b/app/jobs/revert_import_job.rb
@@ -1,0 +1,7 @@
+class RevertImportJob < ApplicationJob
+  queue_as :latency_low
+
+  def perform(import)
+    import.revert
+  end
+end

--- a/app/models/demo/generator.rb
+++ b/app/models/demo/generator.rb
@@ -24,7 +24,7 @@ class Demo::Generator
     puts "Data cleared"
 
     family_names.each_with_index do |family_name, index|
-      create_family_and_user!(family_name, "user#{index == 0 ? "" : index + 1}@maybe.local", data_enrichment_enabled: index == 0)
+      create_family_and_user!(family_name, "user#{index == 0 ? "" : index + 1}@maybe.local")
     end
 
     puts "Users reset"

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -6,7 +6,14 @@ class Import < ApplicationRecord
 
   scope :ordered, -> { order(created_at: :desc) }
 
-  enum :status, { pending: "pending", complete: "complete", importing: "importing", failed: "failed" }, validate: true
+  enum :status, {
+    pending: "pending",
+    complete: "complete",
+    importing: "importing",
+    reverting: "reverting",
+    revert_failed: "revert_failed",
+    failed: "failed"
+  }, validate: true, default: "pending"
 
   validates :type, inclusion: { in: TYPES }
   validates :col_sep, inclusion: { in: [ ",", ";" ] }
@@ -33,6 +40,27 @@ class Import < ApplicationRecord
     update! status: :complete
   rescue => error
     update! status: :failed, error: error.message
+  end
+
+  def revert_later
+    raise "Import is not revertable" unless revertable?
+
+    update! status: :reverting
+
+    RevertImportJob.perform_later(self)
+  end
+
+  def revert
+    Import.transaction do
+      accounts.destroy_all
+      entries.destroy_all
+    end
+
+    family.sync
+
+    update! status: :pending
+  rescue => error
+    update! status: :revert_failed, error: error.message
   end
 
   def csv_rows
@@ -111,6 +139,10 @@ class Import < ApplicationRecord
 
   def publishable?
     cleaned? && mappings.all?(&:valid?)
+  end
+
+  def revertable?
+    complete? || revert_failed?
   end
 
   def has_unassigned_account?

--- a/app/views/import/configurations/_account_import.html.erb
+++ b/app/views/import/configurations/_account_import.html.erb
@@ -4,6 +4,7 @@
   <%= form.select :entity_type_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Entity Type" } %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
   <%= form.select :amount_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Balance" } %>
+  <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Currency" } %>
 
   <%= form.submit "Apply configuration", class: "w-full btn btn--primary", disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -16,6 +16,8 @@
     <%= form.select :signage_convention, [["Incomes are negative", "inflows_negative"], ["Incomes are positive", "inflows_positive"]], { label: true }, disabled: import.complete? %>
   </div>
 
+  <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Currency" }, disabled: import.complete? %>
+
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -11,6 +11,8 @@
     <%= form.select :signage_convention, [["Buys are positive qty", "inflows_positive"], ["Buys are negative qty", "inflows_negative"]], label: true %>
   </div>
 
+  <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Currency" } %>
+
   <%= form.select :ticker_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Ticker" } %>
   <%= form.select :price_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Price" } %>
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -11,6 +11,8 @@
     <%= form.select :signage_convention, [["Incomes are positive", "inflows_positive"], ["Incomes are negative", "inflows_negative"]], label: true %>
   </div>
 
+  <%= form.select :currency_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Currency" } %>
+
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" } %>

--- a/app/views/imports/_import.html.erb
+++ b/app/views/imports/_import.html.erb
@@ -17,6 +17,14 @@
       <span class="px-1 py text-xs rounded-full bg-red-500/5 text-red-500 border border-alpha-black-50">
         <%= t(".failed") %>
       </span>
+    <% elsif import.reverting? %>
+      <span class="px-1 py text-xs rounded-full bg-orange-500/5 text-orange-500 border border-alpha-black-50">
+        <%= t(".reverting") %>
+      </span>
+    <% elsif import.revert_failed? %>
+      <span class="px-1 py text-xs rounded-full bg-red-500/5 text-red-500 border border-alpha-black-50">
+        <%= t(".revert_failed") %>
+      </span>
     <% elsif import.complete? %>
       <span class="px-1 py text-xs rounded-full bg-green-500/5 text-green-500 border border-alpha-black-50">
         <%= t(".complete") %>
@@ -33,7 +41,16 @@
         <span><%= t(".view") %></span>
       <% end %>
 
-      <% unless import.complete? %>
+      <% if import.complete? || import.revert_failed? %>
+        <%= button_to revert_import_path(import), 
+                      method: :put,
+                      class: "block w-full py-2 px-3 space-x-2 text-orange-600 hover:bg-orange-50 flex items-center rounded-lg",
+                      data: { turbo_confirm: true } do %>
+          <%= lucide_icon "rotate-ccw", class: "w-5 h-5" %>
+
+          <span>Revert</span>
+        <% end %>
+      <% else %>
         <%= button_to import_path(import),
                       method: :delete,
                       class: "block w-full py-2 px-3 space-x-2 text-red-600 hover:bg-red-50 flex items-center rounded-lg",

--- a/app/views/imports/_revert_failure.html.erb
+++ b/app/views/imports/_revert_failure.html.erb
@@ -1,0 +1,18 @@
+<%# locals: (import:) %>
+
+<div class="h-full flex flex-col justify-center items-center">
+  <div class="space-y-6 max-w-sm">
+    <div class="mx-auto bg-red-500/5 h-8 w-8 rounded-full flex items-center justify-center">
+      <%= lucide_icon "alert-octagon", class: "w-5 h-5 text-red-500" %>
+    </div>
+
+    <div class="text-center space-y-2">
+      <h1 class="font-medium text-gray-900 text-center text-3xl">Reverting import failed</h1>
+      <p class="text-sm text-gray-500">Please try again or contact support.</p>
+    </div>
+
+    <div>
+      <%= button_to "Try again", revert_import_path(import), class: "btn btn--primary text-center w-full" %>
+    </div>
+  </div>
+</div>

--- a/app/views/imports/show.html.erb
+++ b/app/views/imports/show.html.erb
@@ -10,6 +10,8 @@
   <%= render "imports/success", import: @import %>
 <% elsif @import.failed? %>
   <%= render "imports/failure", import: @import %>
+<% elsif @import.revert_failed? %>
+  <%= render "imports/revert_failure", import: @import %>
 <% else %>
   <%= render "imports/ready", import: @import %>
 <% end %>

--- a/config/locales/views/imports/en.yml
+++ b/config/locales/views/imports/en.yml
@@ -63,6 +63,8 @@ en:
       failed: Failed
       in_progress: In progress
       label: "%{type}: %{datetime}"
+      reverting: Reverting
+      revert_failed: Revert failed
       uploading: Processing rows
       view: View
     index:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
 
   resources :imports, only: %i[index new show create destroy] do
     post :publish, on: :member
+    put :revert, on: :member
 
     resource :upload, only: %i[show update], module: :import
     resource :configuration, only: %i[show update], module: :import

--- a/db/migrate/20250206003115_remove_import_status_enum.rb
+++ b/db/migrate/20250206003115_remove_import_status_enum.rb
@@ -1,0 +1,21 @@
+class RemoveImportStatusEnum < ActiveRecord::Migration[7.2]
+  def up
+    change_column_default :imports, :status, nil
+    change_column :imports, :status, :string
+    execute "DROP TYPE IF EXISTS import_status"
+  end
+
+  def down
+    execute <<-SQL
+      CREATE TYPE import_status AS ENUM (
+        'pending',
+        'importing',
+        'complete',
+        'failed'
+      );
+    SQL
+
+    change_column :imports, :status, :import_status, using: 'status::import_status'
+    change_column_default :imports, :status, 'pending'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_06_003115) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_06_204404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_31_171943) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_06_003115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -18,7 +18,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_31_171943) do
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "account_status", ["ok", "syncing", "error"]
-  create_enum "import_status", ["pending", "importing", "complete", "failed"]
 
   create_table "account_balances", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "account_id", null: false
@@ -391,7 +390,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_31_171943) do
 
   create_table "imports", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.jsonb "column_mappings"
-    t.enum "status", default: "pending", enum_type: "import_status"
+    t.string "status"
     t.string "raw_file_str"
     t.string "normalized_csv_str"
     t.datetime "created_at", null: false

--- a/test/fixtures/imports.yml
+++ b/test/fixtures/imports.yml
@@ -1,3 +1,4 @@
 transaction:
   family: dylan_family
   type: TransactionImport
+  status: pending

--- a/test/jobs/revert_import_job_test.rb
+++ b/test/jobs/revert_import_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RevertImportJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Fixes #1355, #1827 

This PR allows users to "revert" a CSV import.  Reverting an import removes the imported data and puts the import back into "pending" status.

https://github.com/user-attachments/assets/12cee0bc-7417-429f-8287-de2e3e7da3d9

