### PR TITLE
loans: Remove initial_balance field from Loan model.

### DIFF
--- a/app/views/loans/_form.html.erb
+++ b/app/views/loans/_form.html.erb
@@ -9,6 +9,7 @@
         <%= loan_form.money_field :initial_balance,
                                  label: t("loans.form.initial_balance"),
                                  default_currency: Current.family.currency,
+                                 value: account.first_valuation_amount,
                                  required: true %>
       </div>
 

--- a/db/migrate/20250420011909_remove_initial_balance_field.rb
+++ b/db/migrate/20250420011909_remove_initial_balance_field.rb
@@ -1,0 +1,5 @@
+class RemoveInitialBalanceField < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :loans, :initial_balance, :decimal
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_16_235758) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_20_011909) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -373,7 +373,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_16_235758) do
     t.string "rate_type"
     t.decimal "interest_rate", precision: 10, scale: 3
     t.integer "term_months"
-    t.decimal "initial_balance", precision: 19, scale: 4
     t.jsonb "locked_attributes", default: {}
   end
 


### PR DESCRIPTION
This PR features changes to remove the initial_balance field allowing loan accounts to operate using its first entry as the source of truth.

**Note:** I've tested this in manually, however I couldn't fully verify it with Plaid 

Fixes part of #2115.