### PR TITLE
Fix: Purge stale holdings from accounts during sync

### DIFF
--- a/app/controllers/account/holdings_controller.rb
+++ b/app/controllers/account/holdings_controller.rb
@@ -9,9 +9,12 @@ class Account::HoldingsController < ApplicationController
   end
 
   def destroy
-    @holding.destroy_holding_and_entries!
-
-    flash[:notice] = t(".success")
+    if @holding.account.plaid_account_id.present?
+      flash[:alert] = "You cannot delete this holding"
+    else
+      @holding.destroy_holding_and_entries!
+      flash[:notice] = t(".success")
+    end
 
     respond_to do |format|
       format.html { redirect_back_or_to account_path(@holding.account) }

--- a/app/controllers/plaid_items_controller.rb
+++ b/app/controllers/plaid_items_controller.rb
@@ -22,7 +22,7 @@ class PlaidItemsController < ApplicationController
     end
 
     respond_to do |format|
-      format.html { redirect_to accounts_path }
+      format.html { redirect_back_or_to accounts_path }
       format.json { head :ok }
     end
   end

--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -47,7 +47,7 @@ class Account::Syncer
 
       Account.transaction do
         load_holdings(calculated_holdings)
-        purge_outdated_holdings
+        purge_outdated_holdings unless plaid_sync?
       end
 
       calculated_holdings
@@ -139,8 +139,8 @@ class Account::Syncer
     def purge_outdated_holdings
       portfolio_security_ids = account.entries.account_trades.map { |entry| entry.entryable.security_id }.uniq
 
-      if portfolio_security_ids.empty? && !plaid_sync?
-        # If there are no securities in the portfolio and it's not a plaid sync, delete all holdings
+      # If there are no securities in the portfolio, delete all holdings
+      if portfolio_security_ids.empty?
         account.holdings.delete_all
       else
         account.holdings.delete_by("date < ? OR security_id NOT IN (?)", account_start_date, portfolio_security_ids)

--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -10,7 +10,7 @@ class Account::Syncer
     holdings = sync_holdings
     balances = sync_balances(holdings)
     account.reload
-    update_account_info(balances, holdings) unless
+    update_account_info(balances, holdings) unless plaid_sync?
     convert_records_to_family_currency(balances, holdings) unless account.currency == account.family.currency
 
     # Enrich if user opted in or if we're syncing transactions from a Plaid account on the hosted app

--- a/app/views/account/holdings/index.html.erb
+++ b/app/views/account/holdings/index.html.erb
@@ -21,12 +21,12 @@
       </div>
 
       <div class="rounded-lg bg-white shadow-border-xs">
+        <%= render "account/holdings/cash", account: @account %>
+
+        <%= render "account/holdings/ruler" %>
+
         <% if @account.current_holdings.any? %>
-          <%= render "account/holdings/cash", account: @account %>
-          <%= render "account/holdings/ruler" %>
           <%= render partial: "account/holdings/holding", collection: @account.current_holdings, spacer_template: "ruler" %>
-        <% else %>
-          <p class="text-secondary text-sm p-4"><%= t(".no_holdings") %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/account/holdings/show.html.erb
+++ b/app/views/account/holdings/show.html.erb
@@ -87,26 +87,28 @@
       </div>
     </details>
 
-    <details class="group space-y-2" open>
-      <summary class="flex list-none items-center justify-between rounded-xl px-3 py-2 text-xs font-medium uppercase text-secondary bg-gray-25 focus-visible:outline-hidden">
-        <h4><%= t(".settings") %></h4>
-        <%= lucide_icon "chevron-down", class: "group-open:transform group-open:rotate-180 text-secondary w-5" %>
-      </summary>
+    <% unless @holding.account.plaid_account_id.present? %>
+      <details class="group space-y-2" open>
+        <summary class="flex list-none items-center justify-between rounded-xl px-3 py-2 text-xs font-medium uppercase text-secondary bg-gray-25 focus-visible:outline-hidden">
+          <h4><%= t(".settings") %></h4>
+          <%= lucide_icon "chevron-down", class: "group-open:transform group-open:rotate-180 text-secondary w-5" %>
+        </summary>
 
-      <div class="pb-4">
-        <div class="flex items-center justify-between gap-2 p-3">
-          <div class="text-sm space-y-1">
-            <h4 class="text-primary"><%= t(".delete_title") %></h4>
-            <p class="text-secondary"><%= t(".delete_subtitle") %></p>
-          </div>
+        <div class="pb-4">
+          <div class="flex items-center justify-between gap-2 p-3">
+            <div class="text-sm space-y-1">
+              <h4 class="text-primary"><%= t(".delete_title") %></h4>
+              <p class="text-secondary"><%= t(".delete_subtitle") %></p>
+            </div>
 
-          <%= button_to t(".delete"),
+            <%= button_to t(".delete"),
                 account_holding_path(@holding),
                 method: :delete,
                 class: "rounded-lg px-3 py-2 text-red-500 text-sm font-medium border border-secondary",
                 data: { turbo_confirm: true } %>
+          </div>
         </div>
-      </div>
-    </details>
+      </details>
+    <% end %>
   </div>
 <% end %>

--- a/test/models/account/syncer_test.rb
+++ b/test/models/account/syncer_test.rb
@@ -17,6 +17,8 @@ class Account::SyncerTest < ActiveSupport::TestCase
     @account.family.update! currency: "USD"
     @account.update! currency: "EUR"
 
+    @account.entries.create!(date: 1.day.ago.to_date, currency: "EUR", amount: 500, name: "Buy AAPL", entryable: Account::Trade.new(security: securities(:aapl), qty: 10, price: 50, currency: "EUR"))
+
     ExchangeRate.create!(date: 1.day.ago.to_date, from_currency: "EUR", to_currency: "USD", rate: 1.2)
     ExchangeRate.create!(date: Date.current, from_currency: "EUR", to_currency: "USD", rate: 2)
 


### PR DESCRIPTION
This PR fixes a few things related to holding deletions:

- When there are no holdings, we now show the "Cash balance" (previously, this was hidden when there were no holdings)
- Removes the ability for a user to delete Plaid holdings (because they are externally managed)
- When manual holding is deleted, it properly removes the holding (addresses #1953 directly)