### PR TITLE
Allow CSV imports to be configured with single or multi-account mode

### DIFF
--- a/app/controllers/import/confirms_controller.rb
+++ b/app/controllers/import/confirms_controller.rb
@@ -4,6 +4,10 @@ class Import::ConfirmsController < ApplicationController
   before_action :set_import
 
   def show
+    if @import.mapping_steps.empty?
+      return redirect_to import_path(@import)
+    end
+
     redirect_to import_clean_path(@import), alert: "You have invalid data, please edit until all errors are resolved" unless @import.cleaned?
   end
 

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -8,8 +8,8 @@ class Import::UploadsController < ApplicationController
 
   def update
     if csv_valid?(csv_str)
-      account = Current.family.accounts.find_by(id: upload_params[:account_id])
-      @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep], account: account)
+      @import.account = Current.family.accounts.find_by(id: params.dig(:import, :account_id))
+      @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep])
       @import.save!(validate: false)
 
       redirect_to import_configuration_path(@import), notice: "CSV uploaded successfully."
@@ -41,6 +41,6 @@ class Import::UploadsController < ApplicationController
     end
 
     def upload_params
-      params.require(:import).permit(:raw_file_str, :csv_file, :col_sep, :account_id)
+      params.require(:import).permit(:raw_file_str, :csv_file, :col_sep)
     end
 end

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -8,7 +8,8 @@ class Import::UploadsController < ApplicationController
 
   def update
     if csv_valid?(csv_str)
-      @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep])
+      account = Current.family.accounts.find_by(id: upload_params[:account_id])
+      @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep], account: account)
       @import.save!(validate: false)
 
       redirect_to import_configuration_path(@import), notice: "CSV uploaded successfully."
@@ -40,6 +41,6 @@ class Import::UploadsController < ApplicationController
     end
 
     def upload_params
-      params.require(:import).permit(:raw_file_str, :csv_file, :col_sep)
+      params.require(:import).permit(:raw_file_str, :csv_file, :col_sep, :account_id)
     end
 end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -18,7 +18,7 @@ class ImportsController < ApplicationController
   end
 
   def create
-    account = Current.family.accounts.find_by(id: import_params[:account_id])
+    account = Current.family.accounts.find_by(id: params.dig(:import, :account_id))
     import = Current.family.imports.create!(type: import_params[:type], account: account)
 
     redirect_to import_upload_path(import)
@@ -49,6 +49,6 @@ class ImportsController < ApplicationController
     end
 
     def import_params
-      params.require(:import).permit(:type, :account_id)
+      params.require(:import).permit(:type)
     end
 end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -18,7 +18,8 @@ class ImportsController < ApplicationController
   end
 
   def create
-    import = Current.family.imports.create! import_params
+    account = Current.family.accounts.find_by(id: import_params[:account_id])
+    import = Current.family.imports.create!(type: import_params[:type], account: account)
 
     redirect_to import_upload_path(import)
   end
@@ -48,6 +49,6 @@ class ImportsController < ApplicationController
     end
 
     def import_params
-      params.require(:import).permit(:type)
+      params.require(:import).permit(:type, :account_id)
     end
 end

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -106,7 +106,7 @@ class Family < ApplicationRecord
     # If family has any entries in different currencies, they need a provider for historical exchange rates
     uniq_currencies = entries.pluck(:currency).uniq
     return true if uniq_currencies.count > 1
-    return true if uniq_currencies.first != self.currency
+    return true if uniq_currencies.count > 0 && uniq_currencies.first != self.currency
 
     false
   end

--- a/app/models/import/account_mapping.rb
+++ b/app/models/import/account_mapping.rb
@@ -1,5 +1,5 @@
 class Import::AccountMapping < Import::Mapping
-  validates :mappable, presence: true, if: -> { key.blank? || !create_when_empty }
+  validates :mappable, presence: true, if: :requires_mapping?
 
   class << self
     def mapping_values(import)
@@ -42,4 +42,9 @@ class Import::AccountMapping < Import::Mapping
     self.mappable = account
     save!
   end
