### PR TITLE
Enhance Plaid connection management with re-authentication and error handling

### DIFF
--- a/app/controllers/plaid_items_controller.rb
+++ b/app/controllers/plaid_items_controller.rb
@@ -21,7 +21,10 @@ class PlaidItemsController < ApplicationController
       @plaid_item.sync_later
     end
 
-    redirect_to accounts_path
+    respond_to do |format|
+      format.html { redirect_to accounts_path }
+      format.json { head :ok }
+    end
   end
 
   private

--- a/app/helpers/plaid_helper.rb
+++ b/app/helpers/plaid_helper.rb
@@ -1,0 +1,9 @@
+module PlaidHelper
+  def plaid_webhooks_url(region = :us)
+    if Rails.env.production?
+      region.to_sym == :eu ? webhooks_plaid_eu_url : webhooks_plaid_url
+    else
+      ENV.fetch("DEV_WEBHOOKS_URL", root_url.chomp("/")) + "/webhooks/plaid#{region.to_sym == :eu ? '_eu' : ''}"
+    end
+  end
+end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -62,7 +62,7 @@ class Family < ApplicationRecord
     country != "US" && country != "CA"
   end
 
-  def get_link_token(webhooks_url:, redirect_url:, accountable_type: nil, region: :us)
+  def get_link_token(webhooks_url:, redirect_url:, accountable_type: nil, region: :us, access_token: nil)
     provider = if region.to_sym == :eu
       self.class.plaid_eu_provider
     else
@@ -77,6 +77,7 @@ class Family < ApplicationRecord
       webhooks_url: webhooks_url,
       redirect_url: redirect_url,
       accountable_type: accountable_type,
+      access_token: access_token
     ).link_token
   end
 

--- a/app/views/plaid_items/_plaid_item.html.erb
+++ b/app/views/plaid_items/_plaid_item.html.erb
@@ -28,6 +28,11 @@
               <%= lucide_icon "loader", class: "w-4 h-4 animate-pulse" %>
               <%= tag.span t(".syncing") %>
             </div>
+          <% elsif plaid_item.requires_update? %>
+            <div class="text-amber-500 flex items-center gap-1">
+              <%= lucide_icon "alert-triangle", class: "w-4 h-4" %>
+              <%= tag.span t(".requires_update") %>
+            </div>
           <% elsif plaid_item.sync_error.present? %>
             <div class="text-gray-500 flex items-center gap-1">
               <%= lucide_icon "alert-circle", class: "w-4 h-4 text-red-500" %>
@@ -42,8 +47,53 @@
       </div>
 
       <div class="flex items-center gap-2">
-        <%= button_to sync_plaid_item_path(plaid_item), disabled: plaid_item.syncing? || plaid_item.scheduled_for_deletion?, class: "disabled:text-gray-400 text-gray-900 flex hover:text-gray-800 items-center text-sm font-medium hover:underline" do %>
-          <%= lucide_icon "refresh-cw", class: "w-4 h-4" %>
+        <% if plaid_item.requires_update? %>
+          <% begin %>
+            <% link_token = plaid_item.get_update_link_token(webhooks_url: plaid_webhooks_url(plaid_item.plaid_region), redirect_url: accounts_url) %>
+            <button 
+              data-controller="plaid" 
+              data-action="plaid#open" 
+              data-plaid-region-value="<%= plaid_item.plaid_region %>"
+              data-plaid-link-token-value="<%= link_token %>"
+              data-plaid-is-update-value="true"
+              data-plaid-item-id-value="<%= plaid_item.id %>"
+              class="btn btn--secondary flex items-center gap-2"
+            >
+              <%= lucide_icon "refresh-cw", class: "w-4 h-4" %>
+              <%= tag.span t(".update") %>
+            </button>
+          <% rescue PlaidItem::PlaidConnectionLostError %>
+            <div class="flex flex-col gap-2">
+              <div class="text-amber-500 flex items-center gap-1">
+                <%= lucide_icon "alert-triangle", class: "w-4 h-4" %>
+                <%= tag.span t(".connection_lost") %>
+              </div>
+              <p class="text-sm text-gray-500"><%= t(".connection_lost_description") %></p>
+              <div class="flex items-center gap-2">
+                <%= button_to plaid_item_path(plaid_item),
+                          method: :delete,
+                          class: "btn btn--danger flex items-center gap-2",
+                          data: {
+                            turbo_confirm: {
+                              title: t(".confirm_title"),
+                              body: t(".confirm_body"),
+                              accept: t(".confirm_accept")
+                            }
+                          } do %>
+                  <%= lucide_icon "trash-2", class: "w-4 h-4" %>
+                  <%= tag.span t(".delete") %>
+                <% end %>
+                <%= link_to new_account_path, class: "btn btn--secondary flex items-center gap-2" do %>
+                  <%= lucide_icon "plus", class: "w-4 h-4" %>
+                  <%= tag.span t(".add_new") %>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <%= button_to sync_plaid_item_path(plaid_item), disabled: plaid_item.syncing? || plaid_item.scheduled_for_deletion?, class: "disabled:text-gray-400 text-gray-900 flex hover:text-gray-800 items-center text-sm font-medium hover:underline" do %>
+            <%= lucide_icon "refresh-cw", class: "w-4 h-4" %>
+          <% end %>
         <% end %>
 
         <%= contextual_menu do %>

--- a/config/locales/views/plaid_items/en.yml
+++ b/config/locales/views/plaid_items/en.yml
@@ -18,3 +18,9 @@ en:
       status: Last synced %{timestamp} ago
       status_never: Requires data sync
       syncing: Syncing...
+      requires_update: Requires re-authentication
+      update: Update connection
+      reconnect: Reconnect account
+      connection_lost: Connection lost
+      connection_lost_description: This connection is no longer valid. You'll need to delete this connection and add it again to continue syncing data.
+      add_new: Add new connection

--- a/config/locales/views/plaid_items/en.yml
+++ b/config/locales/views/plaid_items/en.yml
@@ -20,7 +20,6 @@ en:
       syncing: Syncing...
       requires_update: Requires re-authentication
       update: Update connection
-      reconnect: Reconnect account
       connection_lost: Connection lost
       connection_lost_description: This connection is no longer valid. You'll need to delete this connection and add it again to continue syncing data.
       add_new: Add new connection

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,9 @@ Rails.application.routes.draw do
   end
 
   resources :plaid_items, only: %i[create destroy] do
-    post :sync, on: :member
+    member do
+      post :sync
+    end
   end
 
   namespace :webhooks do

--- a/db/migrate/20250212163624_add_status_to_plaid_items.rb
+++ b/db/migrate/20250212163624_add_status_to_plaid_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToPlaidItems < ActiveRecord::Migration[7.2]
+  def change
+    add_column :plaid_items, :status, :string, null: false, default: "good"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_11_161238) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_12_163624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -520,6 +520,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_11_161238) do
     t.string "institution_url"
     t.string "institution_id"
     t.string "institution_color"
+    t.string "status", default: "good", null: false
     t.index ["family_id"], name: "index_plaid_items_on_family_id"
   end
 


### PR DESCRIPTION
Fixes #1583 

- Add support for Plaid item status tracking (good/requires_update)
- Implement re-authentication flow for Plaid connections
- Handle connection errors and provide user-friendly reconnection options
- Update Plaid link token generation to support item updates
- Add localization for new connection management states