### PR TITLE
feat(import): add currency and number format support for CSV imports

### DIFF
--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -27,7 +27,6 @@ class Import < ApplicationRecord
   validates :type, inclusion: { in: TYPES }
   validates :col_sep, inclusion: { in: [ ",", ";" ] }
   validates :signage_convention, inclusion: { in: SIGNAGE_CONVENTIONS }
-  validates :currency, presence: true
   validates :number_format, presence: true, inclusion: { in: NUMBER_FORMATS.keys }
 
   has_many :rows, dependent: :destroy

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -11,7 +11,7 @@ class Import < ApplicationRecord
 
   belongs_to :family
 
-  before_validation :set_default_currency_and_format
+  before_validation :set_default_number_format
 
   scope :ordered, -> { order(created_at: :desc) }
 

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -217,7 +217,7 @@ class Import < ApplicationRecord
       sanitized
     end
 
-    def set_default_currency_and_format
+    def set_default_number_format
       self.number_format ||= "1,234.56" # Default to US/UK format
     end
 end

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -205,7 +205,6 @@ class Import < ApplicationRecord
     end
 
     def set_default_currency_and_format
-      self.currency ||= family&.currency
       self.number_format ||= "1,234.56" # Default to US/UK format
     end
 end

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -16,6 +16,11 @@
     <%= form.select :signage_convention, [["Incomes are negative", "inflows_negative"], ["Incomes are positive", "inflows_positive"]], { label: true }, disabled: import.complete? %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, currencies_for_select.map { |currency| [ "#{currency.name} (#{currency.iso_code})", currency.iso_code ] }, { label: "Currency", prompt: "Select currency" }, required: true %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
+  </div>
+
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -11,6 +11,11 @@
     <%= form.select :signage_convention, [["Buys are positive qty", "inflows_positive"], ["Buys are negative qty", "inflows_negative"]], label: true %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, currencies_for_select.map { |currency| [ "#{currency.name} (#{currency.iso_code})", currency.iso_code ] }, { label: "Currency", prompt: "Select currency" }, required: true %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
+  </div>
+
   <%= form.select :ticker_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Ticker" } %>
   <%= form.select :price_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Price" } %>
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -11,6 +11,11 @@
     <%= form.select :signage_convention, [["Incomes are positive", "inflows_positive"], ["Incomes are negative", "inflows_negative"]], label: true %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, currencies_for_select.map { |currency| [ "#{currency.name} (#{currency.iso_code})", currency.iso_code ] }, { label: "Currency", prompt: "Select currency" }, required: true %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
+  </div>
+
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" } %>

--- a/config/locales/models/import/en.yml
+++ b/config/locales/models/import/en.yml
@@ -7,3 +7,7 @@ en:
           attributes:
             raw_file_str:
               invalid_csv_format: is not a valid CSV format
+    attributes:
+      import:
+        currency: Currency
+        number_format: Number Format

--- a/db/migrate/20250207014022_add_currency_and_format_to_imports.rb
+++ b/db/migrate/20250207014022_add_currency_and_format_to_imports.rb
@@ -1,6 +1,0 @@
-class AddCurrencyAndFormatToImports < ActiveRecord::Migration[7.2]
-  def change
-    add_column :imports, :currency, :string
-    add_column :imports, :number_format, :string
-  end
-end

--- a/db/migrate/20250207014022_add_currency_and_format_to_imports.rb
+++ b/db/migrate/20250207014022_add_currency_and_format_to_imports.rb
@@ -1,0 +1,6 @@
+class AddCurrencyAndFormatToImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column :imports, :currency, :string
+    add_column :imports, :number_format, :string
+  end
+end

--- a/db/migrate/20250207014022_add_number_format_to_imports.rb
+++ b/db/migrate/20250207014022_add_number_format_to_imports.rb
@@ -1,0 +1,5 @@
+class AddNumberFormatToImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column :imports, :number_format, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_06_204404) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_014022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -414,7 +414,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_06_204404) do
     t.string "date_format", default: "%m/%d/%Y"
     t.string "signage_convention", default: "inflows_positive"
     t.string "error"
-    t.string "currency"
     t.string "number_format"
     t.index ["family_id"], name: "index_imports_on_family_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_06_151825) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_014022) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -102,7 +102,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_06_151825) do
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
     t.boolean "is_active", default: true, null: false
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.boolean "scheduled_for_deletion", default: false
@@ -415,6 +415,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_06_151825) do
     t.string "date_format", default: "%m/%d/%Y"
     t.string "signage_convention", default: "inflows_positive"
     t.string "error"
+    t.string "currency"
+    t.string "number_format"
     t.index ["family_id"], name: "index_imports_on_family_id"
   end
 

--- a/test/models/transaction_import_test.rb
+++ b/test/models/transaction_import_test.rb
@@ -28,14 +28,19 @@ class TransactionImportTest < ActiveSupport::TestCase
   end
 
   test "imports transactions, categories, tags, and accounts" do
-    import = <<-CSV
+    import = <<~CSV
       date,name,amount,category,tags,account,notes
       01/01/2024,Txn1,100,TestCategory1,TestTag1,TestAccount1,notes1
       01/02/2024,Txn2,200,TestCategory2,TestTag1|TestTag2,TestAccount2,notes2
       01/03/2024,Txn3,300,,,,notes3
     CSV
 
-    @import.update!(raw_file_str: import)
+    @import.update!(
+      raw_file_str: import,
+      date_col_label: "date",
+      amount_col_label: "amount",
+      date_format: "%m/%d/%Y"
+    )
 
     @import.generate_rows_from_csv
 


### PR DESCRIPTION
Fixes #1713 
/claim #1713

Before this change, importing a CSV with European-style numbers (like `1.234,56`) would result in incorrect values because the parser would strip the decimal comma. Now, users can specify their number format and get accurate imports regardless of their region.

```csv
Date,Name,Amount
2023-05-01,Grocery Store,1.254,54
```

**Before**: Would parse as `125454`
**After**: Correctly parses as `1254.54` when European format is selected