### PR TITLE
fix: Rule notification should not be triggered when category is unassigned

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -118,7 +118,7 @@ class TransactionsController < ApplicationController
         return false if time_since_last_rule_prompt < 1.day
       end
 
-      transaction.saved_change_to_category_id? &&
+      transaction.saved_change_to_category_id? && transaction.category_id.present? &&
       transaction.eligible_for_category_rule?
     end
 


### PR DESCRIPTION
## Motiviation

Currently, when a transaction's category is changed, the rule CTA (category_rule) is triggered. However, it incorrectly assumes that a category is always present, which causes issues when the category is unassigned (i.e., nil). This leads to an error when transaction.category is `nil`.

```
flash[:cta] = {
          type: "category_rule",
          category_id: transaction.category_id,
          category_name: transaction.category.name
        }
```