### PR TITLE
Move to 3 decimal place precision for loans

### DIFF
--- a/app/views/loans/_overview.html.erb
+++ b/app/views/loans/_overview.html.erb
@@ -12,7 +12,6 @@
   <%= summary_card title: t(".interest_rate") do %>
     <% if account.loan.interest_rate.present? %>
       <%= number_to_percentage(account.loan.interest_rate, precision: 3) %>
-      
     <% else %>
       <%= t(".unknown") %>
     <% end %>

--- a/app/views/loans/_overview.html.erb
+++ b/app/views/loans/_overview.html.erb
@@ -11,7 +11,7 @@
 
   <%= summary_card title: t(".interest_rate") do %>
     <% if account.loan.interest_rate.present? %>
-      <%= number_to_percentage(account.loan.interest_rate, precision: 2) %>
+      <%= number_to_percentage(account.loan.interest_rate, precision: 3) %>
     <% else %>
       <%= t(".unknown") %>
     <% end %>

--- a/app/views/loans/_overview.html.erb
+++ b/app/views/loans/_overview.html.erb
@@ -12,6 +12,7 @@
   <%= summary_card title: t(".interest_rate") do %>
     <% if account.loan.interest_rate.present? %>
       <%= number_to_percentage(account.loan.interest_rate, precision: 3) %>
+      
     <% else %>
       <%= t(".unknown") %>
     <% end %>


### PR DESCRIPTION
Most mortgages that I have seen are usually in 1/8th % increments, e.g. 6.875%. This is accurately displayed in the edit menu, but the current overview menu rounds to 2 decimal places. This PR changes that to show 3 decimal places to account for the 1/8% jumps.

![CleanShot-003046 2025-05-15 at 19 22 28@2x](https://github.com/user-attachments/assets/38a33c79-b7c0-46ee-89b5-cbc53c7e5860)


This is something that probably varies greatly by lender/country/etc, so if this is something that many others disagree with I can close this out.