+
+  private
+    def requires_mapping?
+      (key.blank? || !create_when_empty) && import.account.nil?
+    end
 end

--- a/app/models/trade_import.rb
+++ b/app/models/trade_import.rb
@@ -4,7 +4,11 @@ class TradeImport < Import
       mappings.each(&:create_mappable!)
 
       rows.each do |row|
-        account = mappings.accounts.mappable_for(row.account)
+        mapped_account = if account
+          account
+        else
+          mappings.accounts.mappable_for(row.account)
+        end
 
         # Try to find or create security with ticker only
         security = find_or_create_security(
@@ -12,15 +16,15 @@ class TradeImport < Import
           exchange_operating_mic: row.exchange_operating_mic
         )
 
-        entry = account.entries.build \
+        entry = mapped_account.entries.build \
           date: row.date_iso,
           amount: row.signed_amount,
           name: row.name,
-          currency: row.currency.presence || account.currency,
+          currency: row.currency.presence || mapped_account.currency,
           entryable: Account::Trade.new(
             security: security,
             qty: row.qty,
-            currency: row.currency.presence || account.currency,
+            currency: row.currency.presence || mapped_account.currency,
             price: row.price
           ),
           import: self
@@ -31,7 +35,9 @@ class TradeImport < Import
   end
 
   def mapping_steps
-    [ Import::AccountMapping ]
+    base = []
+    base << Import::AccountMapping if account.nil?
+    base
   end
 
   def required_column_keys
@@ -39,14 +45,19 @@ class TradeImport < Import
   end
 
   def column_keys
-    %i[date ticker exchange_operating_mic currency qty price account name]
+    base = %i[date ticker exchange_operating_mic currency qty price name]
+    base.unshift(:account) if account.nil?
+    base
   end
 
   def dry_run
-    {
-      transactions: rows.count,
+    mappings = { transactions: rows.count }
+
+    mappings.merge(
       accounts: Import::AccountMapping.for_import(self).creational.count
-    }
+    ) if account.nil?
+
+    mappings
   end
 
   def csv_template
@@ -57,7 +68,9 @@ class TradeImport < Import
       05/17/2024,TSLA,XNAS,USD,2,700.50,Retirement Account,Tesla Inc. Purchase
     CSV
 
-    CSV.parse(template, headers: true)
+    csv = CSV.parse(template, headers: true)
+    csv.delete("account") if account.present?
+    csv
   end
 
   private

--- a/app/views/account/trades/_form.html.erb
+++ b/app/views/account/trades/_form.html.erb
@@ -29,11 +29,11 @@
       <% if %w[buy sell].include?(type) %>
         <% if Security.provider.present? %>
           <div class="form-field combobox">
-            <%= form.combobox :ticker, 
-                            securities_path(country_code: Current.family.country), 
+            <%= form.combobox :ticker,
+                            securities_path(country_code: Current.family.country),
                             name_when_new: "account_entry[manual_ticker]",
-                            label: t(".holding"), 
-                            placeholder: t(".ticker_placeholder"), 
+                            label: t(".holding"),
+                            placeholder: t(".ticker_placeholder"),
                             required: true %>
           </div>
         <% else %>

--- a/app/views/accounts/show/_menu.html.erb
+++ b/app/views/accounts/show/_menu.html.erb
@@ -20,7 +20,7 @@
       <% end %>
 
       <% unless account.crypto? %>
-        <%= button_to imports_path({ import: { type: account.investment? ? "TradeImport" : "TransactionImport", account_id: account.id } }), 
+        <%= button_to imports_path({ import: { type: account.investment? ? "TradeImport" : "TransactionImport", account_id: account.id } }),
                       data: { turbo_frame: :_top },
                       class: "block w-full py-2 px-3 space-x-2 text-primary hover:bg-gray-50 flex items-center rounded-lg" do %>
           <%= lucide_icon "download", class: "w-5 h-5 text-secondary" %>

