### PR TITLE
Change the "Add condition" button in groups to type button to avoid form submission

### DIFF
--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -44,6 +44,7 @@
     text: "Add condition",
     leading_icon: "plus",
     variant: "ghost",
+    type: "button",
     data: { action: "rule--conditions#addSubCondition" }
   ) %>
 </li>

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -12,7 +12,7 @@
   <section class="space-y-4">
     <h3 class="text-sm font-medium text-primary">If <%= rule.resource_type %></h3>
 
-    <%# Condition template, used by Stimulus controller to add new conditions dynamically %>
+    <%# Condition Group template, used by Stimulus controller to add new conditions dynamically %>
     <template data-rules-target="conditionGroupTemplate">
       <%= f.fields_for :conditions, Rule::Condition.new(rule: rule, condition_type: "compound", operator: "and"), child_index: "IDX_PLACEHOLDER" do |cf| %>
         <%= render "rule/conditions/condition_group", form: cf %>


### PR DESCRIPTION
Right now the "Add condition" button inside a condition group is submitting the form, which causes a few weird things to happen:
- Validation to run and fail
- An extra condition is added

This PR ensures the button is `type: button` instead of `type: submit` to avoid this submission.

| Before             |  After |
|-------------------------|-------------------------|
![](https://github.com/user-attachments/assets/3c947b70-92f6-4720-bfa9-841c32510dd6)  |  ![](https://github.com/user-attachments/assets/d7076131-71fa-4b79-bc61-0196893be3a4)


Fixes #2221