### PR TITLE
fix: improve CSV number format handling for non-USD currencies

### DIFF
--- a/app/views/import/configurations/_account_import.html.erb
+++ b/app/views/import/configurations/_account_import.html.erb
@@ -5,5 +5,10 @@
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
   <%= form.select :amount_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Balance" } %>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, Money::Currency.all_instances.map { |c| [c.name, c.iso_code] }, { label: "Currency" }, required: true %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys.map { |f| [f, f] }, { label: "Number Format" }, required: true %>
+  </div>
+
   <%= form.submit "Apply configuration", class: "w-full btn btn--primary", disabled: import.complete? %>
 <% end %>

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -16,6 +16,11 @@
     <%= form.select :signage_convention, [["Incomes are negative", "inflows_negative"], ["Incomes are positive", "inflows_positive"]], { label: true }, disabled: import.complete? %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, Money::Currency.all_instances.map { |c| [c.name, c.iso_code] }, { label: "Currency" }, required: true, disabled: import.complete? %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys.map { |f| [f, f] }, { label: "Number Format" }, required: true, disabled: import.complete? %>
+  </div>
+
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -11,6 +11,11 @@
     <%= form.select :signage_convention, [["Buys are positive qty", "inflows_positive"], ["Buys are negative qty", "inflows_negative"]], label: true %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, Money::Currency.all_instances.map { |c| [c.name, c.iso_code] }, { label: "Currency" }, required: true %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys.map { |f| [f, f] }, { label: "Number Format" }, required: true %>
+  </div>
+
   <%= form.select :ticker_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Ticker" } %>
   <%= form.select :price_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Price" } %>
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -11,6 +11,11 @@
     <%= form.select :signage_convention, [["Incomes are positive", "inflows_positive"], ["Incomes are negative", "inflows_negative"]], label: true %>
   </div>
 
+  <div class="flex items-center gap-2">
+    <%= form.select :currency, Money::Currency.all_instances.map { |c| [c.name, c.iso_code] }, { label: "Currency" }, required: true %>
+    <%= form.select :number_format, Import::NUMBER_FORMATS.keys.map { |f| [f, f] }, { label: "Number Format" }, required: true %>
+  </div>
+
   <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" } %>

--- a/db/migrate/20250207004108_add_currency_and_number_format_to_imports.rb
+++ b/db/migrate/20250207004108_add_currency_and_number_format_to_imports.rb
@@ -1,0 +1,6 @@
+class AddCurrencyAndNumberFormatToImports < ActiveRecord::Migration[7.2]
+  def change
+    add_column :imports, :currency, :string, default: "USD"
+    add_column :imports, :number_format, :string, default: "1,234.56"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_06_151825) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_004108) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -102,7 +102,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_06_151825) do
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
     t.boolean "is_active", default: true, null: false
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.boolean "scheduled_for_deletion", default: false
@@ -415,6 +415,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_06_151825) do
     t.string "date_format", default: "%m/%d/%Y"
     t.string "signage_convention", default: "inflows_positive"
     t.string "error"
+    t.string "currency", default: "USD"
+    t.string "number_format", default: "1,234.56"
     t.index ["family_id"], name: "index_imports_on_family_id"
   end
 