--- a/app/views/accounts/show/_menu.html.erb
+++ b/app/views/accounts/show/_menu.html.erb
@@ -20,8 +20,8 @@
       <% end %>
 
       <% unless account.crypto? %>
-        <%= link_to new_import_path,
-                      data: { turbo_frame: :modal },
+        <%= button_to imports_path({ import: { type: account.investment? ? "TradeImport" : "TransactionImport", account_id: account.id } }), 
+                      data: { turbo_frame: :_top },
                       class: "block w-full py-2 px-3 space-x-2 text-primary hover:bg-gray-50 flex items-center rounded-lg" do %>
           <%= lucide_icon "download", class: "w-5 h-5 text-secondary" %>
 

--- a/app/views/import/configurations/_mint_import.html.erb
+++ b/app/views/import/configurations/_mint_import.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (import:) %>
 
-<div class="flex items-center justify-between border border-secondary rounded-lg bg-green-500/5 p-5 gap-4">
+<div class="flex items-center justify-between border border-secondary rounded-lg bg-green-500/5 p-5 gap-4 mb-4">
   <%= lucide_icon("check-circle", class: "w-5 h-5 shrink-0 text-green-500") %>
   <p class="text-sm text-primary italic">We have pre-configured your Mint import for you. Please proceed to the next step.</p>
 </div>
@@ -21,7 +21,10 @@
     <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
   </div>
 
-  <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
+  <% unless import.account.present? %>
+    <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" }, disabled: import.complete? %>
+  <% end %>
+
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" }, disabled: import.complete? %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" }, disabled: import.complete? %>
   <%= form.select :tags_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Tags (optional)" }, disabled: import.complete? %>

--- a/app/views/import/configurations/_trade_import.html.erb
+++ b/app/views/import/configurations/_trade_import.html.erb
@@ -20,7 +20,11 @@
     <%= form.select :ticker_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Ticker" } %>
     <%= form.select :exchange_operating_mic_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Exchange Operating MIC" } %>
     <%= form.select :price_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Price" } %>
-    <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
+
+    <% unless import.account.present? %>
+      <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
+    <% end %>
+
     <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
 
     <% unless Security.provider %>

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -16,7 +16,10 @@
     <%= form.select :number_format, Import::NUMBER_FORMATS.keys, { label: "Format", prompt: "Select format" }, required: true %>
   </div>
 
-  <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
+  <% unless import.account.present? %>
+    <%= form.select :account_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Account (optional)" } %>
+  <% end %>
+
   <%= form.select :name_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Name (optional)" } %>
   <%= form.select :category_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Category (optional)" } %>
   <%= form.select :tags_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Tags (optional)" } %>

--- a/app/views/import/confirms/_mappings.html.erb
+++ b/app/views/import/confirms/_mappings.html.erb
@@ -3,7 +3,7 @@
 <% mappings = mapping_class.for_import(import) %>
 <% is_last_step = step_idx == import.mapping_steps.count - 1 %>
 
-<% if mapping_class == Import::AccountMapping %>
+<% if mapping_class == Import::AccountMapping && import.account.nil? %>
   <% if import.requires_account? %>
     <div class="flex items-center justify-between p-4 mb-4 gap-4 text-secondary bg-red-100 border border-red-200 rounded-lg w-[650px]">
       <%= tag.p t(".no_accounts"), class: "text-sm" %>

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -19,33 +19,33 @@
         </div>
       </div>
 
-      <div data-tabs-target="tab" id="csv-paste-tab">
-        <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-2" do |form| %>
-          <%= form.select :col_sep, [["Comma (,)", ","], ["Semicolon (;)", ";"]], label: true %>
-          <%= form.text_area :raw_file_str,
+      <% ["csv-paste-tab", "csv-upload-tab"].each do |tab| %>
+        <%= tag.div id: tab, data: { tabs_target: "tab" }, class: tab == "csv-upload-tab" ? "hidden" : "" do %>
+          <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-2" do |form| %>
+            <%= form.select :col_sep, Import::SEPARATORS, label: true %>
+
+            <% unless @import.type == "MintImport" %>
+              <%= form.select :account_id, @import.family.accounts.pluck(:name, :id), { label: "Account (optional)", include_blank: "Multi-account import" } %>
+            <% end %>
+
+            <% if tab == "csv-paste-tab" %>
+              <%= form.text_area :raw_file_str,
                        rows: 10,
                        required: true,
                        placeholder: "Paste your CSV file contents here",
                        "data-auto-submit-form-target": "auto" %>
