### PR TITLE
Feature: Trusted Header based login (SSO)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,8 @@ module Maybe
 
     config.app_mode = (ENV["SELF_HOSTED"] == "true" || ENV["SELF_HOSTING_ENABLED"] == "true" ? "self_hosted" : "managed").inquiry
 
+    config.remote_login_email_header_name = ENV["REMOTE_LOGIN_EMAIL_HEADER"]
+
     # Self hosters can optionally set their own encryption keys if they want to use ActiveRecord encryption.
     if Rails.application.credentials.active_record_encryption.present?
       config.active_record.encryption = Rails.application.credentials.active_record_encryption

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -192,3 +192,18 @@ docker volume rm maybe_postgres-data # this is the name of the volume the DB is 
 docker compose up
 docker exec -it maybe-postgres-1 psql -U maybe -d maybe_production -c "SELECT 1;" # This will verify that the issue is fixed
 ```
+
+## External Authorization (SSO)
+
+### Remote User (Header-based)
+
+Maybe can be configured to accept a header that acts as an automatic login (passwordless) for the user specified in the header. This is intended to be used in conjunction with separate authorization software.
+
+For more information and examples, see https://doc.traefik.io/traefik/middlewares/http/forwardauth/ or similar documentation for your http proxy and authentication software.
+
+Configure the Maybe environment with:
+```
+REMOTE_USER_HEADER_EMAIL="Remote-Email"
+```
+
+ !! NOTE!! this allows unchallenged (passwordless) login via simple HTTP headers. Only use this method if you have a proxy in front of Maybe that is applying the authentication challenge, *AND THE MAYBE HTTP SERVER IS NOT ACCESSIBLE DIRECTLY*.


### PR DESCRIPTION
This PR adds login via a trusted header, which we expect to be inserted by a proxy that handles authentication external to the maybe application and completely controls access to the maybe web server. 

Some background on the trusted-header login approach:
https://doc.traefik.io/traefik/middlewares/http/forwardauth/
https://www.authelia.com/integration/trusted-header-sso/introduction/

Spiritually, this is similar to OIDC, but easier to set up, and keeps the "client" applications from needing direct exposure (unauthorized users are only able to access the auth proxy, and cannot access the underlying application at all).

To enable, self-hosting users can add an environment variable specifying the name of a header containing the email of the currently logged-in user. That email will be used to find a user within maybe, and log in automatically. If the user does not exist, it is created, with a random 50-char password, admin privileges, and a new Family. If there are more sensible defaults here, I'm very open to them.