### PR TITLE
bug: Use correct currency value while setting the currency.

### DIFF
--- a/app/views/shared/_money_field.html.erb
+++ b/app/views/shared/_money_field.html.erb
@@ -45,7 +45,7 @@
       <div>
         <%= form.select currency_method,
                       currencies_for_select.map(&:iso_code),
-                      { inline: true, selected: currency_value },
+                      { inline: true, selected: currency.iso_code },
                       {
                         class: "w-fit pr-5 disabled:text-subdued form-field__input",
                         disabled: options[:disable_currency],


### PR DESCRIPTION
Currently, `currency_value` may evaluate to `nil` despite the default family currency. Rather, we should use `currency` as it baskets `currency_value` and family currency.

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/169909d6-50b5-4ea4-9f4a-c3186c8052c7)| ![image](https://github.com/user-attachments/assets/10e4927e-738f-4da0-ab20-7cf60d7889b6)|
| ![image](https://github.com/user-attachments/assets/44658af9-8716-431b-9210-02e6f381d7d3)| ![image](https://github.com/user-attachments/assets/324df03c-29c4-43b0-b5e8-8c6f9c142974)|

Fixes: #1754.