### PR TITLE
fix: subcategories are not properly handled for budget allocations

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -133,10 +133,10 @@ class Budget < ApplicationRecord
   end
 
   # =============================================================================
-  # Budget allocations: How much user has budgeted for all categories combined
+  # Budget allocations: How much user has budgeted for all parent categories combined
   # =============================================================================
   def allocated_spending
-    budget_categories.joins(:category).where(categories: { parent_id: nil }).sum(:budgeted_spending)
+    budget_categories.reject { |bc| bc.subcategory? }.sum(&:budgeted_spending)  
   end
 
   def allocated_percent

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -136,7 +136,7 @@ class Budget < ApplicationRecord
   # Budget allocations: How much user has budgeted for all parent categories combined
   # =============================================================================
   def allocated_spending
-    budget_categories.reject { |bc| bc.subcategory? }.sum(&:budgeted_spending)  
+    budget_categories.reject { |bc| bc.subcategory? }.sum(&:budgeted_spending)
   end
 
   def allocated_percent

--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -136,7 +136,7 @@ class Budget < ApplicationRecord
   # Budget allocations: How much user has budgeted for all categories combined
   # =============================================================================
   def allocated_spending
-    budget_categories.sum(:budgeted_spending)
+    budget_categories.joins(:category).where(categories: { parent_id: nil }).sum(:budgeted_spending)
   end
 
   def allocated_percent

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -93,4 +93,16 @@ class BudgetCategory < ApplicationRecord
     [ parent_budget - siblings_budget, 0 ].max
   end
 
+  def subcategories
+    return BudgetCategory.none unless category.parent_id.nil?
+    
+    budget.budget_categories
+      .joins(:category)
+      .where(categories: { parent_id: category.id })
+  end
+  
+  def subcategory?
+    category.parent_id.present?
+  end
+
 end

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -86,23 +86,22 @@ class BudgetCategory < ApplicationRecord
 
   def max_allocation
     return nil unless subcategory?
-  
+
     parent_budget = budget.budget_categories.find { |bc| bc.category.id == category.parent_id }&.budgeted_spending
     siblings_budget = siblings.sum(&:budgeted_spending)
-  
+
     [ parent_budget - siblings_budget, 0 ].max
   end
 
   def subcategories
     return BudgetCategory.none unless category.parent_id.nil?
-    
+
     budget.budget_categories
       .joins(:category)
       .where(categories: { parent_id: category.id })
   end
-  
+
   def subcategory?
     category.parent_id.present?
   end
-
 end

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -79,4 +79,16 @@ class BudgetCategory < ApplicationRecord
 
     segments
   end
+
+  def max_allocation
+    return nil unless subcategory?
+  
+    siblings = budget.budget_categories.select { |bc| bc.category.parent_id == category.parent_id && bc.id != id }
+  
+    parent_budget = budget.budget_categories.find { |bc| bc.category.id == category.parent_id }&.budgeted_spending
+    siblings_budget = siblings.sum(&:budgeted_spending)
+  
+    [ parent_budget - siblings_budget, 0 ].max
+  end
+
 end

--- a/app/models/budget_category.rb
+++ b/app/models/budget_category.rb
@@ -80,10 +80,12 @@ class BudgetCategory < ApplicationRecord
     segments
   end
 
+  def siblings
+    budget.budget_categories.select { |bc| bc.category.parent_id == category.parent_id && bc.id != id }
+  end
+
   def max_allocation
     return nil unless subcategory?
-  
-    siblings = budget.budget_categories.select { |bc| bc.category.parent_id == category.parent_id && bc.id != id }
   
     parent_budget = budget.budget_categories.find { |bc| bc.category.id == category.parent_id }&.budgeted_spending
     siblings_budget = siblings.sum(&:budgeted_spending)

--- a/app/views/budget_categories/_budget_category_form.html.erb
+++ b/app/views/budget_categories/_budget_category_form.html.erb
@@ -2,16 +2,6 @@
 
 <% currency = Money::Currency.new(budget_category.budget.currency) %>
 
