### PR TITLE
Fix import configuration form so number format is applied

### DIFF
--- a/app/controllers/import/configurations_controller.rb
+++ b/app/controllers/import/configurations_controller.rb
@@ -35,6 +35,7 @@ class Import::ConfigurationsController < ApplicationController
         :notes_col_label,
         :currency_col_label,
         :date_format,
+        :number_format,
         :signage_convention
       )
     end

--- a/test/controllers/import/configurations_controller_test.rb
+++ b/test/controllers/import/configurations_controller_test.rb
@@ -23,11 +23,24 @@ class Import::ConfigurationsControllerTest < ActionDispatch::IntegrationTest
         tags_col_label: "Tags",
         amount_col_label: "Amount",
         signage_convention: "inflows_positive",
-        account_col_label: "Account"
+        account_col_label: "Account",
+        number_format: "1.234,56"
       }
     }
 
     assert_redirected_to import_clean_url(@import)
     assert_equal "Import configured successfully.", flash[:notice]
+
+    # Verify configurations were saved
+    @import.reload
+    assert_equal "Date", @import.date_col_label
+    assert_equal "%Y-%m-%d", @import.date_format
+    assert_equal "Name", @import.name_col_label
+    assert_equal "Category", @import.category_col_label
+    assert_equal "Tags", @import.tags_col_label
+    assert_equal "Amount", @import.amount_col_label
+    assert_equal "inflows_positive", @import.signage_convention
+    assert_equal "Account", @import.account_col_label
+    assert_equal "1.234,56", @import.number_format
   end
 end


### PR DESCRIPTION
Previously, the number format was not being applied as it wasn't added to permitted params