### PR TITLE
Fix AND prefix on rule form

### DIFF
--- a/app/javascript/controllers/rule/conditions_controller.js
+++ b/app/javascript/controllers/rule/conditions_controller.js
@@ -21,11 +21,24 @@ export default class extends Controller {
   }
 
   remove(e) {
+    // Find the parent rules controller before removing the condition
+    const rulesEl = this.element.closest('[data-controller~="rules"]');
+
+    // Remove the condition
     if (e.params.destroy) {
       this.destroyFieldTarget.value = true;
       this.element.classList.add("hidden");
     } else {
       this.element.remove();
+    }
+
+    // Update the prefixes of all siblings from the parent rules controller
+    if (rulesEl) {
+      const rulesController = this.application.getControllerForElementAndIdentifier(rulesEl, "rules");
+      if (rulesController && typeof rulesController.updateConditionPrefixes === "function") {
+        rulesController.updateConditionPrefixes();
+        console.log("updated prefixes")
+      }
     }
   }
 

--- a/app/javascript/controllers/rule/conditions_controller.js
+++ b/app/javascript/controllers/rule/conditions_controller.js
@@ -24,7 +24,6 @@ export default class extends Controller {
     // Find the parent rules controller before removing the condition
     const rulesEl = this.element.closest('[data-controller~="rules"]');
 
-    // Remove the condition
     if (e.params.destroy) {
       this.destroyFieldTarget.value = true;
       this.element.classList.add("hidden");
@@ -37,7 +36,6 @@ export default class extends Controller {
       const rulesController = this.application.getControllerForElementAndIdentifier(rulesEl, "rules");
       if (rulesController && typeof rulesController.updateConditionPrefixes === "function") {
         rulesController.updateConditionPrefixes();
-        console.log("updated prefixes")
       }
     }
   }

--- a/app/javascript/controllers/rule/conditions_controller.js
+++ b/app/javascript/controllers/rule/conditions_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
       this.element.remove();
     }
 
