### PR TITLE
Show Uncategorized segment currency as per budget currency

### DIFF
--- a/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
+++ b/app/views/budget_categories/_uncategorized_budget_category_form.html.erb
@@ -13,8 +13,8 @@
   <div class="ml-auto">
     <div class="form-field w-[120px]">
       <div class="flex items-center">
-        <span class="text-subdued text-sm mr-2">$</span>
-        <%= text_field_tag :uncategorized, budget_category.budgeted_spending_money, autocomplete: "off", class: "form-field__input text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none", disabled: true %>
+        <span class="text-subdued text-sm mr-2"><%= budget_category.budgeted_spending_money.currency.symbol %></span>
+        <%= text_field_tag :uncategorized, budget_category.budgeted_spending_money.amount, autocomplete: "off", class: "form-field__input text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none", disabled: true %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Updated the Uncategorized budget segment UI to reflect the actual currency symbol from budget instead of hardcoding $.

Before:
<img width="506" alt="image" src="https://github.com/user-attachments/assets/070a8c2e-288a-4331-b701-d3709ea607b5" />


After:
<img width="506" alt="image" src="https://github.com/user-attachments/assets/8d09c7da-474d-4dba-83d5-075a53e1e103" />
