### PR TITLE
fix(dashboard): account groups wrapping in balance sheet

### DIFF
--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -12,7 +12,7 @@
               <div class="h-1.5 rounded-sm" style="width: <%= account_group.weight %>%; background-color: <%= account_group.color %>;"></div>
             <% end %>
           </div>
-          <div class="flex gap-4">
+          <div class="flex flex-wrap gap-4">
             <% classification_group.account_groups.each do |account_group| %>
               <div class="flex items-center gap-2 text-sm">
                 <div class="h-2.5 w-2.5 rounded-full" style="background-color: <%= account_group.color %>;"></div>


### PR DESCRIPTION
Before:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/72440d38-df29-4a3b-8851-242e682d8f64" />

After:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/ada80228-ebc0-4eea-bdf9-b5312e9883ea" />
