### PR TITLE
Add new ai chat button, tweak ai navigation

### DIFF
--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -8,7 +8,7 @@
       id: "chat-nav-back",
       variant: "icon",
       icon: "menu",
-      href: chats_path,
+      href: path,
       frame: chat_frame,
       text: "All chats"
     ) %>

--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -7,9 +7,10 @@
     <%= render LinkComponent.new(
       id: "chat-nav-back",
       variant: "icon",
-      icon: "arrow-left",
+      icon: "menu",
       href: chats_path,
-      frame: chat_frame
+      frame: chat_frame,
+      text: "All chats"
     ) %>
 
     <div class="grow">
@@ -25,7 +26,8 @@
         variant: "link",
         text: "Edit chat title",
         href: edit_chat_path(chat, ctx: "chat"),
-        icon: "pencil", data: { turbo_frame: dom_id(chat, "title") }) %>
+        icon: "pencil",
+        frame: dom_id(chat, "title")) %>
 
       <% menu.with_item(
         variant: "button",

--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -7,8 +7,9 @@
     <%= render LinkComponent.new(
       id: "chat-nav-back",
       variant: "icon",
-      icon: "menu",
-      href: path,
+      icon: "arrow-left",
+      href: chats_path,
+      frame: chat_frame
     ) %>
 
     <div class="grow">

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -3,15 +3,15 @@
     <div class="flex flex-col h-full md:p-4">
       <% if @chats.any? %>
         <div class="grow flex flex-col">
-          <h1 class="text-xl font-medium my-6">Chats</h1>
-          <div class="mb-4">
+          <div class="flex items-center justify-between my-6">
+            <h1 class="text-xl font-medium">Chats</h1>
             <%= render LinkComponent.new(
-              text: "New chat",
+              id: "new-chat",
               icon: "plus",
-              variant: :primary,
+              variant: "icon",
               href: new_chat_path,
               frame: chat_frame,
-              class: "w-full justify-center"
+              text: "New chat"
             ) %>
           </div>
           <div class="space-y-2 px-0.5">

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -16,6 +16,16 @@
       <div class="grow flex flex-col">
         <% if @chats.any? %>
           <h1 class="text-xl font-medium mb-6">Chats</h1>
+          <div class="mb-4">
+            <%= render LinkComponent.new(
+              text: "New chat",
+              icon: "plus",
+              variant: :primary,
+              href: new_chat_path,
+              frame: chat_frame,
+              class: "w-full justify-center"
+            ) %>
+          </div>
           <div class="space-y-2 px-0.5">
             <%= render @chats %>
           </div>

--- a/app/views/chats/index.html.erb
+++ b/app/views/chats/index.html.erb
@@ -2,20 +2,8 @@
   <%= turbo_frame_tag chat_frame do %>
     <div class="flex flex-col h-full md:p-4">
       <% if @chats.any? %>
-        <nav class="mb-6">
-          <% back_path = @last_viewed_chat ? chat_path(@last_viewed_chat) : new_chat_path %>
-
-          <%= render LinkComponent.new(
-            variant: "icon",
-            icon: "arrow-left",
-            href: back_path,
-          ) %>
-        </nav>
-      <% end %>
-
-      <div class="grow flex flex-col">
-        <% if @chats.any? %>
-          <h1 class="text-xl font-medium mb-6">Chats</h1>
+        <div class="grow flex flex-col">
+          <h1 class="text-xl font-medium my-6">Chats</h1>
           <div class="mb-4">
             <%= render LinkComponent.new(
               text: "New chat",
@@ -29,15 +17,16 @@
           <div class="space-y-2 px-0.5">
             <%= render @chats %>
           </div>
-        <% else %>
+        </div>
+      <% else %>
+        <div class="grow flex flex-col">
           <h1 class="sr-only">Chats</h1>
           <div class="mt-auto py-8">
             <%= render "chats/ai_greeting" %>
           </div>
-
           <%= render "messages/chat_form" %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/chats/new.html.erb
+++ b/app/views/chats/new.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag chat_frame do %>
-  <div class="flex flex-col h-full md:p4">
+  <div class="flex flex-col h-full md:p-4">
     <%= render "chats/chat_nav", chat: @chat %>
 
     <div class="mt-auto py-8">

--- a/app/views/chats/new.html.erb
+++ b/app/views/chats/new.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag chat_frame do %>
-  <div class="flex flex-col h-full md:px-4 md:pb-4">
+  <div class="flex flex-col h-full md:p4">
     <%= render "chats/chat_nav", chat: @chat %>
 
     <div class="mt-auto py-8">


### PR DESCRIPTION
I've been playing with the AI chat a bit, and some of the navigation of it all kept tripping me up so I thought I'd suggest a couple of improvements!

1. Add a 'new chat' button to the main page. A new chat being hidden behind the 3 dot menu of an existing chat felt a bit strange - this option hasn't been removed. The default chat on the dashboard load is also still the most recent chat.

  <img width="426" alt="image" src="https://github.com/user-attachments/assets/66e63fc8-3570-4d48-80cd-b4fa48f0c8a5" />

2. Tweak the navigation in the AI chat. Currently when you're on a new chat there's a 3 line button that puts you back to the 'main chat page', and the main chat page has a back button which takes you to your most recent. This feels very unintuitive to me - when I'm inside of something it makes sense to go 'back' to something else. If I'm on the main menu I don't expect to really go 'back' to a chat that is within that menu. If I'm alone on this, happy to swap this back to the current behavior! You can see the lack of a back button on the main page above, and here is the new back button on each chat:

  ![CleanShot-003141 2025-05-20 at 20 59 14@2x](https://github.com/user-attachments/assets/a1eef24f-d1e4-485e-acaf-2c3c5431cf31)

3. Fix the padding around the nav title on a new chat

  ![CleanShot-003143 2025-05-20 at 21 03 20@2x](https://github.com/user-attachments/assets/a0b4f4bb-b551-4253-809e-251e125732ea)


