### PR TITLE
fix: prevent content overflow in transaction modal by enabling internal scrolling

### DIFF
--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (content:, classes:) -%>
 <%= turbo_frame_tag "modal" do %>
-  <dialog class="m-auto bg-container shadow-border-xs rounded-2xl max-w-[580px] w-min-content h-fit overflow-visible <%= classes %>" data-controller="modal" data-action="mousedown->modal#clickOutside">
+  <dialog class="m-auto bg-container shadow-border-xs rounded-2xl max-w-[580px] w-min-content h-fit max-h-[90vh] overflow-y-auto <%= classes %>" data-controller="modal" data-action="mousedown->modal#clickOutside">
     <div class="flex flex-col">
       <%= content %>
     </div>


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/5f255e37-d810-48ab-a4b4-8d7ea0651c64

After:

https://github.com/user-attachments/assets/66b3091c-4c1a-4ec9-b649-5841b798da0c