-    // Update the prefixes of all siblings from the parent rules controller
+    // Update the prefixes of all conditions from the parent rules controller
     if (rulesEl) {
       const rulesController = this.application.getControllerForElementAndIdentifier(rulesEl, "rules");
       if (rulesController && typeof rulesController.updateConditionPrefixes === "function") {

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -16,6 +16,7 @@ export default class extends Controller {
       this.conditionGroupTemplateTarget,
       this.conditionsListTarget,
     );
+    this.updateConditionPrefixes();
   }
 
   addCondition() {
@@ -23,6 +24,7 @@ export default class extends Controller {
       this.conditionTemplateTarget,
       this.conditionsListTarget,
     );
+    this.updateConditionPrefixes();
   }
 
   addAction() {
@@ -44,5 +46,16 @@ export default class extends Controller {
 
   #uniqueKey() {
     return Date.now();
+  }
+
+  updateConditionPrefixes() {
+    const items = this.conditionsListTarget.querySelectorAll('[data-condition-prefix]');
+    items.forEach((el, idx) => {
+      if (idx === 0) {
+        el.classList.add('hidden');
+      } else {
+        el.classList.remove('hidden');
+      }
+    });
   }
 }

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -11,6 +11,11 @@ export default class extends Controller {
     "effectiveDateInput",
   ];
 
+  connect() {
+    // Update condition prefixes on first connection (form render)
+    this.updateConditionPrefixes();
+  }
+
   addConditionGroup() {
     this.#appendTemplate(
       this.conditionGroupTemplateTarget,

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -48,13 +48,33 @@ export default class extends Controller {
     return Date.now();
   }
 
+  // Updates the prefix visibility of all conditions and condition groups
+  // This is also called by the rule/conditions_controller when a subcondition is removed
   updateConditionPrefixes() {
-    const items = this.conditionsListTarget.querySelectorAll('[data-condition-prefix]');
-    items.forEach((el, idx) => {
-      if (idx === 0) {
-        el.classList.add('hidden');
-      } else {
-        el.classList.remove('hidden');
+    // Update conditions
+    this.#updatePrefixesForList(this.conditionsListTarget);
+
+    // Update subconditions for each condition group
+    // We currently only support a single level of subconditions
+    const groupSubLists = this.conditionsListTarget.querySelectorAll('[data-rule--conditions-target="subConditionsList"]');
+    groupSubLists.forEach((subList) => {
+      this.#updatePrefixesForList(subList);
+    });
+  }
+
+  // Helper to update prefixes for a given list
+  #updatePrefixesForList(listEl) {
+    const items = Array.from(listEl.children);
+    let conditionIdx = 0;
+    items.forEach((item) => {
+      const prefixEl = item.querySelector('[data-condition-prefix]');
+      if (prefixEl) {
+        if (conditionIdx === 0) {
+          prefixEl.classList.add('hidden');
+        } else {
+          prefixEl.classList.remove('hidden');
+        }
+        conditionIdx++;
       }
     });
   }

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -72,14 +72,18 @@ export default class extends Controller {
     const items = Array.from(listEl.children);
     let conditionIdx = 0;
     items.forEach((item) => {
-      const prefixEl = item.querySelector('[data-condition-prefix]');
-      if (prefixEl) {
-        if (conditionIdx === 0) {
-          prefixEl.classList.add('hidden');
-        } else {
-          prefixEl.classList.remove('hidden');
+      // Only process visible items, this prevents conditions that are marked for removal and hidden
+      // from being added to the index. This is important when editing a rule.
+      if (!item.classList.contains('hidden')) {
+        const prefixEl = item.querySelector('[data-condition-prefix]');
+        if (prefixEl) {
+          if (conditionIdx === 0) {
+            prefixEl.classList.add('hidden');
+          } else {
+            prefixEl.classList.remove('hidden');
+          }
+          conditionIdx++;
         }
-        conditionIdx++;
       }
     });
   }

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
   ];
 
   connect() {
-    // Update condition prefixes on first connection (form render)
+    // Update condition prefixes on first connection (form render on edit)
     this.updateConditionPrefixes();
   }
 
@@ -57,32 +57,22 @@ export default class extends Controller {
   // This is also called by the rule/conditions_controller when a subcondition is removed
   updateConditionPrefixes() {
     // Update conditions
-    this.#updatePrefixesForList(this.conditionsListTarget);
+    const conditions = Array.from(this.conditionsListTarget.children);
 
-    // Update subconditions for each condition group
-    // We currently only support a single level of subconditions
-    const groupSubLists = this.conditionsListTarget.querySelectorAll('[data-rule--conditions-target="subConditionsList"]');
-    groupSubLists.forEach((subList) => {
-      this.#updatePrefixesForList(subList);
-    });
-  }
+    let conditionIndex = 0;
 
-  // Helper to update prefixes for a given list
-  #updatePrefixesForList(listEl) {
-    const items = Array.from(listEl.children);
-    let conditionIdx = 0;
-    items.forEach((item) => {
-      // Only process visible items, this prevents conditions that are marked for removal and hidden
+    conditions.forEach((condition) => {
+      // Only process visible conditions, this prevents conditions that are marked for removal and hidden
       // from being added to the index. This is important when editing a rule.
-      if (!item.classList.contains('hidden')) {
-        const prefixEl = item.querySelector('[data-condition-prefix]');
+      if (!condition.classList.contains('hidden')) {
+        const prefixEl = condition.querySelector('[data-condition-prefix]');
         if (prefixEl) {
-          if (conditionIdx === 0) {
+          if (conditionIndex === 0) {
             prefixEl.classList.add('hidden');
           } else {
             prefixEl.classList.remove('hidden');
           }
-          conditionIdx++;
+          conditionIndex++;
         }
       }
     });

--- a/app/javascript/controllers/rules_controller.js
+++ b/app/javascript/controllers/rules_controller.js
@@ -56,9 +56,7 @@ export default class extends Controller {
   // Updates the prefix visibility of all conditions and condition groups
   // This is also called by the rule/conditions_controller when a subcondition is removed
   updateConditionPrefixes() {
-    // Update conditions
     const conditions = Array.from(this.conditionsListTarget.children);
-
     let conditionIndex = 0;
 
     conditions.forEach((condition) => {

--- a/app/models/rule.rb
+++ b/app/models/rule.rb
@@ -46,6 +46,18 @@ class Rule < ApplicationRecord
     RuleJob.perform_later(self, ignore_attribute_locks: ignore_attribute_locks)
   end
 
+  def primary_condition_title
+    return "No conditions" if conditions.none?
+
+    first_condition = conditions.first
+    if first_condition.compound? && first_condition.sub_conditions.any?
+      first_sub_condition = first_condition.sub_conditions.first
+      "If #{first_sub_condition.filter.label.downcase} #{first_sub_condition.operator} #{first_sub_condition.value_display}"
+    else
+      "If #{first_condition.filter.label.downcase} #{first_condition.operator} #{first_condition.value_display}"
+    end
+  end
+
   private
     def matching_resources_scope
       scope = registry.resource_scope

--- a/app/views/rule/conditions/_condition.html.erb
+++ b/app/views/rule/conditions/_condition.html.erb
@@ -1,14 +1,18 @@
-<%# locals: (form:) %>
+<%# locals: (form:, show_prefix: true) %>
 
 <% condition = form.object %>
 <% rule = condition.rule %>
 
 <li data-controller="rule--conditions" data-rule--conditions-condition-filters-value="<%= rule.condition_filters.to_json %>" class="flex items-center gap-3">
 
-  <%# Show prefix on conditions, except the first one %>
-  <div class="pl-2" data-condition-prefix>
-    <span class="font-medium uppercase text-xs">and</span>
-  </div>
+  <%# Conditionally render the prefix %>
+  <%# Condition groups pass in show_prefix: false for subconditions since the ANY/ALL selector makes that clear %>
+  <% if show_prefix %>
+    <div class="pl-2" data-condition-prefix>
+      <span class="font-medium uppercase text-xs">and</span>
+    </div>
+  <% end %>
+
   <div class="grow flex gap-2 items-center h-full">
     <%= form.hidden_field :_destroy, value: false, data: { rule__conditions_target: "destroyField" } %>
 

--- a/app/views/rule/conditions/_condition.html.erb
+++ b/app/views/rule/conditions/_condition.html.erb
@@ -6,10 +6,13 @@
 <li data-controller="rule--conditions" data-rule--conditions-condition-filters-value="<%= rule.condition_filters.to_json %>" class="flex items-center gap-3">
   <% if form.index.to_i > 0 && show_prefix %>
     <div class="pl-4">
-      <span class="font-medium uppercase text-xs">and</span>
+      <span class="font-medium uppercase text-xs" data-condition-prefix>and</span>
+    </div>
+  <% else %>
+    <div class="pl-4">
+      <span class="font-medium uppercase text-xs hidden" data-condition-prefix>and</span>
     </div>
   <% end %>
-
   <div class="grow flex gap-2 items-center h-full">
     <%= form.hidden_field :_destroy, value: false, data: { rule__conditions_target: "destroyField" } %>
 

--- a/app/views/rule/conditions/_condition.html.erb
+++ b/app/views/rule/conditions/_condition.html.erb
@@ -1,18 +1,14 @@
-<%# locals: (form:, show_prefix: true) %>
+<%# locals: (form:) %>
 
 <% condition = form.object %>
 <% rule = condition.rule %>
 
 <li data-controller="rule--conditions" data-rule--conditions-condition-filters-value="<%= rule.condition_filters.to_json %>" class="flex items-center gap-3">
-  <% if form.index.to_i > 0 && show_prefix %>
-    <div class="pl-4">
-      <span class="font-medium uppercase text-xs" data-condition-prefix>and</span>
-    </div>
-  <% else %>
-    <div class="pl-4">
-      <span class="font-medium uppercase text-xs hidden" data-condition-prefix>and</span>
-    </div>
-  <% end %>
+
+  <%# Show prefix on conditions, except the first one %>
+  <div class="pl-2" data-condition-prefix>
+    <span class="font-medium uppercase text-xs">and</span>
+  </div>
   <div class="grow flex gap-2 items-center h-full">
     <%= form.hidden_field :_destroy, value: false, data: { rule__conditions_target: "destroyField" } %>
 

--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -3,7 +3,7 @@
 <% condition = form.object %>
 <% rule = condition.rule %>
 
-<li data-controller="rule--conditions element-removal" class="border border-secondary rounded-md p-4 space-y-3">
+<li data-controller="rule--conditions" class="border border-secondary rounded-md p-4 space-y-3">
 
   <%= form.hidden_field :condition_type, value: "compound" %>
 
@@ -20,9 +20,9 @@
 
     <%= icon(
       "trash-2",
-      size: "sm",
       as_button: true,
-      data: { action: "element-removal#remove" }
+      size: "sm",
+      data: { action: "rule--conditions#remove" }
     ) %>
   </div>
 

--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -9,15 +9,10 @@
 
   <div class="flex items-center justify-between gap-2">
     <div class="flex items-center gap-2">
-      <% unless form.index == 0 %>
-        <div class="pl-2">
-          <span class="font-medium uppercase text-xs" data-condition-prefix>and</span>
-        </div>
-      <% else %>
-        <div class="pl-2">
-          <span class="font-medium uppercase text-xs hidden" data-condition-prefix>and</span>
-        </div>
-      <% end %>
+      <%# Show prefix on condition groups, except the first one %>
+      <div class="pl-2" data-condition-prefix>
+        <span class="font-medium uppercase text-xs">and</span>
+      </div>
       <p class="text-sm text-secondary">match</p>
       <%= form.select :operator, [["all", "and"], ["any", "or"]], { container_class: "w-fit" }, data: { rules_target: "operatorField" } %>
       <p class="text-sm text-secondary">of the following conditions</p>
@@ -40,7 +35,7 @@
 
   <ul data-rule--conditions-target="subConditionsList" class="space-y-3">
     <%= form.fields_for :sub_conditions do |scf| %>
-      <%= render "rule/conditions/condition", form: scf, show_prefix: false %>
+      <%= render "rule/conditions/condition", form: scf %>
     <% end %>
   </ul>
 

--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -11,7 +11,11 @@
     <div class="flex items-center gap-2">
       <% unless form.index == 0 %>
         <div class="pl-2">
-          <span class="font-medium uppercase text-xs">and</span>
+          <span class="font-medium uppercase text-xs" data-condition-prefix>and</span>
+        </div>
+      <% else %>
+        <div class="pl-2">
+          <span class="font-medium uppercase text-xs hidden" data-condition-prefix>and</span>
         </div>
       <% end %>
       <p class="text-sm text-secondary">match</p>

--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -48,6 +48,7 @@
     text: "Add condition",
     leading_icon: "plus",
     variant: "ghost",
+    type: "button",
     data: { action: "rule--conditions#addSubCondition" }
   ) %>
 </li>

--- a/app/views/rule/conditions/_condition_group.html.erb
+++ b/app/views/rule/conditions/_condition_group.html.erb
@@ -29,13 +29,13 @@
   <%# Sub-condition template, used by Stimulus controller to add new sub-conditions dynamically %>
   <template data-rule--conditions-target="subConditionTemplate">
     <%= form.fields_for :sub_conditions, Rule::Condition.new(parent: condition, condition_type: rule.condition_filters.first.key), child_index: "IDX_PLACEHOLDER" do |scf| %>
-      <%= render "rule/conditions/condition", form: scf %>
+      <%= render "rule/conditions/condition", form: scf, show_prefix: false %>
     <% end %>
   </template>
 
   <ul data-rule--conditions-target="subConditionsList" class="space-y-3">
     <%= form.fields_for :sub_conditions do |scf| %>
-      <%= render "rule/conditions/condition", form: scf %>
+      <%= render "rule/conditions/condition", form: scf, show_prefix: false %>
     <% end %>
   </ul>
 

--- a/app/views/rules/_form.html.erb
+++ b/app/views/rules/_form.html.erb
@@ -12,7 +12,7 @@
   <section class="space-y-4">
     <h3 class="text-sm font-medium text-primary">If <%= rule.resource_type %></h3>
 
-    <%# Condition template, used by Stimulus controller to add new conditions dynamically %>
+    <%# Condition Group template, used by Stimulus controller to add new conditions dynamically %>
     <template data-rules-target="conditionGroupTemplate">
       <%= f.fields_for :conditions, Rule::Condition.new(rule: rule, condition_type: "compound", operator: "and"), child_index: "IDX_PLACEHOLDER" do |cf| %>
         <%= render "rule/conditions/condition_group", form: cf %>

--- a/app/views/rules/_rule.html.erb
+++ b/app/views/rules/_rule.html.erb
@@ -4,12 +4,8 @@
   <div class="text-sm space-y-1.5">
     <% if rule.conditions.any? %>
       <p class="flex items-center flex-wrap gap-1.5">
-        <span class="px-2 py-1 border border-alpha-black-200 rounded-full">
-          <% if rule.conditions.first.compound? %>
-            If <%= rule.conditions.first.sub_conditions.first.filter.label %> <%= rule.conditions.first.sub_conditions.first.operator %> <%= rule.conditions.first.sub_conditions.first.value_display %>
-          <% else %>
-            If <%= rule.conditions.first.filter.label %> <%= rule.conditions.first.operator %> <%= rule.conditions.first.value_display %>
-          <% end %>
+        <span class="px-2 py-1 border border-secondary rounded-full">
+          <%= rule.primary_condition_title %>
         </span>
 
         <% if rule.conditions.count > 1 %>


### PR DESCRIPTION
Currently, there are a handful of weird things when creating/editing rules around the prefix for a condition:
- When creating a new rule, there is no AND prefix on any condition until the form is submitted
- When creating a new rule, there is always the prefix on a condition group, even if its the first condition on the rule
- When editing a rule with multiple conditions, the saved conditions have the prefix, but new conditions do not
- When editing a rule with multiple conditions, if the first condition is deleted, the new first condition has the prefix

I'm sure there are some more odd cases for different circumstances, but ultimately it seems like the issues are:
- The prefix isn't updated on any change
- The index for an item that isn't yet saved is a very large number, and not `0`, which breaks the current logic.

To solve for all of this weird behavior, I've done a few things:
- Add a new method to our stimulus controller to dynamically add/remove the prefix, filtering out hidden items (those marked for deletion)
- Run the stimulus method when form is rendered, adding a condition or group, and removing a condition or group. Removing a condition is done by the condition controller, so instead of duplicating the prefix logic, I look for the closet rule controller to the condition controller and use the prefix update method from there
- I fell down a deep and dark rabbit hole trying to dynamically show `AND` vs `OR` on the 2+ subcondition in a condition group based on the `ANY` or `ALL` operators. This added a lot of complexity for a small payoff in my opinion, since the any/all operator already clearly show what the condition will be. Maybe this could be a future improvement, but it didn't seem worth the complexity at the moment. 

Here's a video showing proper prefixes for all the actions (adding condition, group, subconditions, removals, edits, etc):

https://github.com/user-attachments/assets/b121eeb3-115e-4a2f-9de3-ffc4f5ae097c

Fixes #2230

This also implements the `primary_condition_title` field on a rule that [Zach recommended here](https://github.com/maybe-finance/maybe/pull/2177#discussion_r2081762981).