### PR TITLE
Format money for trade history in holdings drawer

### DIFF
--- a/app/views/account/holdings/show.html.erb
+++ b/app/views/account/holdings/show.html.erb
@@ -73,7 +73,7 @@
                       ".trade_history_entry",
                       qty: trade_entry.account_trade.qty,
                       security: trade_entry.account_trade.security.ticker,
-                      price: format_money(trade_entry.account_trade.price)
+                      price: trade_entry.account_trade.price_money.format
                     ) %></p>
                   </div>
                 </li>

--- a/app/views/accounts/show/_chart.html.erb
+++ b/app/views/accounts/show/_chart.html.erb
@@ -21,8 +21,7 @@
             [["Total value", "balance"], ["Holdings", "holdings_balance"], ["Cash", "cash_balance"]],
             { selected: chart_view },
             class: "border border-secondary rounded-lg text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0",
-            data: { "auto-submit-form-target": "auto" }
-          %>
+            data: { "auto-submit-form-target": "auto" } %>
         <% end %>
 
         <%= period_select form: form, selected: period %>

--- a/lib/money/formatting.rb
+++ b/lib/money/formatting.rb
@@ -13,7 +13,7 @@ module Money::Formatting
     local_option_overrides = locale_options(locale)
 
     {
-      unit: currency.symbol,
+      unit: get_symbol,
       precision: currency.default_precision,
       delimiter: currency.delimiter,
       separator: currency.separator,
@@ -22,6 +22,14 @@ module Money::Formatting
   end
 
   private
+    def get_symbol
+      if currency.symbol == "$" && currency.iso_code != "USD"
+        [ currency.iso_code.first(2), currency.symbol ].join
+      else
+        currency.symbol
+      end
+    end
+
     def locale_options(locale)
       case [ currency.iso_code, locale.to_sym ]
       when [ "EUR", :nl ], [ "EUR", :pt ]

--- a/test/models/security/price_test.rb
+++ b/test/models/security/price_test.rb
@@ -33,7 +33,7 @@ class Security::PriceTest < ActiveSupport::TestCase
     tomorrow = Date.current + 1.day
 
     @provider.expects(:fetch_security_prices)
-            .with(ticker: security.ticker, mic_code: security.exchange_mic, start_date: tomorrow, end_date: tomorrow)
+            .with(ticker: security.ticker, mic_code: security.exchange_operating_mic, start_date: tomorrow, end_date: tomorrow)
             .once
             .returns(
               OpenStruct.new(
@@ -54,7 +54,7 @@ class Security::PriceTest < ActiveSupport::TestCase
     Security::Price.delete_all # Clear any existing prices
 
     @provider.expects(:fetch_security_prices)
-             .with(ticker: security.ticker, mic_code: security.exchange_mic, start_date: Date.current, end_date: Date.current)
+             .with(ticker: security.ticker, mic_code: security.exchange_operating_mic, start_date: Date.current, end_date: Date.current)
              .once
              .returns(OpenStruct.new(success?: false))
 
@@ -91,7 +91,7 @@ class Security::PriceTest < ActiveSupport::TestCase
 
     @provider.expects(:fetch_security_prices)
              .with(ticker: security.ticker,
-                  mic_code: security.exchange_mic,
+                  mic_code: security.exchange_operating_mic,
                   start_date: 2.days.ago.to_date,
                   end_date: 2.days.ago.to_date)
              .returns(OpenStruct.new(success?: true, prices: [ { date: 2.days.ago.to_date, price: missing_price, currency: "USD" } ]))


### PR DESCRIPTION
- Fixes currency formatting bug
- Disambiguates currencies that have `$` as their primary symbol but are not USD.  Since Maybe often shows multiple currencies in a single view, its unclear when printing say, `MXN` with just the `$` symbol.  For all currencies that have `$` as their symbol and are NOT `USD`, we will show them with the first 2 characters of their iso code + $, such as `MX$`