### PR TITLE
Don't override changed name from plaid

### DIFF
--- a/app/models/plaid_account.rb
+++ b/app/models/plaid_account.rb
@@ -20,7 +20,10 @@ class PlaidAccount < ApplicationRecord
 
         internal_account = family.accounts.find_or_initialize_by(plaid_account_id: plaid_account.id)
 
-        internal_account.name = plaid_data.name
+        # Only set the name for new records or if the name is not locked
+        if internal_account.new_record? || internal_account.enrichable?(:name)
+          internal_account.name = plaid_data.name
+        end
         internal_account.balance = plaid_data.balances.current || plaid_data.balances.available
         internal_account.currency = plaid_data.balances.iso_currency_code
         internal_account.accountable = TYPE_MAPPING[plaid_data.type].new


### PR DESCRIPTION
I've noticed that when I update the name of an account, the next plaid sync will revert the custom name. 

I don't have a plaid sandbox (I probably should do this at some point) so I don't have a for sure way to validate this, but I think this should do the trick. If I'm off the right path here, happy to dig further!
