### PR TITLE
perf(imports): Bulk import CSV transactions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem "intercom-rails"
 gem "plaid"
 gem "rotp", "~> 6.3"
 gem "rqrcode", "~> 2.2"
+gem "activerecord-import"
 
 group :development, :test do
   gem "debug", platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       activemodel (= 7.2.2.1)
       activesupport (= 7.2.2.1)
       timeout (>= 0.4.0)
+    activerecord-import (2.1.0)
+      activerecord (>= 4.2)
     activestorage (7.2.2.1)
       actionpack (= 7.2.2.1)
       activejob (= 7.2.2.1)
@@ -529,6 +531,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  activerecord-import
   aws-sdk-s3 (~> 1.177.0)
   bcrypt (~> 3.1)
   benchmark-ips

--- a/app/models/transaction_import.rb
+++ b/app/models/transaction_import.rb
@@ -3,7 +3,7 @@ class TransactionImport < Import
     transaction do
       mappings.each(&:create_mappable!)
 
-      rows.each do |row|
+      transactions = rows.map do |row|
         mapped_account = if account
           account
         else
@@ -13,17 +13,22 @@ class TransactionImport < Import
         category = mappings.categories.mappable_for(row.category)
         tags = row.tags_list.map { |tag| mappings.tags.mappable_for(tag) }.compact
 
-        entry = mapped_account.entries.build \
-          date: row.date_iso,
-          amount: row.signed_amount,
-          name: row.name,
-          currency: row.currency,
-          notes: row.notes,
-          entryable: Account::Transaction.new(category: category, tags: tags),
-          import: self
-
-        entry.save!
+        Account::Transaction.new(
+          category: category,
+          tags: tags,
+          entry: Account::Entry.new(
+            account: mapped_account,
+            date: row.date_iso,
+            amount: row.signed_amount,
+            name: row.name,
+            currency: row.currency,
+            notes: row.notes,
+            import: self
+          )
+        )
       end
+
+      Account::Transaction.import!(transactions, recursive: true)
     end
   end
 


### PR DESCRIPTION
Bulk import transactions from CSV instead of importing each row at a time resulting in a optimization in performance and faster imports

| Entries | Before: (s)  | After: (s) |
|:---:|:---:|:---:|
| 1000 | 5.7 | 2.2 |
| 10000 |    93.9   | 16.4 |
| 100000 | 2083.7 | 203.8|

Fixes: #1846.