### PR TITLE
Fix parent category sums in budget

### DIFF
--- a/app/models/budget.rb
+++ b/app/models/budget.rb
@@ -100,11 +100,11 @@ class Budget < ApplicationRecord
   end
 
   def income_category_totals
-    income_totals.category_totals.reject { |ct| ct.category.subcategory? }.sort_by(&:weight).reverse
+    income_totals.category_totals.reject { |ct| ct.category.subcategory? || ct.total.zero? }.sort_by(&:weight).reverse
   end
 
   def expense_category_totals
-    expense_totals.category_totals.reject { |ct| ct.category.subcategory? }.sort_by(&:weight).reverse
+    expense_totals.category_totals.reject { |ct| ct.category.subcategory? || ct.total.zero? }.sort_by(&:weight).reverse
   end
 
   def current?

--- a/lib/tasks/demo_data.rake
+++ b/lib/tasks/demo_data.rake
@@ -12,6 +12,12 @@ namespace :demo_data do
   end
 
   task multi_currency: :environment do
-    Demo::Generator.new.generate_multi_currency_data!
+    families = [ "Demo Family 1", "Demo Family 2" ]
+    Demo::Generator.new.generate_multi_currency_data!(families)
+  end
+
+  task basic_budget: :environment do
+    families = [ "Demo Family 1" ]
+    Demo::Generator.new.generate_basic_budget_data!(families)
   end
 end

--- a/test/models/income_statement_test.rb
+++ b/test/models/income_statement_test.rb
@@ -8,15 +8,15 @@ class IncomeStatementTest < ActiveSupport::TestCase
 
     @income_category = @family.categories.create! name: "Income", classification: "income"
     @food_category = @family.categories.create! name: "Food", classification: "expense"
-    @shopping_category = @family.categories.create! name: "Shopping", classification: "expense", parent: @food_category
+    @groceries_category = @family.categories.create! name: "Groceries", classification: "expense", parent: @food_category
 
     @checking_account = @family.accounts.create! name: "Checking", currency: @family.currency, balance: 5000, accountable: Depository.new
     @credit_card_account = @family.accounts.create! name: "Credit Card", currency: @family.currency, balance: 1000, accountable: CreditCard.new
 
-    create_transaction(account: @checking_account, amount: -1000, category: @food_category)
-    create_transaction(account: @checking_account, amount: 200, category: @shopping_category)
-    create_transaction(account: @credit_card_account, amount: 300, category: @food_category)
-    create_transaction(account: @credit_card_account, amount: 400, category: @shopping_category)
+    create_transaction(account: @checking_account, amount: -1000, category: @income_category)
+    create_transaction(account: @checking_account, amount: 200, category: @groceries_category)
+    create_transaction(account: @credit_card_account, amount: 300, category: @groceries_category)
+    create_transaction(account: @credit_card_account, amount: 400, category: @groceries_category)
   end
 
   test "calculates totals for transactions" do
@@ -28,12 +28,23 @@ class IncomeStatementTest < ActiveSupport::TestCase
 
   test "calculates expenses for a period" do
     income_statement = IncomeStatement.new(@family)
-    assert_equal 200 + 300 + 400, income_statement.expense_totals(period: Period.last_30_days).total
+    expense_totals = income_statement.expense_totals(period: Period.last_30_days)
+
+    expected_total_expense = 200 + 300 + 400
+
+    assert_equal expected_total_expense, expense_totals.total
+    assert_equal expected_total_expense, expense_totals.category_totals.find { |ct| ct.category.id == @groceries_category.id }.total
+    assert_equal expected_total_expense, expense_totals.category_totals.find { |ct| ct.category.id == @food_category.id }.total
   end
 
   test "calculates income for a period" do
     income_statement = IncomeStatement.new(@family)
-    assert_equal 1000, income_statement.income_totals(period: Period.last_30_days).total
+    income_totals = income_statement.income_totals(period: Period.last_30_days)
+
+    expected_total_income = 1000
+
+    assert_equal expected_total_income, income_totals.total
+    assert_equal expected_total_income, income_totals.category_totals.find { |ct| ct.category.id == @income_category.id }.total
   end
 
   test "calculates median expense" do


### PR DESCRIPTION
The changes in #1823 introduced a regression where if a user had a parent category with _zero_ transactions assigned to it while there were transactions assigned to one or more of its subcategories, the parent category summed to 0.

This is because the totals query filters out any categories with no transactions.  This PR fixes this by ensuring that _all_ family categories are included in the `PeriodTotals` response of the `IncomeStatement`.