### PR TITLE
Fix chart timezone bug

### DIFF
--- a/app/models/period.rb
+++ b/app/models/period.rb
@@ -11,55 +11,55 @@ class Period
 
   PERIODS = {
     "last_day" => {
-      date_range: [ 1.day.ago.to_date, Date.current ],
+      date_range: -> { [ 1.day.ago.to_date, Date.current ] },
       label_short: "1D",
       label: "Last Day",
       comparison_label: "vs. yesterday"
     },
     "current_week" => {
-      date_range: [ Date.current.beginning_of_week, Date.current ],
+      date_range: -> { [ Date.current.beginning_of_week, Date.current ] },
       label_short: "WTD",
       label: "Current Week",
       comparison_label: "vs. start of week"
     },
     "last_7_days" => {
-      date_range: [ 7.days.ago.to_date, Date.current ],
+      date_range: -> { [ 7.days.ago.to_date, Date.current ] },
       label_short: "7D",
       label: "Last 7 Days",
       comparison_label: "vs. last week"
     },
     "current_month" => {
-      date_range: [ Date.current.beginning_of_month, Date.current ],
+      date_range: -> { [ Date.current.beginning_of_month, Date.current ] },
       label_short: "MTD",
       label: "Current Month",
       comparison_label: "vs. start of month"
     },
     "last_30_days" => {
-      date_range: [ 30.days.ago.to_date, Date.current ],
+      date_range: -> { [ 30.days.ago.to_date, Date.current ] },
       label_short: "30D",
       label: "Last 30 Days",
       comparison_label: "vs. last month"
     },
     "last_90_days" => {
-      date_range: [ 90.days.ago.to_date, Date.current ],
+      date_range: -> { [ 90.days.ago.to_date, Date.current ] },
       label_short: "90D",
       label: "Last 90 Days",
       comparison_label: "vs. last quarter"
     },
     "current_year" => {
-      date_range: [ Date.current.beginning_of_year, Date.current ],
+      date_range: -> { [ Date.current.beginning_of_year, Date.current ] },
       label_short: "YTD",
       label: "Current Year",
       comparison_label: "vs. start of year"
     },
     "last_365_days" => {
-      date_range: [ 365.days.ago.to_date, Date.current ],
+      date_range: -> { [ 365.days.ago.to_date, Date.current ] },
       label_short: "365D",
       label: "Last 365 Days",
       comparison_label: "vs. 1 year ago"
     },
     "last_5_years" => {
-      date_range: [ 5.years.ago.to_date, Date.current ],
+      date_range: -> { [ 5.years.ago.to_date, Date.current ] },
       label_short: "5Y",
       label: "Last 5 Years",
       comparison_label: "vs. 5 years ago"
@@ -72,7 +72,7 @@ class Period
         raise InvalidKeyError, "Invalid period key: #{key}"
       end
 
-      start_date, end_date = PERIODS[key].fetch(:date_range)
+      start_date, end_date = PERIODS[key].fetch(:date_range).call
 
       new(key: key, start_date: start_date, end_date: end_date)
     end


### PR DESCRIPTION
The `Period` value object (used for many charts) was instantiating pre-defined date ranges into a config hash and reading them at request time.

Since our timezones are dynamically set around each request and these values were already instantiated, the `Date.current` used in many of them was evaluating based on UTC time instead of the user's configured timezone.

This PR configures these pre-defined values as procs so they are evaluated dynamically within the context of the user's timezone.