### PR TITLE
Account-level import configuration templates

### DIFF
--- a/app/controllers/import/rows_controller.rb
+++ b/app/controllers/import/rows_controller.rb
@@ -2,9 +2,7 @@ class Import::RowsController < ApplicationController
   before_action :set_import_row
 
   def update
-    @row.assign_attributes(row_params)
-    @row.save!(validate: false)
-    @row.sync_mappings
+    @row.update_and_sync(row_params)
 
     redirect_to import_row_path(@row.import, @row)
   end

--- a/app/controllers/import/uploads_controller.rb
+++ b/app/controllers/import/uploads_controller.rb
@@ -12,7 +12,7 @@ class Import::UploadsController < ApplicationController
       @import.assign_attributes(raw_file_str: csv_str, col_sep: upload_params[:col_sep])
       @import.save!(validate: false)
 
-      redirect_to import_configuration_path(@import), notice: "CSV uploaded successfully."
+      redirect_to import_configuration_path(@import, template_hint: true), notice: "CSV uploaded successfully."
     else
       flash.now[:alert] = "Must be valid CSV with headers and at least one row of data"
 

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -19,7 +19,11 @@ class ImportsController < ApplicationController
 
   def create
     account = Current.family.accounts.find_by(id: params.dig(:import, :account_id))
-    import = Current.family.imports.create!(type: import_params[:type], account: account)
+    import = Current.family.imports.create!(
+      type: import_params[:type],
+      account: account,
+      date_format: Current.family.date_format,
+    )
 
     redirect_to import_upload_path(import)
   end

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,5 +1,5 @@
 class ImportsController < ApplicationController
-  before_action :set_import, only: %i[show publish destroy revert]
+  before_action :set_import, only: %i[show publish destroy revert apply_template]
 
   def publish
     @import.publish_later
@@ -35,6 +35,15 @@ class ImportsController < ApplicationController
   def revert
     @import.revert_later
     redirect_to imports_path, notice: "Import is reverting in the background."
+  end
+
+  def apply_template
+    if @import.suggested_template
+      @import.apply_template!(@import.suggested_template)
+      redirect_to import_configuration_path(@import), notice: "Template applied."
+    else
+      redirect_to import_configuration_path(@import), alert: "No template found, please manually configure your import."
+    end
   end
 
   def destroy

--- a/app/models/import/account_mapping.rb
+++ b/app/models/import/account_mapping.rb
@@ -2,8 +2,11 @@ class Import::AccountMapping < Import::Mapping
   validates :mappable, presence: true, if: :requires_mapping?
 
   class << self
-    def mapping_values(import)
-      import.rows.map(&:account).uniq
+    def mappables_by_key(import)
+      unique_values = import.rows.map(&:account).uniq
+      accounts = import.family.accounts.where(name: unique_values).index_by(&:name)
+
+      unique_values.index_with { |value| accounts[value] }
     end
   end
 

--- a/app/models/import/account_type_mapping.rb
+++ b/app/models/import/account_type_mapping.rb
@@ -2,8 +2,8 @@ class Import::AccountTypeMapping < Import::Mapping
   validates :value, presence: true
 
   class << self
-    def mapping_values(import)
-      import.rows.map(&:entity_type).uniq
+    def mappables_by_key(import)
+      import.rows.map(&:entity_type).uniq.index_with { nil }
     end
   end
 

--- a/app/models/import/category_mapping.rb
+++ b/app/models/import/category_mapping.rb
@@ -1,7 +1,10 @@
 class Import::CategoryMapping < Import::Mapping
   class << self
-    def mapping_values(import)
-      import.rows.map(&:category).uniq
+    def mappables_by_key(import)
+      unique_values = import.rows.map(&:category).uniq
+      categories = import.family.categories.where(name: unique_values).index_by(&:name)
+
+      unique_values.index_with { |value| categories[value] }
     end
   end
 

--- a/app/models/import/mapping.rb
+++ b/app/models/import/mapping.rb
@@ -18,19 +18,8 @@ class Import::Mapping < ApplicationRecord
       find_by(key: key)&.mappable
     end
 
-    def sync(import)
-      unique_values = mapping_values(import).uniq
-
-      unique_values.each do |value|
-        mapping = find_or_initialize_by(key: value, import: import, create_when_empty: value.present?)
-        mapping.save(validate: false) if mapping.new_record?
-      end
-
-      where(import: import).where.not(key: unique_values).destroy_all
-    end
-
-    def mapping_values(import)
-      raise NotImplementedError, "Subclass must implement mapping_values"
+    def mappables_by_key(import)
+      raise NotImplementedError, "Subclass must implement mappables_by_key"
     end
   end
 

--- a/app/models/import/row.rb
+++ b/app/models/import/row.rb
@@ -30,11 +30,10 @@ class Import::Row < ApplicationRecord
     end
   end
 
-  def sync_mappings
-    Import::CategoryMapping.sync(import) if import.column_keys.include?(:category)
-    Import::TagMapping.sync(import) if import.column_keys.include?(:tags)
-    Import::AccountMapping.sync(import) if import.column_keys.include?(:account)
-    Import::AccountTypeMapping.sync(import) if import.column_keys.include?(:entity_type)
+  def update_and_sync(params)
+    assign_attributes(params)
+    save!(validate: false)
+    import.sync_mappings
   end
 
   private

