### PR TITLE
Fix incorrect totals calculation when family has loan payments

### DIFF
--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -18,7 +18,7 @@ class IncomeStatement
     total_expense = result.select { |t| t.classification == "expense" }.sum(&:total)
 
     ScopeTotals.new(
-      transactions_count: transactions_scope.count,
+      transactions_count: result.sum(&:transactions_count),
       income_money: Money.new(total_income, family.currency),
       expense_money: Money.new(total_expense, family.currency),
       missing_exchange_rates?: result.any?(&:missing_exchange_rates?)

--- a/app/models/income_statement/base_query.rb
+++ b/app/models/income_statement/base_query.rb
@@ -8,6 +8,7 @@ module IncomeStatement::BaseQuery
           date_trunc(:interval, ae.date) as date,
           CASE WHEN ae.amount < 0 THEN 'income' ELSE 'expense' END as classification,
           SUM(ae.amount * COALESCE(er.rate, 1)) as total,
+          COUNT(ae.id) as transactions_count,
           BOOL_OR(ae.currency <> :target_currency AND er.rate IS NULL) as missing_exchange_rates
         FROM (#{transactions_scope.to_sql}) at
         JOIN account_entries ae ON ae.entryable_id = at.id AND ae.entryable_type = 'Account::Transaction'

--- a/app/models/income_statement/base_query.rb
+++ b/app/models/income_statement/base_query.rb
@@ -29,7 +29,7 @@ module IncomeStatement::BaseQuery
         )
         WHERE (
           transfer_info.transfer_id IS NULL OR
-          (ae.amount < 0 AND transfer_info.accountable_type = 'Loan')
+          (ae.amount > 0 AND transfer_info.accountable_type = 'Loan')
         )
         GROUP BY 1, 2, 3, 4
       SQL

--- a/app/models/income_statement/totals.rb
+++ b/app/models/income_statement/totals.rb
@@ -13,13 +13,14 @@ class IncomeStatement::Totals
         category_id: row["category_id"],
         classification: row["classification"],
         total: row["total"],
+        transactions_count: row["transactions_count"],
         missing_exchange_rates?: row["missing_exchange_rates"]
       )
     end
   end
 
   private
-    TotalsRow = Data.define(:parent_category_id, :category_id, :classification, :total, :missing_exchange_rates?)
+    TotalsRow = Data.define(:parent_category_id, :category_id, :classification, :total, :transactions_count, :missing_exchange_rates?)
 
     def query_sql
       base_sql = base_query_sql(family: @family, interval: "day", transactions_scope: @transactions_scope)
@@ -33,7 +34,8 @@ class IncomeStatement::Totals
             category_id,
             classification,
             ABS(SUM(total)) as total,
-            BOOL_OR(missing_exchange_rates) as missing_exchange_rates
+            BOOL_OR(missing_exchange_rates) as missing_exchange_rates,
+            SUM(transactions_count) as transactions_count
         FROM base_totals
         GROUP BY 1, 2, 3;
       SQL

--- a/app/views/transactions/_summary.html.erb
+++ b/app/views/transactions/_summary.html.erb
@@ -2,7 +2,7 @@
 <div class="grid grid-cols-3 bg-white rounded-xl shadow-border-xs divide-x divide-alpha-black-100">
   <div class="p-4 space-y-2">
     <p class="text-sm text-secondary">Total transactions</p>
-    <p class="text-primary font-medium text-xl" id="total-transactions"><%= totals.transactions_count %></p>
+    <p class="text-primary font-medium text-xl" id="total-transactions"><%= totals.transactions_count.round(0) %></p>
   </div>
   <div class="p-4 space-y-2">
     <p class="text-sm text-secondary">Income</p>


### PR DESCRIPTION
This fixes a list of related issues _when a family has loan payments_ (which are included as expenses, while other transfers are not):

- Total transactions count is wrong on transactions page
- Total income/expense sum is wrong on transactions page
- Total budget for category where loan payment was made is wrong


https://github.com/user-attachments/assets/451c5f98-558a-423e-953d-ec022e06f79e

