### PR TITLE
devContainer: Use Redis for ActiveJob and ActionCable.

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -21,15 +21,35 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       BUNDLE_PATH: /bundle
+      REDIS_URL: redis://redis:6379/1
 
     depends_on:
       - db
+      - redis
+
+  worker:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    command: bundle exec sidekiq
+    restart: unless-stopped
+    environment:
+      DB_HOST: db
+      HOST: "0.0.0.0"
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      BUNDLE_PATH: /bundle
+      REDIS_URL: redis://redis:6379/1
+    depends_on:
       - redis
 
   redis:
     image: redis:latest
     ports:
       - "6379:6379"
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
   db:
     image: postgres:latest
     restart: unless-stopped
@@ -44,4 +64,5 @@ services:
 
 volumes:
   postgres-data:
+  redis-data:
   bundle_cache:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 x-db-env: &db_env
   POSTGRES_USER: postgres
   POSTGRES_DB: postgres

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,18 @@
 version: "3"
 
+x-db-env: &db_env
+  POSTGRES_USER: postgres
+  POSTGRES_DB: postgres
+  POSTGRES_PASSWORD: postgres
+
+x-rails-env: &rails_env
+  DB_HOST: db
+  HOST: "0.0.0.0"
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: postgres
+  BUNDLE_PATH: /bundle
+  REDIS_URL: redis://redis:6379/1
+
 services:
   app:
     build:
@@ -16,12 +29,7 @@ services:
     command: sleep infinity
 
     environment:
-      DB_HOST: db
-      HOST: "0.0.0.0"
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      BUNDLE_PATH: /bundle
-      REDIS_URL: redis://redis:6379/1
+      <<: *rails_env
 
     depends_on:
       - db
@@ -34,12 +42,7 @@ services:
     command: bundle exec sidekiq
     restart: unless-stopped
     environment:
-      DB_HOST: db
-      HOST: "0.0.0.0"
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      BUNDLE_PATH: /bundle
-      REDIS_URL: redis://redis:6379/1
+      <<: *rails_env
     depends_on:
       - redis
 
@@ -56,9 +59,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: postgres
+      <<: *db_env
     ports:
       - "5432:5432"
 


### PR DESCRIPTION
After #2004, we are now using Redis and Sidekiq for background job processing. This means that we will need to update the dev container to utilize those services.