-<% max_amount = if budget_category.category.parent_id?
-    parent_budget_category = budget_category.category.parent.budget_categories.find_by(budget: budget_category.budget)
-    sibling_total = budget_category.category.parent.subcategories
-      .joins(:budget_categories)
-      .where(budget_categories: { budget_id: budget_category.budget_id })
-      .where.not(budget_categories: { id: budget_category.id })
-      .sum('budget_categories.budgeted_spending')
-    parent_budget_category&.budgeted_spending.to_i - sibling_total
-  end %>
-
 <div class="w-full flex gap-3">
   <div class="w-1 h-3 rounded-xl mt-1" style="background-color: <%= budget_category.category.color %>"></div>
 
@@ -32,7 +22,7 @@
                             step: currency.step,
                             id: dom_id(budget_category, :budgeted_spending),
                             min: 0,
-                            max: max_amount,
+                            max: budget_category.max_allocation,
                             data: { auto_submit_form_target: "auto" } %>
         </div>
       </div>

--- a/app/views/budget_categories/_budget_category_form.html.erb
+++ b/app/views/budget_categories/_budget_category_form.html.erb
@@ -2,7 +2,7 @@
 
 <% currency = Money::Currency.new(budget_category.budget.currency) %>
 
-<div class="w-full flex gap-3">
+<div id=<%= dom_id(budget_category, :form) %> class="w-full flex gap-3">
   <div class="w-1 h-3 rounded-xl mt-1" style="background-color: <%= budget_category.category.color %>"></div>
 
   <div class="text-sm mr-3">

--- a/app/views/budget_categories/_budget_category_form.html.erb
+++ b/app/views/budget_categories/_budget_category_form.html.erb
@@ -2,6 +2,16 @@
 
 <% currency = Money::Currency.new(budget_category.budget.currency) %>
 
+<% max_amount = if budget_category.category.parent_id?
+    parent_budget_category = budget_category.category.parent.budget_categories.find_by(budget: budget_category.budget)
+    sibling_total = budget_category.category.parent.subcategories
+      .joins(:budget_categories)
+      .where(budget_categories: { budget_id: budget_category.budget_id })
+      .where.not(budget_categories: { id: budget_category.id })
+      .sum('budget_categories.budgeted_spending')
+    parent_budget_category&.budgeted_spending.to_i - sibling_total
+  end %>
+
 <div class="w-full flex gap-3">
   <div class="w-1 h-3 rounded-xl mt-1" style="background-color: <%= budget_category.category.color %>"></div>
 
@@ -22,6 +32,7 @@
                             step: currency.step,
                             id: dom_id(budget_category, :budgeted_spending),
                             min: 0,
+                            max: max_amount,
                             data: { auto_submit_form_target: "auto" } %>
         </div>
       </div>

--- a/app/views/budget_categories/_confirm_button.html.erb
+++ b/app/views/budget_categories/_confirm_button.html.erb
@@ -1,0 +1,11 @@
+<div id="<%= dom_id(budget, :confirm_button) %>">
+  <% if budget.allocations_valid? %>
+    <%= link_to "Confirm",
+        budget_path(budget),
+        class: "block btn btn--primary w-full text-center" %>
+  <% else %>
+    <span class="block btn btn--secondary w-full text-center text-gray-400 cursor-not-allowed">
+      Confirm
+    </span>
+  <% end %>
+</div>

--- a/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
+++ b/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
@@ -2,7 +2,7 @@
 
 <% budget_category = budget.uncategorized_budget_category %>
 
-<div class="flex gap-3">
+<div id="<%= dom_id(budget, :uncategorized_budget_category_form) %>" class="flex gap-3">
   <div class="w-1 h-3 rounded-xl mt-1" style="background-color: <%= budget_category.category.color %>"></div>
 
   <div class="text-sm mr-3">

--- a/app/views/budget_categories/index.html.erb
+++ b/app/views/budget_categories/index.html.erb
@@ -45,15 +45,7 @@
             <%= render "budget_categories/uncategorized_budget_category_form", budget: @budget %>
           </div>
 
