### PR TITLE
Add assign merchant rule for transactions

### DIFF
--- a/app/models/rule/action_executor/set_transaction_merchant.rb
+++ b/app/models/rule/action_executor/set_transaction_merchant.rb
@@ -1,0 +1,30 @@
+class Rule::ActionExecutor::SetTransactionMerchant < Rule::ActionExecutor
+  def type
+    "select"
+  end
+
+  def options
+    family.merchants.pluck(:name, :id)
+  end
+
+  def execute(transaction_scope, value: nil, ignore_attribute_locks: false)
+    merchant = family.merchants.find_by_id(value)
+    return unless merchant
+
+    scope = transaction_scope
+    unless ignore_attribute_locks
+      scope = scope.enrichable(:merchant_id)
+    end
+
+    scope.each do |txn|
+      Rule.transaction do
+        txn.log_enrichment!(
+          attribute_name: "merchant_id",
+          attribute_value: merchant.id,
+          source: "rule"
+        )
+        txn.update!(merchant: merchant)
+      end
+    end
+  end
+end

--- a/app/models/rule/registry/transaction_resource.rb
+++ b/app/models/rule/registry/transaction_resource.rb
@@ -14,7 +14,8 @@ class Rule::Registry::TransactionResource < Rule::Registry
   def action_executors
     enabled_executors = [
       Rule::ActionExecutor::SetTransactionCategory.new(rule),
-      Rule::ActionExecutor::SetTransactionTags.new(rule)
+      Rule::ActionExecutor::SetTransactionTags.new(rule),
+      Rule::ActionExecutor::SetTransactionMerchant.new(rule)
     ]
 
     if ai_enabled?

--- a/test/models/rule/action_test.rb
+++ b/test/models/rule/action_test.rb
@@ -58,4 +58,25 @@ class Rule::ActionTest < ActiveSupport::TestCase
       assert_equal [ tag ], transaction.reload.tags
     end
   end
+
+  test "set_transaction_merchant" do
+    merchant = @family.merchants.create!(name: "Rule test merchant")
+
+    # Does not modify transactions that are locked (user edited them)
+    @txn1.lock!(:merchant_id)
+
+    action = Rule::Action.new(
+      rule: @transaction_rule,
+      action_type: "set_transaction_merchant",
+      value: merchant.id
+    )
+
+    action.apply(@rule_scope)
+
+    assert_not_equal merchant.id, @txn1.reload.merchant_id
+
+    [ @txn2, @txn3 ].each do |transaction|
+      assert_equal merchant.id, transaction.reload.merchant_id
+    end
+  end
 end


### PR DESCRIPTION
This PR allows someone to set a merchant as part of a transaction rule. This fixes #2143.

One weird piece of UX in here is that you can't create a new merchant from this menu - this is true of other places that reference merchants as well (like the transaction drawer). It would be great to do this in all of the places that mention merchants becuase navigating out of a rule/transaction to make a merchant is kind of annoying, but that isn't part of this PR. 


<img src="https://github.com/user-attachments/assets/4442f580-6be2-4fdc-85e5-a3795492a60f" width="500">


