### PR TITLE
Add ability to delete all tags

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -34,6 +34,11 @@ class TagsController < ApplicationController
     redirect_to tags_path, notice: t(".deleted")
   end
 
+  def destroy_all
+    Current.family.tags.destroy_all
+    redirect_back_or_to tags_path, notice: "All tags deleted"
+  end
+
   private
 
     def set_tag

--- a/app/helpers/custom_confirm.rb
+++ b/app/helpers/custom_confirm.rb
@@ -6,7 +6,7 @@ class CustomConfirm
       new(
         destructive: true,
         high_severity: high_severity,
-        title: "Delete #{resource_name.downcase}?",
+        title: "Delete #{resource_name.titleize}?",
         body: "Are you sure you want to delete #{resource_name.downcase}? This is not reversible.",
         btn_text: "Delete #{resource_name.downcase}"
       )

--- a/app/helpers/custom_confirm.rb
+++ b/app/helpers/custom_confirm.rb
@@ -6,9 +6,9 @@ class CustomConfirm
       new(
         destructive: true,
         high_severity: high_severity,
-        title: "Delete #{resource_name}?",
-        body: "Are you sure you want to delete #{resource_name}? This is not reversible.",
-        btn_text: "Delete #{resource_name}"
+        title: "Delete #{resource_name.downcase}?",
+        body: "Are you sure you want to delete #{resource_name.downcase}? This is not reversible.",
+        btn_text: "Delete #{resource_name.downcase}"
       )
     end
   end

--- a/app/helpers/custom_confirm.rb
+++ b/app/helpers/custom_confirm.rb
@@ -8,7 +8,7 @@ class CustomConfirm
         high_severity: high_severity,
         title: "Delete #{resource_name.titleize}?",
         body: "Are you sure you want to delete #{resource_name.downcase}? This is not reversible.",
-        btn_text: "Delete #{resource_name.downcase}"
+        btn_text: "Delete #{resource_name.titleize}"
       )
     end
   end

--- a/app/views/accounts/show/_menu.html.erb
+++ b/app/views/accounts/show/_menu.html.erb
@@ -19,7 +19,7 @@
     href: account_path(account),
     method: :delete,
     icon: "trash-2",
-    confirm: CustomConfirm.for_resource_deletion("Account", high_severity: true),
+    confirm: CustomConfirm.for_resource_deletion("account", high_severity: true),
     data: { turbo_frame: :_top }
   ) %>
 <% end %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -9,7 +9,7 @@
           href: destroy_all_categories_path,
           method: :delete,
           icon: "trash-2",
-          confirm: CustomConfirm.for_resource_deletion("All categories", high_severity: true)) %>
+          confirm: CustomConfirm.for_resource_deletion("all categories", high_severity: true)) %>
     <% end %>
 
     <%= render LinkComponent.new(

--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -17,6 +17,6 @@
       href: chat_path(chat),
       icon: "trash-2",
       method: :delete,
-      confirm: CustomConfirm.for_resource_deletion("Chat")) %>
+      confirm: CustomConfirm.for_resource_deletion("chat")) %>
   <% end %>
 <% end %>

--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -29,7 +29,7 @@
         href: chat_path(chat),
         icon: "trash-2",
         method: :delete,
-        confirm: CustomConfirm.for_resource_deletion("Chat")) %>
+        confirm: CustomConfirm.for_resource_deletion("chat")) %>
     <% end %>
   <% end %>
 </nav>

--- a/app/views/imports/_import.html.erb
+++ b/app/views/imports/_import.html.erb
@@ -59,7 +59,7 @@
         href: import_path(import),
         icon: "trash-2",
         method: :delete,
-        confirm: CustomConfirm.for_resource_deletion("Import")) %>
+        confirm: CustomConfirm.for_resource_deletion("import")) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/rules/_rule.html.erb
+++ b/app/views/rules/_rule.html.erb
@@ -55,7 +55,7 @@
         href: rule_path(rule),
         icon: "trash-2",
         method: :delete,
-        confirm: CustomConfirm.for_resource_deletion("Rule")) %>
+        confirm: CustomConfirm.for_resource_deletion("rule")) %>
     <% end %>
   </div>
 </div>

--- a/app/views/rules/index.html.erb
+++ b/app/views/rules/index.html.erb
@@ -10,7 +10,7 @@
           href: destroy_all_rules_path,
           icon: "trash-2",
           method: :delete,
-          confirm: CustomConfirm.for_resource_deletion("All rules", high_severity: true)) %>
+          confirm: CustomConfirm.for_resource_deletion("all rules", high_severity: true)) %>
       <% end %>
     <% end %>
 

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,13 +1,27 @@
 <header class="flex items-center justify-between">
   <h1 class="text-primary text-xl font-medium"><%= t(".tags") %></h1>
 
-  <%= render LinkComponent.new(
-    text: t(".new"),
-    variant: "primary",
-    href: new_tag_path,
-    icon: "plus",
-    frame: :modal
-  ) %>
+<div class="flex items-center gap-2">
+  <%= render MenuComponent.new do |menu| %>
+    <% menu.with_item(
+          variant: "button",
+          text: "Delete all",
+          href: destroy_all_tags_path,
+          method: :delete,
+          icon: "trash-2",
+          confirm: CustomConfirm.for_resource_deletion("all tags", high_severity: true)) %>
+  <% end %>
+
+    <%= render LinkComponent.new(
+      text: t(".new"),
+      variant: "primary",
+      href: new_tag_path,
+      icon: "plus",
+      frame: :modal
+    ) %>
+
+</div>
+
 </header>
 
 <div class="bg-container shadow-border-xs rounded-xl p-4">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
 
   resources :tags, except: :show do
     resources :deletions, only: %i[new create], module: :tag
+    delete :destroy_all, on: :collection
   end
 
   namespace :category do


### PR DESCRIPTION
I've done a few imports that I messed up and have a lot of tags that I don't want/care about, and I'd love to be able to start fresh. I think having the ability to mass select tags (or categories) for deletion would be great as well in the future, but as a starting point I thought I'd bring tags up to the same functionality that categories have.

https://github.com/user-attachments/assets/5a970982-cf13-445c-b463-cc2831a9a22e

I also noticed, when copying this from the categories, that the capitalization of the confirmation button was a bit strange. I updated the `CustomConfirm` to have `titlelize` for the title & button, and `downcase` for the text. I think this is a bit nicer looking personally, but happy to revert if others feel differently. 

![CleanShot-002820 2025-05-02 at 19 57 47@2x](https://github.com/user-attachments/assets/cb5b8df0-47fe-488c-bd83-5a3817aa0403)