-          <% if @budget.allocations_valid? %>
-            <%= link_to "Confirm",
-                budget_path(@budget),
-                class: "block btn btn--primary w-full text-center" %>
-          <% else %>
-            <span class="block btn btn--secondary w-full text-center text-gray-400 cursor-not-allowed">
-              Confirm
-            </span>
-          <% end %>
+        <%= render "budget_categories/confirm_button", budget: @budget %>
         </div>
       <% end %>
     </div>

--- a/app/views/budget_categories/update.turbo_stream.erb
+++ b/app/views/budget_categories/update.turbo_stream.erb
@@ -1,1 +1,7 @@
 <%= turbo_stream.replace dom_id(@budget, :allocation_progress), partial: "budget_categories/allocation_progress", locals: { budget: @budget } %>
+
+<% if @budget_category.subcategory? %>
+  <% @budget_category.siblings.each do |sibling| %>
+    <%= turbo_stream.update dom_id(sibling, :form), partial: "budget_categories/budget_category_form", locals: { budget_category: sibling } %>
+  <% end %>
+<% end %>

--- a/app/views/budget_categories/update.turbo_stream.erb
+++ b/app/views/budget_categories/update.turbo_stream.erb
@@ -5,3 +5,7 @@
     <%= turbo_stream.update dom_id(sibling, :form), partial: "budget_categories/budget_category_form", locals: { budget_category: sibling } %>
   <% end %>
 <% end %>
+
+<%= turbo_stream.replace dom_id(@budget, :uncategorized_budget_category_form), partial: "budget_categories/uncategorized_budget_category_form", locals: { budget: @budget } %>
+
+<%= turbo_stream.replace dom_id(@budget, :confirm_button), partial: "budget_categories/confirm_button", locals: { budget: @budget } %>

--- a/app/views/budget_categories/update.turbo_stream.erb
+++ b/app/views/budget_categories/update.turbo_stream.erb
@@ -1,11 +1,19 @@
 <%= turbo_stream.replace dom_id(@budget, :allocation_progress), partial: "budget_categories/allocation_progress", locals: { budget: @budget } %>
 
-<% if @budget_category.subcategory? %>
-  <% @budget_category.siblings.each do |sibling| %>
-    <%= turbo_stream.update dom_id(sibling, :form), partial: "budget_categories/budget_category_form", locals: { budget_category: sibling } %>
-  <% end %>
-<% end %>
-
 <%= turbo_stream.replace dom_id(@budget, :uncategorized_budget_category_form), partial: "budget_categories/uncategorized_budget_category_form", locals: { budget: @budget } %>
 
 <%= turbo_stream.replace dom_id(@budget, :confirm_button), partial: "budget_categories/confirm_button", locals: { budget: @budget } %>
+
+
+<% if @budget_category.subcategory? %>
+  <%# Update sibling subcategories when a subcategory changes %>
+  <% @budget_category.siblings.each do |sibling| %>
+    <%= turbo_stream.update dom_id(sibling, :form), partial: "budget_categories/budget_category_form", locals: { budget_category: sibling } %>
+  <% end %>
+  
+<% else %>
+  <%# Update all subcategories when a parent category changes %>
+  <% @budget_category.subcategories.each do |subcategory| %>
+    <%= turbo_stream.update dom_id(subcategory, :form), partial: "budget_categories/budget_category_form", locals: { budget_category: subcategory } %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
This PR ensures that subcategory budget allocations cannot exceed the total budget allocated to their parent category.

Changes:
- Updated the allocated_spending method to only sum parent category budgets.
- Added logic in the budget category form to enforce a max allocation based on the parent’s available budget.

Issue Fixed:
Fixes #1665

Testing:
- Tried allocating more to subcategories than the parent allows ✅
- Verified that subcategory allocations are correctly restricted ✅

Demo:


https://github.com/user-attachments/assets/15ea047d-a621-4098-a1d3-8a1804f2fc2a

