### PR TITLE
Chromium E2E test fixes

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -101,7 +101,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_11_140604) do
     t.decimal "balance", precision: 19, scale: 4
     t.string "currency"
     t.boolean "is_active", default: true, null: false
-    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY (ARRAY[('Loan'::character varying)::text, ('CreditCard'::character varying)::text, ('OtherLiability'::character varying)::text])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
+    t.virtual "classification", type: :string, as: "\nCASE\n    WHEN ((accountable_type)::text = ANY ((ARRAY['Loan'::character varying, 'CreditCard'::character varying, 'OtherLiability'::character varying])::text[])) THEN 'liability'::text\n    ELSE 'asset'::text\nEND", stored: true
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.boolean "scheduled_for_deletion", default: false

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -13,7 +13,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit new_session_path
       within "form" do
         fill_in "Email", with: user.email
-        fill_in "Password", with: "maybetestpassword817983172"
+        fill_in "Password", with: user_password_test
         click_on "Log in"
       end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -13,7 +13,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       visit new_session_path
       within "form" do
         fill_in "Email", with: user.email
-        fill_in "Password", with: "password"
+        fill_in "Password", with: "maybetestpassword817983172"
         click_on "Log in"
       end
 

--- a/test/controllers/mfa_controller_test.rb
+++ b/test/controllers/mfa_controller_test.rb
@@ -54,7 +54,7 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     @user.enable_mfa!
     sign_out
 
-    post sessions_path, params: { email: @user.email, password: "password" }
+    post sessions_path, params: { email: @user.email, password: user_password_test }
     assert_redirected_to verify_mfa_path
 
     get verify_mfa_path
@@ -67,7 +67,7 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     @user.enable_mfa!
     sign_out
 
-    post sessions_path, params: { email: @user.email, password: "password" }
+    post sessions_path, params: { email: @user.email, password: user_password_test }
     totp = ROTP::TOTP.new(@user.otp_secret, issuer: "Maybe")
 
     post verify_mfa_path, params: { code: totp.now }
@@ -81,7 +81,7 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     @user.enable_mfa!
     sign_out
 
-    post sessions_path, params: { email: @user.email, password: "password" }
+    post sessions_path, params: { email: @user.email, password: user_password_test }
     backup_code = @user.otp_backup_codes.first
 
     post verify_mfa_path, params: { code: backup_code }
@@ -96,7 +96,7 @@ class MfaControllerTest < ActionDispatch::IntegrationTest
     @user.enable_mfa!
     sign_out
 
-    post sessions_path, params: { email: @user.email, password: "password" }
+    post sessions_path, params: { email: @user.email, password: user_password_test }
     post verify_mfa_path, params: { code: "invalid" }
 
     assert_response :unprocessable_entity

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -42,7 +42,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     @user.enable_mfa!
     @user.sessions.destroy_all # Clean up any existing sessions
 
-    post sessions_path, params: { email: @user.email, password: "password" }
+    post sessions_path, params: { email: @user.email, password: user_password_test }
 
     assert_redirected_to verify_mfa_path
     assert_equal @user.id, session[:mfa_user_id]

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,7 +3,7 @@ empty:
   first_name: User
   last_name: One
   email: user1@email.com
-  password_digest: $2a$12$7p8hMsoc0zSaC8eY9oewzelHbmCPdpPi.mGiyG4vdZwrXmGpRPoNK 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
 
@@ -12,7 +12,7 @@ maybe_support_staff:
   first_name: Support
   last_name: Admin
   email: support@maybefinance.com
-  password_digest: $2a$12$7p8hMsoc0zSaC8eY9oewzelHbmCPdpPi.mGiyG4vdZwrXmGpRPoNK 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
   role: super_admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
@@ -22,7 +22,7 @@ family_admin:
   first_name: Bob
   last_name: Dylan
   email: bob@bobdylan.com
-  password_digest: $2a$12$7p8hMsoc0zSaC8eY9oewzelHbmCPdpPi.mGiyG4vdZwrXmGpRPoNK 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
   role: admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
@@ -32,7 +32,7 @@ family_member:
   first_name: Jakob
   last_name: Dylan
   email: jakobdylan@yahoo.com
-  password_digest: $2a$12$7p8hMsoc0zSaC8eY9oewzelHbmCPdpPi.mGiyG4vdZwrXmGpRPoNK 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
 
@@ -42,6 +42,6 @@ new_email:
   last_name: User
   email: user@example.com
   unconfirmed_email: new@example.com
-  password_digest: $2a$12$7p8hMsoc0zSaC8eY9oewzelHbmCPdpPi.mGiyG4vdZwrXmGpRPoNK 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
   onboarded_at: <%= Time.current %>
   ai_enabled: true

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ module ActiveSupport
 
     # Add more helper methods to be used by all tests here...
     def sign_in(user)
-      post sessions_path, params: { email: user.email, password: "maybetestpassword817983172" }
+      post sessions_path, params: { email: user.email, password: user_password_test }
     end
 
     def with_env_overrides(overrides = {}, &block)
@@ -59,6 +59,10 @@ module ActiveSupport
     def with_self_hosting
       Rails.configuration.stubs(:app_mode).returns("self_hosted".inquiry)
       yield
+    end
+
+    def user_password_test
+      "maybetestpassword817983172"
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -49,7 +49,7 @@ module ActiveSupport
 
     # Add more helper methods to be used by all tests here...
     def sign_in(user)
-      post sessions_path, params: { email: user.email, password: "password" }
+      post sessions_path, params: { email: user.email, password: "maybetestpassword817983172" }
     end
 
     def with_env_overrides(overrides = {}, &block)


### PR DESCRIPTION
Likely due to some recent update of the Chromium driver, we started seeing some E2E test failures due to our test password being flagged as not safe.  This PR adds a test password that doesn't trigger this behavior.