### PR TITLE
Fix dark mode support and improve notification/MFA UI

### DIFF
--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -50,8 +50,7 @@ export default class extends Controller {
   }
 
   systemPrefersDark() {
-    return false
-    // return window.matchMedia("(prefers-color-scheme: dark)").matches
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
   }
 
   handleSystemThemeChange = (event) => {

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -10,18 +10,20 @@
             <h2 class="text-3xl font-medium text-primary text-center">
               <%= content_for?(:header_title) ? yield(:header_title).html_safe : t(".your_account") %>
             </h2>
-            <div class="space-y-3 md:hidden w-full my-4">
-              <div class="bg-surface-inset rounded-lg p-1 flex">
-                <%= link_to new_session_path, 
+            <% unless controller_name == "mfa" && action_name == "verify" %>
+              <div class="space-y-3 md:hidden w-full my-4">
+                <div class="bg-surface-inset rounded-lg p-1 flex">
+                  <%= link_to new_session_path, 
       class: "w-1/2 px-2 py-1 rounded-md text-sm text-center font-medium #{current_page?(new_session_path) ? 'bg-surface shadow-sm text-primary' : 'text-secondary'}" do %>
-                  <%= t("layouts.auth.sign_in") %>
-                <% end %>
-                <%= link_to new_registration_path, 
+                    <%= t("layouts.auth.sign_in") %>
+                  <% end %>
+                  <%= link_to new_registration_path, 
       class: "w-1/2 px-2 py-1 rounded-md text-sm text-center font-medium #{!current_page?(new_session_path) ? 'bg-surface shadow-sm text-primary' : 'text-secondary'}" do %>
-                  <%= t("layouts.auth.sign_up") %>
-                <% end %>
+                    <%= t("layouts.auth.sign_up") %>
+                  <% end %>
+                </div>
               </div>
-            </div>
+            <% end %>
             <% if controller_name == "sessions" %>
               <p class="text-sm text-center hidden md:block">
                 <%= tag.span t(".no_account"), class: "text-secondary" %> <%= link_to t(".sign_up"), new_registration_path, class: "font-medium text-primary hover:underline transition" %>

--- a/app/views/layouts/auth.html.erb
+++ b/app/views/layouts/auth.html.erb
@@ -10,7 +10,7 @@
             <h2 class="text-3xl font-medium text-primary text-center">
               <%= content_for?(:header_title) ? yield(:header_title).html_safe : t(".your_account") %>
             </h2>
-            <% unless controller_name == "mfa" && action_name == "verify" %>
+            <% if (controller_name == "sessions" && action_name == "new") || (controller_name == "registrations" && action_name == "new") %>
               <div class="space-y-3 md:hidden w-full my-4">
                 <div class="bg-surface-inset rounded-lg p-1 flex">
                   <%= link_to new_session_path, 

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -6,7 +6,7 @@
   </head>
 
   <body class="h-screen overflow-hidden lg:overflow-auto antialiased h-screen-safe ">
-    <div class="fixed z-50 top-6 md:top-4 md:left-1/2 -translate-x-1/2 w-full md:w-80 mx-auto md:mx-0 md:right-auto mt-safe">
+    <div class="fixed z-50 top-6 md:top-4 left-1/2 -translate-x-1/2 w-full md:w-80 px-4 md:px-0 mx-auto md:mx-0 md:right-auto mt-safe">
       <div id="notification-tray" class="space-y-1 w-full">
         <%= render_flash_notifications %>
 

--- a/app/views/mfa/verify.html.erb
+++ b/app/views/mfa/verify.html.erb
@@ -3,11 +3,12 @@
   header_description t(".description")
 %>
 
-<%= styled_form_with url: verify_mfa_path, method: :post, class: "space-y-4", data: { turbo: false } do |form| %>
+<%= styled_form_with url: verify_mfa_path, method: :post, class: "space-y-4 mt-4 md:mt-0", data: { turbo: false } do |form| %>
   <%= form.text_field :code,
     required: true,
     autofocus: true,
     autocomplete: "one-time-code",
+    type: "number",
     label: t(".page_title") %>
 
   <%= form.submit t(".verify_button") %>

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -1,8 +1,8 @@
 <%# locals: (message:) %>
 
-<%= tag.div class: "flex gap-3 rounded-lg bg-white p-4 group max-w-80 shadow-border-lg",
+<%= tag.div class: "flex gap-3 rounded-lg bg-container-inset p-4 group w-full md:max-w-80 shadow-border-lg",
             data: { controller: "element-removal" } do %>
-  <div class="h-5 w-5 shrink-0 p-px text-white">
+  <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-destructive">
       <%= lucide_icon "x", class: "w-3 h-3" %>
     </div>

--- a/app/views/shared/notifications/_cta.html.erb
+++ b/app/views/shared/notifications/_cta.html.erb
@@ -1,8 +1,8 @@
 <%# locals: (message:, description:) %>
 
 <div id="cta">
-  <%= tag.div class: "relative flex gap-3 rounded-lg bg-white p-4 group max-w-80 shadow-border-xs", data: { controller: "element-removal" } do %>
-    <div class="h-5 w-5 shrink-0 p-px text-white">
+  <%= tag.div class: "relative flex gap-3 rounded-lg bg-container-inset p-4 group w-full md:max-w-80 shadow-border-xs", data: { controller: "element-removal" } do %>
+    <div class="h-5 w-5 shrink-0 p-px text-primary">
       <div class="flex h-full items-center justify-center rounded-full bg-success">
         <%= lucide_icon "check", class: "w-3 h-3" %>
       </div>

--- a/app/views/shared/notifications/_loading.html.erb
+++ b/app/views/shared/notifications/_loading.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (message:, id: nil) %>
 
-<%= tag.div id: id, class: "flex gap-3 rounded-lg bg-white p-4 group w-full shadow-border-xs" do %>
-  <div class="h-5 w-5 shrink-0 p-px text-white">
+<%= tag.div id: id, class: "flex gap-3 rounded-lg bg-container-inset p-4 group w-full md:max-w-80 shadow-border-xs" do %>
+  <div class="h-5 w-5 shrink-0 p-px text-primary">
     <%= lucide_icon "loader", class: "w-5 h-5 text-secondary animate-pulse" %>
   </div>
 

--- a/app/views/shared/notifications/_notice.html.erb
+++ b/app/views/shared/notifications/_notice.html.erb
@@ -1,12 +1,12 @@
 <%# locals: (message:, description: nil, cta: nil) %>
 
-<%= tag.div class: "relative flex gap-3 rounded-lg bg-white p-4 group max-w-80 shadow-border-xs",
+<%= tag.div class: "relative flex gap-3 rounded-lg bg-container-inset p-4 group w-full md:max-w-80 shadow-border-xs",
             data: {
               controller: "element-removal",
               action: "animationend->element-removal#remove"
             } do %>
 
-  <div class="h-5 w-5 shrink-0 p-px text-white">
+  <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-success">
       <%= lucide_icon "check", class: "w-3 h-3" %>
     </div>


### PR DESCRIPTION
This pull request fixes dark mode support for the notification tray and hides the authentication tabs on the 2FA page.
Also uncomments a hardcoded line in theme-controller that accidentally slipped past

/closes #2124 regression caused by https://github.com/maybe-finance/maybe/pull/1900
Partially addresses #2120 by hiding auth tabs on 2fa verification page

<img width="405" alt="image" src="https://github.com/user-attachments/assets/d310bf5f-d4a5-41f1-9a6c-b9d3c23fcda8" />