### PR TITLE
Transactional locks for sync completions

### DIFF
--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -96,15 +96,15 @@ class Family < ApplicationRecord
     broadcast_refresh
   end
 
-  # If family has any syncs pending/syncing within the last hour, we show a persistent "syncing" notice.
-  # Ignore syncs older than 1 hour as they are considered "stale"
+  # If family has any syncs pending/syncing within the last 10 minutes, we show a persistent "syncing" notice.
+  # Ignore syncs older than 10 minutes as they are considered "stale"
   def syncing?
     Sync.where(
       "(syncable_type = 'Family' AND syncable_id = ?) OR
        (syncable_type = 'Account' AND syncable_id IN (SELECT id FROM accounts WHERE family_id = ? AND plaid_account_id IS NULL)) OR
        (syncable_type = 'PlaidItem' AND syncable_id IN (SELECT id FROM plaid_items WHERE family_id = ?))",
       id, id, id
-    ).where(status: [ "pending", "syncing" ], created_at: 1.hour.ago..).exists?
+    ).where(status: [ "pending", "syncing" ], created_at: 10.minutes.ago..).exists?
   end
 
   def eu?


### PR DESCRIPTION
Users have complained about syncs getting "stuck", which many have been caused by the `Family` sync, which delegates to its child syncs to alert it when they have all completed.

Given the concurrent nature of sync operations, in some cases, multiple child syncs were alerting the parent of completion at the same time.  Without DB locks, this occasionally resulted in an "infinite sync" scenario where the parent never completed.