+            <% else %>
+              <label for="import_csv_file" class="flex flex-col items-center justify-center w-full h-56 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50">
+                <div class="flex flex-col items-center justify-center pt-5 pb-6">
+                  <%= form.file_field :csv_file, class: "ml-32", "data-auto-submit-form-target": "auto" %>
+                </div>
+              </label>
+            <% end %>
 
-          <%= form.submit "Upload CSV", disabled: @import.complete? %>
+            <%= form.submit "Upload CSV", disabled: @import.complete? %>
+          <% end %>
         <% end %>
-
-      </div>
-
-      <div data-tabs-target="tab" id="csv-upload-tab" class="hidden">
-        <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-2" do |form| %>
-          <%= form.select :col_sep, [["Comma (,)", ","], ["Semicolon (;)", ";"]], label: true %>
-
-          <label for="import_csv_file" class="flex flex-col items-center justify-center w-full h-56 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer bg-gray-50">
-            <div class="flex flex-col items-center justify-center pt-5 pb-6">
-              <%= form.file_field :csv_file, class: "ml-32", "data-auto-submit-form-target": "auto" %>
-            </div>
-          </label>
-
-          <%= form.submit "Upload CSV", disabled: @import.complete? %>
-        <% end %>
-      </div>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -25,7 +25,7 @@
             <%= form.select :col_sep, Import::SEPARATORS, label: true %>
 
             <% unless @import.type == "MintImport" %>
-              <%= form.select :account_id, @import.family.accounts.pluck(:name, :id), { label: "Account (optional)", include_blank: "Multi-account import" } %>
+              <%= form.select :account_id, @import.family.accounts.pluck(:name, :id), { label: "Account (optional)", include_blank: "Multi-account import", selected: @import.account_id } %>
             <% end %>
 
             <% if tab == "csv-paste-tab" %>

--- a/app/views/imports/_import.html.erb
+++ b/app/views/imports/_import.html.erb
@@ -2,6 +2,10 @@
 
   <div class="flex items-center gap-2 mb-1">
     <%= link_to import_path(import), class: "text-sm text-primary hover:underline" do %>
+      <% if import.account.present? %>
+        <%= import.account.name + " " %>
+      <% end %>
+
       <%= t(".label", type: import.type.titleize, datetime: import.updated_at.strftime("%b %-d, %Y at %l:%M %p")) %>
     <% end %>
 

--- a/app/views/imports/_nav.html.erb
+++ b/app/views/imports/_nav.html.erb
@@ -6,7 +6,7 @@
   { name: "Clean", path: import_clean_path(import), is_complete: import.cleaned?, step_number: 3 },
   { name: "Map", path: import_confirm_path(import), is_complete: import.publishable?, step_number: 4 },
   { name: "Confirm", path: import_path(import), is_complete: import.complete?, step_number: 5 }
-] %>
+].reject { |step| step[:name] == "Map" && import.mapping_steps.empty? } %>
 
 <ul class="flex items-center gap-2">
   <% steps.each_with_index do |step, idx| %>

--- a/db/migrate/20250303141007_add_optional_account_for_import.rb
+++ b/db/migrate/20250303141007_add_optional_account_for_import.rb
@@ -1,0 +1,5 @@
+class AddOptionalAccountForImport < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :imports, :original_account_id, :account_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -544,31 +544,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_03_141007) do
     t.index ["outflow_transaction_id"], name: "index_rejected_transfers_on_outflow_transaction_id"
   end
 
