### PR TITLE
fix: Ghost subcategories when parent category is deleted

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,7 +5,7 @@ class Category < ApplicationRecord
   belongs_to :family
 
   has_many :budget_categories, dependent: :destroy
-  has_many :subcategories, class_name: "Category", foreign_key: :parent_id
+  has_many :subcategories, class_name: "Category", foreign_key: :parent_id, dependent: :nullify
   belongs_to :parent, class_name: "Category", optional: true
 
   validates :name, :color, :family, presence: true


### PR DESCRIPTION
close #1872 