### PR TITLE
Add pikapods.com hosting option

### DIFF
--- a/docs/hosting/one-click-deploy.md
+++ b/docs/hosting/one-click-deploy.md
@@ -2,6 +2,24 @@
 
 Below are our "one-click deploy" options for running Maybe in the cloud:
 
+## PikaPods
+
+Allows running a large selection of open source apps with just a few clicks.
+New users get $5 free welcome credit. Running Maybe is $1.7/month at the time
+of writing.
+
+You can also use your own domain, like `budget.example.com` or set up encrypted
+backups to your own S3 account.
+
+<a href="https://www.pikapods.com/pods?run=maybe">
+<img src="https://www.pikapods.com/static/run-button.svg" alt="Deploy to PikaPods" />
+</a>
+
+### Instructions
+
+1. [Sign up](https://www.pikapods.com/register) for an account and confirm email
+2. [Run](https://www.pikapods.com/pods?run=maybe) Maybe
+
 ## Render
 
 Welcome to the one-click deploy guide for Maybe on [Render](https://render.com/)!


### PR DESCRIPTION
This adds [pikapods.com](https://www.pikapods.com/) as additional one-click hosting option that's 90% cheaper and simpler than Render.

Thanks to our users, who [suggested](https://feedback.pikapods.com/posts/486/add-maybe-finance) the app about a year ago.

If the authors are interested, we also offer a revenue sharing option of 20%. Please get in touch at `hello at pikapods.com` to set it up.