### PR TITLE
Propagate child sync errors up to parent, fix sync status

### DIFF
--- a/app/controllers/concerns/auto_sync.rb
+++ b/app/controllers/concerns/auto_sync.rb
@@ -7,7 +7,6 @@ module AutoSync
 
   private
     def sync_family
-      Current.family.update!(last_synced_at: Time.current)
       Current.family.sync_later
     end
 

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -82,7 +82,7 @@ class Account < ApplicationRecord
   end
 
   def sync_data(sync, start_date: nil)
-    update!(last_synced_at: Time.current)
+    raise "Artifical error for testing"
 
     Rails.logger.info("Processing balances (#{linked? ? 'reverse' : 'forward'})")
     sync_balances

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -82,8 +82,6 @@ class Account < ApplicationRecord
   end
 
   def sync_data(sync, start_date: nil)
-    raise "Artifical error for testing"
-
     Rails.logger.info("Processing balances (#{linked? ? 'reverse' : 'forward'})")
     sync_balances
   end

--- a/app/models/concerns/syncable.rb
+++ b/app/models/concerns/syncable.rb
@@ -27,7 +27,11 @@ module Syncable
   end
 
   def sync_error
-    latest_sync.error
+    latest_sync&.error
+  end
+
+  def last_synced_at
+    latest_sync&.last_ran_at
   end
 
   private

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -66,8 +66,6 @@ class Family < ApplicationRecord
   end
 
   def sync_data(sync, start_date: nil)
-    update!(last_synced_at: Time.current)
-
     # We don't rely on this value to guard the app, but keep it eventually consistent
     sync_trial_status!
 

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -38,8 +38,6 @@ class PlaidItem < ApplicationRecord
   end
 
   def sync_data(sync, start_date: nil)
-    update!(last_synced_at: Time.current)
-
     begin
       Rails.logger.info("Fetching and loading Plaid data")
       fetch_and_load_plaid_data(sync)

--- a/db/migrate/20250509182903_dynamic_last_synced.rb
+++ b/db/migrate/20250509182903_dynamic_last_synced.rb
@@ -1,0 +1,7 @@
+class DynamicLastSynced < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :plaid_items, :last_synced_at, :datetime
+    remove_column :accounts, :last_synced_at, :datetime
+    remove_column :families, :last_synced_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_02_164951) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_09_182903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_02_164951) do
     t.uuid "import_id"
     t.uuid "plaid_account_id"
     t.boolean "scheduled_for_deletion", default: false
-    t.datetime "last_synced_at"
     t.decimal "cash_balance", precision: 19, scale: 4, default: "0.0"
     t.jsonb "locked_attributes", default: {}
     t.index ["accountable_id", "accountable_type"], name: "index_accounts_on_accountable_id_and_accountable_type"
@@ -225,7 +224,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_02_164951) do
     t.string "stripe_customer_id"
     t.string "date_format", default: "%m-%d-%Y"
     t.string "country", default: "US"
-    t.datetime "last_synced_at"
     t.string "timezone"
     t.boolean "data_enrichment_enabled", default: false
     t.boolean "early_access", default: false
@@ -445,7 +443,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_02_164951) do
     t.datetime "updated_at", null: false
     t.string "available_products", default: [], array: true
     t.string "billed_products", default: [], array: true
-    t.datetime "last_synced_at"
     t.string "plaid_region", default: "us", null: false
     t.string "institution_url"
     t.string "institution_id"

--- a/test/fixtures/families.yml
+++ b/test/fixtures/families.yml
@@ -1,8 +1,5 @@
 empty:
   name: Family
-  last_synced_at: <%= Time.now %>
 
 dylan_family:
   name: The Dylan Family
-  last_synced_at: <%= Time.now %>
-


### PR DESCRIPTION
Previously, if a child sync failed, it was not propagating that error status upwards to the parent.

This caused odd behavior in the UI where a single account sync within a Plaid item would fail, but the Plaid Item would report "synced successfully" in the UI giving the user no indication that something was wrong.