### PR TITLE
Fix: Notes not saved on transfer transactions

### DIFF
--- a/test/controllers/transfers_controller_test.rb
+++ b/test/controllers/transfers_controller_test.rb
@@ -30,4 +30,15 @@ class TransfersControllerTest < ActionDispatch::IntegrationTest
       delete transfer_url(transfers(:one))
     end
   end
+
+  test "can add notes to transfer" do
+    transfer = transfers(:one)
+    assert_nil transfer.notes
+
+    patch transfer_url(transfer), params: { transfer: { notes: "Test notes" } }
+
+    assert_redirected_to transactions_url
+    assert_equal "Transfer updated", flash[:notice]
+    assert_equal "Test notes", transfer.reload.notes
+  end
 end


### PR DESCRIPTION
This fixes a bug where users could not add notes to a transfer transaction.

Before:

https://github.com/user-attachments/assets/9111d5f9-b9ff-46a9-abd8-c9506203357f

After:

https://github.com/user-attachments/assets/24ec290a-b4f3-4667-9cdc-916948151f6b