--- a/test/models/import/number_sanitization_test.rb
+++ b/test/models/import/number_sanitization_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class Import::NumberSanitizationTest < ActiveSupport::TestCase
+  setup do
+    @import = imports(:transaction)
+  end
+
+  test "sanitizes US/UK/Asia format (1,234.56)" do
+    @import.number_format = "1,234.56"
+
+    assert_equal "1234.56", @import.send(:sanitize_number, "1,234.56")
+    assert_equal "1234.56", @import.send(:sanitize_number, "$1,234.56")
+    assert_equal "1234.56", @import.send(:sanitize_number, "£1,234.56")
+    assert_equal "1234.56", @import.send(:sanitize_number, "¥1,234.56")
+    assert_equal "-1234.56", @import.send(:sanitize_number, "-1,234.56")
+    assert_equal "1234.56", @import.send(:sanitize_number, "1234.56") # No delimiters
+    assert_equal "1234567.89", @import.send(:sanitize_number, "1,234,567.89")
+  end
+
+  test "sanitizes European format (1.234,56)" do
+    @import.number_format = "1.234,56"
+
+    assert_equal "1234.56", @import.send(:sanitize_number, "1.234,56")
+    assert_equal "1234.56", @import.send(:sanitize_number, "€1.234,56")
+    assert_equal "-1234.56", @import.send(:sanitize_number, "-1.234,56")
+    assert_equal "1234567.89", @import.send(:sanitize_number, "1.234.567,89")
+  end
+
+  test "sanitizes French/Scandinavian format (1 234,56)" do
+    @import.number_format = "1 234,56"
+
+    assert_equal "1234.56", @import.send(:sanitize_number, "1 234,56")
+    assert_equal "1234.56", @import.send(:sanitize_number, "€1 234,56")
+    assert_equal "-1234.56", @import.send(:sanitize_number, "-1 234,56")
+    assert_equal "1234567.89", @import.send(:sanitize_number, "1 234 567,89")
+  end
+
+  test "sanitizes zero-decimal currencies like JPY (1,234)" do
+    @import.number_format = "1,234"
+
+    assert_equal "1234", @import.send(:sanitize_number, "1,234")
+    assert_equal "1234", @import.send(:sanitize_number, "¥1,234")
+    assert_equal "-1234", @import.send(:sanitize_number, "-1,234")
+    assert_equal "1234567", @import.send(:sanitize_number, "1,234,567")
+  end
+
+  test "handles edge cases" do
+    @import.number_format = "1,234.56"
+
+    # Nil and empty values
+    assert_equal "", @import.send(:sanitize_number, nil)
+    assert_equal "", @import.send(:sanitize_number, "")
+    assert_equal "", @import.send(:sanitize_number, " ")
+
+    # Non-numeric input
+    assert_equal "", @import.send(:sanitize_number, "abc")
+    assert_equal "", @import.send(:sanitize_number, "$")
+    assert_equal "", @import.send(:sanitize_number, ".")
+    assert_equal "", @import.send(:sanitize_number, "-")
+    assert_equal "", @import.send(:sanitize_number, "-.")
+
+    # Mixed input with numbers
+    assert_equal "42", @import.send(:sanitize_number, "abc42def")
+    assert_equal "42.42", @import.send(:sanitize_number, "abc42.42def")
+
+    # Decimal point handling
+    assert_equal "0.5", @import.send(:sanitize_number, ".5")
+    assert_equal "5.0", @import.send(:sanitize_number, "5.")
+    assert_equal "-0.5", @import.send(:sanitize_number, "-.5")
+    assert_equal "42.1", @import.send(:sanitize_number, "42.1.2.3")
+  end
+
+  test "defaults to US format if number_format is invalid" do
+    @import.number_format = "invalid_format"
+
+    assert_equal "1234.56", @import.send(:sanitize_number, "1,234.56")
+    assert_equal "-1234.56", @import.send(:sanitize_number, "-1,234.56")
+    assert_equal "", @import.send(:sanitize_number, "abc")
+  end
+end


### PR DESCRIPTION

https://github.com/user-attachments/assets/23433056-89fa-4327-a81b-5468b8ce0efa

Fixes: #1713 
/claim #1713 

## Solution
Implemented a more robust number sanitization system that:

1. Added support for multiple number formats:
   - US/UK/Asia (1,234.56)
   - European (1.234,56)
   - French/Scandinavian (1 234,56)
   - Zero-decimal currencies (1,234)

2. Enhanced the `sanitize_number` method to:
   - Handle different decimal separators and thousand delimiters
   - Preserve the correct numerical value regardless of format
   - Return empty string for non-numeric input
   - Handle edge cases like leading/trailing decimals

3. Added comprehensive tests covering:
   - All supported number formats
   - Currency symbols
   - Negative numbers
   - Edge cases (nil, empty string, non-numeric input)
   - Multiple decimal points
   - Leading/trailing zeros

## Testing
Added a new test file `test/models/import/number_sanitization_test.rb` with 36 assertions covering:
