### PR TITLE
Fix dark mode welcome screen for self-hosting

### DIFF
--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -3,9 +3,9 @@
 %>
 
 <% if self_hosted_first_login? %>
-  <div class="fixed inset-0 w-full h-fit bg-gray-25 p-5 border-b border-secondary flex flex-col gap-3 items-center text-center mb-12">
-    <h2 class="font-bold text-xl"><%= t(".welcome_title") %></h2>
-    <p class="text-secondary text-sm"><%= t(".welcome_body") %></p>
+  <div class="fixed inset-0 w-full h-fit bg-container p-5 border-b border-secondary flex flex-col gap-3 items-center text-center mb-12">
+    <h2 class="font-bold text-primary text-xl"><%= t(".welcome_title") %></h2>
+    <p class="text-secondary text-secondary text-sm"><%= t(".welcome_body") %></p>
   </div>
 <% elsif @invitation %>
   <div class="space-y-1 mb-6 text-center">


### PR DESCRIPTION
This is a super tiny PR, but I decided to start up a self-hosted instance and noticed this screen was a bit weird so figured I'd fix it quickly.

![CleanShot-002916 2025-05-07 at 11 25 17@2x](https://github.com/user-attachments/assets/6022ae06-41a9-4094-8680-977eb1374e0e)


