### PR TITLE
Handle stale syncs

### DIFF
--- a/app/jobs/sync_cleaner_job.rb
+++ b/app/jobs/sync_cleaner_job.rb
@@ -1,0 +1,7 @@
+class SyncCleanerJob < ApplicationJob
+  queue_as :scheduled
+
+  def perform
+    Sync.clean
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -62,7 +62,7 @@ class Account < ApplicationRecord
   end
 
   def syncing?
-    self_syncing = syncs.incomplete.any?
+    self_syncing = syncs.visible.any?
 
     # Since Plaid Items sync as a "group", if the item is syncing, even if the account
     # sync hasn't yet started (i.e. we're still fetching the Plaid data), show it as syncing in UI.

--- a/app/models/family.rb
+++ b/app/models/family.rb
@@ -40,7 +40,7 @@ class Family < ApplicationRecord
     Sync.joins("LEFT JOIN plaid_items ON plaid_items.id = syncs.syncable_id AND syncs.syncable_type = 'PlaidItem'")
         .joins("LEFT JOIN accounts ON accounts.id = syncs.syncable_id AND syncs.syncable_type = 'Account'")
         .where("syncs.syncable_id = ? OR accounts.family_id = ? OR plaid_items.family_id = ?", id, id, id)
-        .incomplete
+        .visible
         .exists?
   end
 

--- a/app/models/plaid_item.rb
+++ b/app/models/plaid_item.rb
@@ -56,7 +56,7 @@ class PlaidItem < ApplicationRecord
     Sync.joins("LEFT JOIN accounts a ON a.id = syncs.syncable_id AND syncs.syncable_type = 'Account'")
         .joins("LEFT JOIN plaid_accounts pa ON pa.id = a.plaid_account_id")
         .where("syncs.syncable_id = ? OR pa.plaid_item_id = ?", id, id)
-        .incomplete
+        .visible
         .exists?
   end
 

--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -1,4 +1,11 @@
 class Sync < ApplicationRecord
+  # We run a cron that marks any syncs that have been running > 2 hours as "stale"
+  # Syncs often become stale when new code is deployed and the worker restarts
+  STALE_AFTER = 2.hours
+
+  # The max time that a sync will show in the UI (after 5 minutes)
+  VISIBLE_FOR = 5.minutes
+
   include AASM
 
   Error = Class.new(StandardError)
@@ -9,7 +16,10 @@ class Sync < ApplicationRecord
   has_many :children, class_name: "Sync", foreign_key: :parent_id, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :desc) }
-  scope :incomplete, -> { where(status: [ :pending, :syncing ]) }
+  scope :incomplete, -> { where("syncs.status IN (?)", [ :pending, :syncing ]) }
+  scope :visible, -> { incomplete.where("syncs.created_at > ?", VISIBLE_FOR.ago) }
+  # In-flight records that have exceeded the allowed runtime
+  scope :stale_candidates, -> { incomplete.where("syncs.created_at < ?", STALE_AFTER.ago) }
 
   validate :window_valid
 
@@ -19,6 +29,7 @@ class Sync < ApplicationRecord
     state :syncing
     state :completed
     state :failed
+    state :stale
 
     after_all_transitions :log_status_change
 
@@ -32,6 +43,17 @@ class Sync < ApplicationRecord
 
     event :fail do
       transitions from: :syncing, to: :failed
+    end
+
+    # Marks a sync that never completed within the expected time window
+    event :mark_stale do
+      transitions from: %i[pending syncing], to: :stale
+    end
+  end
+
+  class << self
+    def clean
+      stale_candidates.find_each(&:mark_stale!)
     end
   end
 

--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -16,8 +16,9 @@ class Sync < ApplicationRecord
   has_many :children, class_name: "Sync", foreign_key: :parent_id, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :desc) }
-  scope :incomplete, -> { where("syncs.status IN (?)", [ :pending, :syncing ]) }
+  scope :incomplete, -> { where("syncs.status IN (?)", %w[pending syncing]) }
   scope :visible, -> { incomplete.where("syncs.created_at > ?", VISIBLE_FOR.ago) }
+
   # In-flight records that have exceeded the allowed runtime
   scope :stale_candidates, -> { incomplete.where("syncs.created_at < ?", STALE_AFTER.ago) }
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -6,3 +6,9 @@ import_market_data:
   args:
     mode: "full"
     clear_cache: false
+  
+clean_syncs:
+  cron: "0 * * * *" # every hour
+  class: "SyncCleanerJob"
+  queue: "scheduled"
+  description: "Cleans up stale syncs"

--- a/test/models/sync_test.rb
+++ b/test/models/sync_test.rb
@@ -167,4 +167,25 @@ class SyncTest < ActiveSupport::TestCase
     assert_equal "failed", family_sync.reload.status
     assert_equal "completed", account_sync.reload.status
   end
+
+  test "clean marks stale incomplete rows" do
+    stale_pending = Sync.create!(
+      syncable: accounts(:depository),
+      status: :pending,
+      created_at: 3.hours.ago
+    )
+
+    stale_syncing = Sync.create!(
+      syncable: accounts(:depository),
+      status: :syncing,
+      created_at: 3.hours.ago,
+      pending_at: 3.hours.ago,
+      syncing_at: 2.hours.ago
+    )
+
+    Sync.clean
+
+    assert_equal "stale", stale_pending.reload.status
+    assert_equal "stale", stale_syncing.reload.status
+  end
 end


### PR DESCRIPTION
When code changes are deployed and workers restart, in-process syncs will be aborted and will never be re-run.  This causes many syncs to become stuck in `pending` or `syncing` status forever.

This PR mitigates the effects of this with a 3-pronged approach:

- The `visible` scope makes it so users won't ever see a sync longer than 5 minutes (and most syncs will complete even faster)
- The `sync_later` method now marks all prior syncs for that specific `syncable` record as `stale` prior to starting a new sync
- The `SyncCleanerJob` runs hourly and marks any syncs that became stale as `stale` 