### PR TITLE
Fix: No comma when locality is empty (small fix)

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -6,7 +6,7 @@ class Address < ApplicationRecord
       line1: line1,
       line2: line2,
       county: county,
-      locality: locality,
+      locality: locality.present? ? "#{locality}, " : "",
       region: region,
       country: country,
       postal_code: postal_code

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -2,14 +2,17 @@ class Address < ApplicationRecord
   belongs_to :addressable, polymorphic: true
 
   def to_s
-    I18n.t("address.format",
+    string = I18n.t("address.format",
       line1: line1,
       line2: line2,
       county: county,
-      locality: locality.present? ? "#{locality}, " : "",
+      locality: locality,
       region: region,
       country: country,
       postal_code: postal_code
     )
+
+    # Clean up the string to maintain I18n comma formatting
+    string.split(",").map(&:strip).reject(&:empty?).join(", ")
   end
 end

--- a/config/locales/models/address/en.yml
+++ b/config/locales/models/address/en.yml
@@ -11,5 +11,5 @@ en:
     format: |-
       %{line1}
       %{line2}
-      %{locality}, %{region} %{postal_code}
+      %{locality}%{region} %{postal_code}
       %{country}

--- a/config/locales/models/address/en.yml
+++ b/config/locales/models/address/en.yml
@@ -8,8 +8,4 @@ en:
       locality: Locality
       postal_code: Postal Code
       region: Region
-    format: |-
-      %{line1}
-      %{line2}
-      %{locality}%{region} %{postal_code}
-      %{country}
+    format: "%{line1} %{line2}, %{locality}, %{region} %{postal_code} %{country}"

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -12,4 +12,39 @@ class AddressTest < ActiveSupport::TestCase
 
     assert_equal "123 Main St, San Francisco, CA 94101 US", address.to_s
   end
+
+  test "can print a formatted address with line2" do
+    address = Address.new(
+      line1: "123 Main St",
+      line2: "Apt 1",
+      locality: "San Francisco",
+      region: "CA",
+      country: "US",
+      postal_code: "94101"
+    )
+
+    assert_equal "123 Main St Apt 1, San Francisco, CA 94101 US", address.to_s
+  end
+
+  test "can print empty when address is empty" do
+    address = Address.new(
+      line1: nil,
+      line2: nil,
+      locality: nil,
+      region: nil,
+      country: nil,
+      postal_code: nil
+    )
+
+    assert_equal "", address.to_s
+  end
+
+  test "can strip extras commas and spaces" do
+    address = Address.new(
+      line1: "123 Main St ,",
+      locality: " San Francisco, ",
+    )
+
+    assert_equal "123 Main St, San Francisco", address.to_s
+  end
 end

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -10,6 +10,6 @@ class AddressTest < ActiveSupport::TestCase
       postal_code: "94101"
     )
 
-    assert_equal "123 Main St\n\nSan Francisco, CA 94101\nUS", address.to_s
+    assert_equal "123 Main St, San Francisco, CA 94101 US", address.to_s
   end
 end


### PR DESCRIPTION
Currently when Properties have empty address it shows a single comma on subtitle
![image](https://github.com/user-attachments/assets/8ddc224e-8c98-4230-ad82-f8323d0b1076)
 
 This PR pushes a fix for that, when no Locality is saved, there is no comma
 
And, perhaps, another fix could be added here.

It seems i18n format should supposed be shown like right side of image? If so, I could just update that too.
 
![image](https://github.com/user-attachments/assets/a916ef21-f961-4643-acb9-55cf87bba9f7)
