### PR TITLE
Add postStartCommand to devcontainer so dev server will be available

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
     "PATH": "/workspace/bin:${containerEnv:PATH}"
   },
   "postCreateCommand": "bundle install && npm install",
+  "postStartCommand": "bin/setup && bin/dev",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
This pull request includes a small change to the `.devcontainer/devcontainer.json` file. The change adds a `postStartCommand` to run `bin/setup` and `bin/dev` after the container starts. This will make sure that Dev server will be able to start and be able to be reached via 127.0.0.1:3000. At current state, it's necessary to start a server manually. This PR should address that and create a more complete dev environment.