### PR TITLE
Prevent account deletions when account is linked to a Plaid Item

### DIFF
--- a/app/controllers/concerns/accountable_resource.rb
+++ b/app/controllers/concerns/accountable_resource.rb
@@ -50,8 +50,12 @@ module AccountableResource
   end
 
   def destroy
-    @account.destroy_later
-    redirect_to accounts_path, notice: t("accounts.destroy.success", type: accountable_type.name.underscore.humanize)
+    if @account.linked?
+      redirect_to account_path(@account), alert: "Cannot delete a linked account"
+    else
+      @account.destroy_later
+      redirect_to accounts_path, notice: t("accounts.destroy.success", type: accountable_type.name.underscore.humanize)
+    end
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,10 +45,6 @@ module ApplicationHelper
     content_for(:header_description) { page_description }
   end
 
-  def family_stream
-    turbo_stream_from Current.family if Current.family
-  end
-
   def page_active?(path)
     current_page?(path) || (request.path.start_with?(path) && path != "/")
   end

--- a/app/models/account/linkable.rb
+++ b/app/models/account/linkable.rb
@@ -2,8 +2,6 @@ module Account::Linkable
   extend ActiveSupport::Concern
 
   included do
-    before_destroy :restrict_linked_account_deletion
-
     belongs_to :plaid_account, optional: true
   end
 
@@ -17,12 +15,4 @@ module Account::Linkable
   def unlinked?
     !linked?
   end
-
-  private
-    def restrict_linked_account_deletion
-      if linked?
-        errors.add(:base, "Cannot delete a linked account")
-        throw(:abort)
-      end
-    end
 end

--- a/app/models/account/linkable.rb
+++ b/app/models/account/linkable.rb
@@ -2,6 +2,8 @@ module Account::Linkable
   extend ActiveSupport::Concern
 
   included do
+    before_destroy :restrict_linked_account_deletion
+
     belongs_to :plaid_account, optional: true
   end
 
@@ -15,4 +17,12 @@ module Account::Linkable
   def unlinked?
     !linked?
   end
+
+  private
+    def restrict_linked_account_deletion
+      if linked?
+        errors.add(:base, "Cannot delete a linked account")
+        throw(:abort)
+      end
+    end
 end

--- a/app/views/accounts/_form.html.erb
+++ b/app/views/accounts/_form.html.erb
@@ -6,7 +6,10 @@
     <%= form.hidden_field :return_to, value: params[:return_to] %>
 
     <%= form.text_field :name, placeholder: t(".name_placeholder"), required: "required", label: t(".name_label") %>
-    <%= form.money_field :balance, label: t(".balance"), required: true, default_currency: Current.family.currency %>
+
+    <% unless account.linked? %>
+      <%= form.money_field :balance, label: t(".balance"), required: true, default_currency: Current.family.currency %>
+    <% end %>
 
     <%= yield form %>
   </div>

--- a/app/views/accounts/show/_menu.html.erb
+++ b/app/views/accounts/show/_menu.html.erb
@@ -13,13 +13,15 @@
     ) %>
   <% end %>
 
-  <% menu.with_item(
-    variant: "button",
-    text: "Delete account",
-    href: account_path(account),
-    method: :delete,
-    icon: "trash-2",
-    confirm: CustomConfirm.for_resource_deletion("account", high_severity: true),
-    data: { turbo_frame: :_top }
-  ) %>
+  <% unless account.linked? %>
+    <% menu.with_item(
+      variant: "button",
+      text: "Delete account",
+      href: account_path(account),
+      method: :delete,
+      icon: "trash-2",
+      confirm: CustomConfirm.for_resource_deletion("account", high_severity: true),
+      data: { turbo_frame: :_top }
+    ) %>
+  <% end %>
 <% end %>

--- a/app/views/layouts/shared/_htmldoc.html.erb
+++ b/app/views/layouts/shared/_htmldoc.html.erb
@@ -30,7 +30,9 @@
       </div>
     </div>
 
-    <%= family_stream %>
+    <% if Current.family %>
+      <%= turbo_stream_from Current.family %>
+    <% end %>
 
     <%= turbo_frame_tag "modal" %>
     <%= turbo_frame_tag "drawer" %>

--- a/app/views/shared/notifications/_alert.html.erb
+++ b/app/views/shared/notifications/_alert.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (message:) %>
 
-<%= tag.div class: "flex gap-3 rounded-lg bg-container-inset p-4 group w-full md:max-w-80 shadow-border-lg",
+<%= tag.div class: "flex gap-3 rounded-lg bg-container p-4 group w-full md:max-w-80 shadow-border-lg",
             data: { controller: "element-removal" } do %>
   <div class="h-5 w-5 shrink-0 p-px text-primary">
     <div class="flex h-full items-center justify-center rounded-full bg-destructive">


### PR DESCRIPTION
Previously, we allowed users to delete accounts that were "linked" to a Plaid Item.

To ensure valid data states, this PR forces users to delete the PlaidItem all at once, or not at all.

To disable accounts within a Plaid item, the user must toggle the `active` / `inactive` switch instead of the deleting the account entirely.