### PR TITLE
WIP - synth: Use `mic_code` as param when fetching security price.

### DIFF
--- a/app/models/provider/synth.rb
+++ b/app/models/provider/synth.rb
@@ -134,7 +134,7 @@ class Provider::Synth < Provider
         end_date: end_date
       }
 
-      params[:operating_mic_code] = security.exchange_operating_mic if security.exchange_operating_mic.present?
+      params[:mic_code] = security.exchange_operating_mic if security.exchange_operating_mic.present?
 
       data = paginate(
         "#{base_url}/tickers/#{security.ticker}/open-close",


### PR DESCRIPTION
Some securities were fetching for the wrong price as the wrong params were passed to the provider.

| Before | After  |
|:---:|:---:|
|![image](https://github.com/user-attachments/assets/b8c5a3fa-0441-4ef6-ad64-169366b90eb9) | ![image](https://github.com/user-attachments/assets/6260bb79-2037-4620-8a4c-b19ff759ad5c)|

Fixes: #2034.

