### PR TITLE
feature: Show total balance in family currency in accounts.

### DIFF
--- a/app/views/accounts/show/_chart.html.erb
+++ b/app/views/accounts/show/_chart.html.erb
@@ -13,12 +13,16 @@
           <%= render "investments/value_tooltip", balance: account.balance_money, holdings: account.balance_money - account.cash_balance_money, cash: account.cash_balance_money %>
         <% end %>
       </div>
-
-      <% if account.syncing? %>
-        <div class="bg-loader rounded-md h-7 w-20"></div>
-      <% else %>
-        <%= tag.p format_money(account.balance_money), class: "text-primary text-3xl font-medium truncate" %>
-      <% end %>
+      <div class="flex flex-row gap-2 items-baseline">
+        <% if account.syncing? %>
+          <div class="bg-loader rounded-md h-7 w-20"></div>
+        <% else %>
+          <%= tag.p format_money(account.balance_money), class: "text-primary text-3xl font-medium truncate" %>
+          <% if account.currency != Current.family.currency %>
+            <%= tag.p format_money(account.balance_money.exchange_to(Current.family.currency, fallback_rate: 1)), class: "text-sm font-medium text-secondary" %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
 
     <%= form_with url: request.path, method: :get, data: { controller: "auto-submit-form" } do |form| %>


### PR DESCRIPTION
For accounts in a different currency from the family currency, show a total balance in the family currency for a better financial overview.

Fixes #2145.

![image](https://github.com/user-attachments/assets/2be56be8-9ff6-483a-86db-8ad2b9869394)

