### PR TITLE
Fix ticker filling when Synth is connected

### DIFF
--- a/app/controllers/securities_controller.rb
+++ b/app/controllers/securities_controller.rb
@@ -1,10 +1,7 @@
 class SecuritiesController < ApplicationController
   def index
-    query = params[:q]
-    return render json: [] if query.blank? || query.length < 2 || query.length > 100
-
     @securities = Security.search_provider({
-      search: query,
+      search: params[:q],
       country: params[:country_code] == "US" ? "US" : nil
     })
   end

--- a/app/models/security/provided.rb
+++ b/app/models/security/provided.rb
@@ -9,6 +9,8 @@ module Security::Provided
     end
 
     def search_provider(query)
+      return [] if query[:search].blank? || query[:search].length < 2
+
       response = provider.search_securities(
         query: query[:search],
         dataset: "limited",


### PR DESCRIPTION
Fixes #1949 

Manual tickers should now work when Synth is not connected and when it is:

https://github.com/user-attachments/assets/43bab4b7-e4fd-4eea-9c66-426899d93c26

