### PR TITLE
syncs: Allow self host clients to clear sync cache.

### DIFF
--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -3,7 +3,7 @@ class Settings::HostingsController < ApplicationController
 
   guard_feature unless: -> { self_hosted? }
 
-  before_action :ensure_admin, only: :clear_cache
+  before_action :ensure_admin, only: [ :clear_cache, :clear_syncs ]
 
   def show
     synth_provider = Provider::Registry.get_provider(:synth)
@@ -32,6 +32,11 @@ class Settings::HostingsController < ApplicationController
   def clear_cache
     DataCacheClearJob.perform_later(Current.family)
     redirect_to settings_hosting_path, notice: t(".cache_cleared")
+  end
+
+  def clear_syncs
+    SyncsCacheClearJob.perform_later(Current.family)
+    redirect_to settings_hosting_path, notice: t(".syncs_cleared")
   end
 
   private

--- a/app/jobs/syncs_cache_clear_job.rb
+++ b/app/jobs/syncs_cache_clear_job.rb
@@ -1,0 +1,12 @@
+class SyncsCacheClearJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform(family)
+    syncs = family.syncs
+    ActiveRecord::Base.transaction do
+      syncs
+        .where(status: [ "pending", "syncing" ])
+        .update_all(status: "failed")
+    end
+  end
+end

--- a/app/views/settings/hostings/_danger_zone_settings.html.erb
+++ b/app/views/settings/hostings/_danger_zone_settings.html.erb
@@ -16,5 +16,21 @@
               }}
       %>
     </div>
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div class="w-full md:w-2/3">
+        <h3 class="font-medium text-primary"><%= t("settings.hostings.show.clear_syncs") %></h3>
+        <p class="text-secondary text-sm"><%= t("settings.hostings.show.clear_syncs_warning") %></p>
+      </div>
+      <%=
+            button_to t("settings.hostings.show.clear_syncs"), clear_syncs_settings_hosting_path, method: :delete,
+              class: "w-full md:w-auto bg-orange-500 text-white text-sm font-medium rounded-lg px-4 py-2",
+              data: { turbo_confirm: {
+                title: t("settings.hostings.show.confirm_clear_syncs.title"),
+                body: t("settings.hostings.show.confirm_clear_syncs.body"),
+                accept: t("settings.hostings.show.clear_syncs"),
+                acceptClass: "w-full bg-orange-500 text-white rounded-xl text-center p-[10px] border mb-2"
+              }}
+      %>
+    </div>
   </div>
 <% end %>

--- a/config/locales/views/settings/hostings/en.yml
+++ b/config/locales/views/settings/hostings/en.yml
@@ -21,6 +21,12 @@ en:
         confirm_clear_cache:
           title: Clear data cache?
           body: Are you sure you want to clear the data cache? This will remove all exchange rates, security prices, account balances, and other data. This action cannot be undone.
+        clear_syncs:  Clear syncs cache
+        clear_syncs_warning:  Clearing the syncs cache will remove all syncs enqueued.
+        confirm_clear_syncs:
+          title: Clear syncs cache?
+          body: Are you sure you want to clear the data cache? This will remove all syncs enqueued.
+
       synth_settings:
         api_calls_used: "%{used} / %{limit} API calls used (%{percentage})"
         description: Input the API key provided by Synth
@@ -33,4 +39,6 @@ en:
         success: Settings updated
       clear_cache:
         cache_cleared: Data cache has been cleared. This may take a few moments to complete.
+      clear_syncs:
+        syncs_cleared: Syncs cache has been cleared. This may take a few moments to complete.
       not_authorized: You are not authorized to perform this action

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
     resource :preferences, only: :show
     resource :hosting, only: %i[show update] do
       delete :clear_cache, on: :collection
+      delete :clear_syncs, on: :collection
     end
     resource :billing, only: :show
     resource :security, only: :show


### PR DESCRIPTION
Add button to self host settings to allow admins remove sync cache.

Fixes part of #2251.
![image](https://github.com/user-attachments/assets/6a322b62-14be-44cc-9aaf-226d3a17c326)
![image](https://github.com/user-attachments/assets/2116c6fd-7b69-4e07-a928-acbc82d3e983)