-  create_table "rule_actions", force: :cascade do |t|
-    t.uuid "rule_id", null: false
-    t.string "action_type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["rule_id"], name: "index_rule_actions_on_rule_id"
-  end
-
-  create_table "rule_triggers", force: :cascade do |t|
-    t.uuid "rule_id", null: false
-    t.string "trigger_type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["rule_id"], name: "index_rule_triggers_on_rule_id"
-  end
-
-  create_table "rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "family_id", null: false
-    t.date "effective_date", null: false
-    t.boolean "active", default: true, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["family_id"], name: "index_rules_on_family_id"
-  end
-
   create_table "securities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "ticker", null: false
     t.string "name"
@@ -744,9 +719,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_03_141007) do
   add_foreign_key "plaid_items", "families"
   add_foreign_key "rejected_transfers", "account_transactions", column: "inflow_transaction_id"
   add_foreign_key "rejected_transfers", "account_transactions", column: "outflow_transaction_id"
-  add_foreign_key "rule_actions", "rules"
-  add_foreign_key "rule_triggers", "rules"
-  add_foreign_key "rules", "families"
   add_foreign_key "security_prices", "securities"
   add_foreign_key "sessions", "impersonation_sessions", column: "active_impersonator_session_id"
   add_foreign_key "sessions", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_20_200735) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_03_141007) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -398,7 +398,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_20_200735) do
     t.datetime "updated_at", null: false
     t.string "col_sep", default: ","
     t.uuid "family_id", null: false
-    t.uuid "original_account_id"
+    t.uuid "account_id"
     t.string "type", null: false
     t.string "date_col_label", default: "date"
     t.string "amount_col_label", default: "amount"
@@ -542,6 +542,31 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_20_200735) do
     t.index ["inflow_transaction_id", "outflow_transaction_id"], name: "idx_on_inflow_transaction_id_outflow_transaction_id_412f8e7e26", unique: true
     t.index ["inflow_transaction_id"], name: "index_rejected_transfers_on_inflow_transaction_id"
     t.index ["outflow_transaction_id"], name: "index_rejected_transfers_on_outflow_transaction_id"
+  end
+
+  create_table "rule_actions", force: :cascade do |t|
+    t.uuid "rule_id", null: false
+    t.string "action_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["rule_id"], name: "index_rule_actions_on_rule_id"
+  end
+
+  create_table "rule_triggers", force: :cascade do |t|
+    t.uuid "rule_id", null: false
+    t.string "trigger_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["rule_id"], name: "index_rule_triggers_on_rule_id"
+  end
+
+  create_table "rules", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "family_id", null: false
+    t.date "effective_date", null: false
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["family_id"], name: "index_rules_on_family_id"
   end
 
   create_table "securities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -719,6 +744,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_20_200735) do
   add_foreign_key "plaid_items", "families"
   add_foreign_key "rejected_transfers", "account_transactions", column: "inflow_transaction_id"
   add_foreign_key "rejected_transfers", "account_transactions", column: "outflow_transaction_id"
+  add_foreign_key "rule_actions", "rules"
+  add_foreign_key "rule_triggers", "rules"
+  add_foreign_key "rules", "families"
   add_foreign_key "security_prices", "securities"
   add_foreign_key "sessions", "impersonation_sessions", column: "active_impersonator_session_id"
   add_foreign_key "sessions", "users"

--- a/test/controllers/import/rows_controller_test.rb
+++ b/test/controllers/import/rows_controller_test.rb
@@ -22,7 +22,7 @@ class Import::RowsControllerTest < ActionDispatch::IntegrationTest
 
     get import_row_path(import, row)
 
-    assert_row_fields(row, [ :date, :ticker, :qty, :price, :currency, :account, :name ])
+    assert_row_fields(row, [ :date, :ticker, :qty, :price, :currency, :account, :name, :account ])
 
     assert_response :success
   end


### PR DESCRIPTION
Many users have expressed confusion about not being able to assign a CSV import to a single account.  This PR enables two modes:

- **Single account import** - all transactions will be assigned to the selected account, regardless of CSV row data
- **Multi-account import** - transactions will be assigned to the account specified in each row of the import, based on account mappings configured in the "map" step of the import process