### PR TITLE
fix: Liabilities favorable direction is "down"

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -115,7 +115,7 @@ class Family < ApplicationRecord
 
     {
       asset_series: TimeSeries.new(result.map { |r| { date: r.date, value: Money.new(r.assets, r.currency) } }),
-      liability_series: TimeSeries.new(result.map { |r| { date: r.date, value: Money.new(r.liabilities, r.currency) } }),
+      liability_series: TimeSeries.new(result.map { |r| { date: r.date, value: Money.new(r.liabilities, r.currency) } }, favorable_direction: "down"),
       net_worth_series: TimeSeries.new(result.map { |r| { date: r.date, value: Money.new(r.net_worth, r.currency) } })
     }
   end


### PR DESCRIPTION
Fixes: #1813.

Now the liabilities graph has the correct favorable direction



![image](https://github.com/user-attachments/assets/98b89cfc-5cd8-4a36-9461-f7709234da9b)
