### PR TITLE
UI Fixes

### DIFF
--- a/app/views/accounts/index/_account_groups.erb
+++ b/app/views/accounts/index/_account_groups.erb
@@ -12,8 +12,11 @@
       <% end %>
     </div>
     <div class="bg-container rounded-lg shadow-border-xs">
-      <% accounts.each do |account| %>
+      <% accounts.each_with_index do |account, index| %>
         <%= render account %>
+        <% unless index == accounts.count - 1 %>
+          <%= render "shared/ruler" %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/budgets/_actuals_summary.html.erb
+++ b/app/views/budgets/_actuals_summary.html.erb
@@ -12,7 +12,7 @@
       <div>
         <div class="flex h-1.5 mb-3 gap-1">
           <% budget.income_category_totals.each do |category_total| %>
-            <div class="h-full rounded-xs" style="background-color: <%= category_total.category.color %>; width: <%= category_total.weight %>%"></div>
+            <div class="h-full rounded-full" style="background-color: <%= category_total.category.color %>; width: <%= category_total.weight %>%"></div>
           <% end %>
         </div>
 
@@ -38,7 +38,7 @@
       <div>
         <div class="flex h-1.5 mb-3 gap-1">
           <% budget.expense_category_totals.each do |category_total| %>
-            <div class="h-full rounded-xs" style="background-color: <%= category_total.category.color %>; width: <%= category_total.weight %>%"></div>
+            <div class="h-full rounded-full" style="background-color: <%= category_total.category.color %>; width: <%= category_total.weight %>%"></div>
           <% end %>
         </div>
 

--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -58,10 +58,13 @@
             </div>
           </div>
 
-          <div class="shadow-border-xs rounded-lg font-medium text-sm bg-container min-w-fit">
-            <% classification_group.account_groups.each do |account_group| %>
-              <details class="group">
-                <summary class="cursor-pointer p-4 group-open:bg-surface bg-container rounded-lg flex items-center justify-between">
+          <div class="shadow-border-xs rounded-lg bg-container font-medium text-sm min-w-fit">
+            <% classification_group.account_groups.each_with_index do |account_group, idx| %>
+              <details class="group open:bg-surface
+                <%= idx == 0 ? "rounded-t-lg" : "" %>
+                <%= idx == classification_group.account_groups.size - 1 ? "rounded-b-lg" : "" %>
+              ">
+                <summary class="cursor-pointer p-4 group-open:bg-surface rounded-lg flex items-center justify-between">
                   <div class="w-40 shrink-0 flex items-center gap-4">
                     <%= icon("chevron-right", class: "group-open:rotate-90") %>
 
@@ -93,7 +96,7 @@
 
                 <div>
                   <% account_group.accounts.each_with_index do |account, idx| %>
-                    <div class="pl-12 pr-4 py-3 flex items-center bg-container justify-between text-sm font-medium">
+                    <div class="pl-12 pr-4 py-3 flex items-center justify-between text-sm font-medium">
                       <div class="flex items-center gap-3">
                         <%= render "accounts/logo", account: account, size: "sm", color: account_group.color %>
 

--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -132,6 +132,9 @@
                   <% end %>
                 </div>
               </details>
+              <% unless idx == classification_group.account_groups.size - 1 %>
+                <%= render "shared/ruler", classes: "mx-4 group-ruler" %>
+              <% end %>
             <% end %>
           </div>
         </div>
@@ -150,3 +153,10 @@
     </div>
   <% end %>
 </div>
+
+<%# Custom style for hiding ruler when details are open %>
+<style>
+  details[open] + .group-ruler {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
This PR is another round of UI fixes from @justinfar

- Use rounded-full on budget allocation bar to match balance sheet:
  
  <img width="753" alt="image" src="https://github.com/user-attachments/assets/daaffa14-d283-4154-a96c-4d0ab7d393e8" />

- Fix backgrounds when balance sheet groups are open, add rulers between accounts/groups

  ![CleanShot-003162 2025-05-21 at 14 46 07@2x](https://github.com/user-attachments/assets/42849aab-ff49-40e7-9357-7c1b1460e279)

  Here's another shot of before on the balance sheet when the groups were open, there is a weird slice between the corners (before I messed up the background in #2271):

  ![image](https://github.com/user-attachments/assets/a1b650fc-784e-47d7-81c7-72e62459aaaf)