--- a/app/models/import/tag_mapping.rb
+++ b/app/models/import/tag_mapping.rb
@@ -1,7 +1,11 @@
 class Import::TagMapping < Import::Mapping
   class << self
-    def mapping_values(import)
-      import.rows.map(&:tags_list).flatten.uniq
+    def mappables_by_key(import)
+      unique_values = import.rows.map(&:tags_list).flatten.uniq
+
+      tags = import.family.tags.where(name: unique_values).index_by(&:name)
+
+      unique_values.index_with { |value| tags[value] }
     end
   end
 

--- a/app/views/import/configurations/show.html.erb
+++ b/app/views/import/configurations/show.html.erb
@@ -4,14 +4,33 @@
 
 <%= content_for :previous_path, import_upload_path(@import) %>
 
-<div>
+<% if @import.suggested_template.present? && params[:template_hint] == "true" %>
+  <div class="py-12">
+    <div class="shadow-border-xs rounded-lg p-4 max-w-lg mx-auto">
+      <h3 class="text-sm font-medium mb-2 flex items-center gap-2">
+        <span class="text-success">
+          <%= icon "sparkles" %>
+        </span>
+
+        Template configuration found
+      </h3>
+
+      <p class="text-sm text-secondary">We found a configuration from a previous import for this account.  Would you like to apply it to this import?</p>
+
+      <div class="mt-4 flex gap-2 items-center">
+        <%= link_to "Manually configure", import_configuration_path(@import), class: "btn btn--outline" %>
+        <%= button_to "Apply template", apply_template_import_path(@import), class: "btn btn--primary", method: :put, data: { turbo_frame: :_top } %>
+      </div>
+    </div>
+  </div>
+<% else %>
   <div class="space-y-4">
     <div class="text-center space-y-2">
       <h1 class="text-3xl text-primary font-medium"><%= t(".title") %></h1>
       <p class="text-secondary text-sm"><%= t(".description") %></p>
     </div>
 
-    <div class="mx-auto max-w-lg">
+    <div class="mx-auto max-w-lg space-y-3">
       <%= render partial: permitted_import_configuration_path(@import), locals: { import: @import } %>
     </div>
   </div>
@@ -19,4 +38,4 @@
   <div class="mx-auto max-w-5xl my-12">
     <%= render "imports/table", headers: @import.csv_headers, rows: @import.csv_sample, caption: "Sample data from your uploaded CSV" %>
   </div>
-</div>
+<% end %>

--- a/app/views/import/uploads/show.html.erb
+++ b/app/views/import/uploads/show.html.erb
@@ -24,7 +24,7 @@
           <%= styled_form_with model: @import, scope: :import, url: import_upload_path(@import), multipart: true, class: "space-y-2" do |form| %>
             <%= form.select :col_sep, Import::SEPARATORS, label: true %>
 
-            <% unless @import.type == "MintImport" %>
+            <% if @import.type == "TransactionImport" || @import.type == "TradeImport" %>
               <%= form.select :account_id, @import.family.accounts.pluck(:name, :id), { label: "Account (optional)", include_blank: "Multi-account import", selected: @import.account_id } %>
             <% end %>
 

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -16,7 +16,7 @@
         <%= lucide_icon "check", class: "w-3 h-3" %>
       </div>
     <% when :alert %>
-      <div class="flex h-full items-center justify-center rounded-full bg-error">
+      <div class="flex h-full items-center justify-center rounded-full bg-destructive">
         <%= lucide_icon "x", class: "w-3 h-3" %>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,8 +68,11 @@ Rails.application.routes.draw do
   resources :transfers, only: %i[new create destroy show update]
 
   resources :imports, only: %i[index new show create destroy] do
-    post :publish, on: :member
-    put :revert, on: :member
+    member do
+      post :publish
+      put :revert
+      put :apply_template
+    end
 
     resource :upload, only: %i[show update], module: :import
     resource :configuration, only: %i[show update], module: :import

--- a/test/controllers/import/uploads_controller_test.rb
+++ b/test/controllers/import/uploads_controller_test.rb
@@ -19,7 +19,7 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to import_configuration_url(@import)
+    assert_redirected_to import_configuration_url(@import, template_hint: true)
     assert_equal "CSV uploaded successfully.", flash[:notice]
   end
 
@@ -31,7 +31,7 @@ class Import::UploadsControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to import_configuration_url(@import)
+    assert_redirected_to import_configuration_url(@import, template_hint: true)
     assert_equal "CSV uploaded successfully.", flash[:notice]
   end
 


### PR DESCRIPTION
This PR helps users who are importing monthly bank statements and need Maybe to "remember" the configuration they used for the previous import on a specific account.  In the video below, notice how configuration properties _and_ mapping values are automatically set for the user on the _second_ import for the same account:


https://github.com/user-attachments/assets/0f9d0bfe-2d9c-4cca-bac4-369c70bd2789

