### PR TITLE
Fix and improve chat title edit

### DIFF
--- a/app/components/menu_item_component.rb
+++ b/app/components/menu_item_component.rb
@@ -1,25 +1,26 @@
 class MenuItemComponent < ViewComponent::Base
   VARIANTS = %i[link button divider].freeze
 
-  attr_reader :variant, :text, :icon, :href, :method, :destructive, :confirm, :opts
+  attr_reader :variant, :text, :icon, :href, :method, :destructive, :confirm, :frame, :opts
 
-  def initialize(variant:, text: nil, icon: nil, href: nil, method: :post, destructive: false, confirm: nil, **opts)
+  def initialize(variant:, text: nil, icon: nil, href: nil, method: :post, destructive: false, confirm: nil, frame: nil, **opts)
     @variant = variant.to_sym
     @text = text
     @icon = icon
     @href = href
     @method = method.to_sym
     @destructive = destructive
-    @opts = opts
     @confirm = confirm
+    @frame = frame
+    @opts = opts
     raise ArgumentError, "Invalid variant: #{@variant}" unless VARIANTS.include?(@variant)
   end
 
   def wrapper(&block)
     if variant == :button
-      button_to href, method: method, class: container_classes, **merged_button_opts, &block
+      button_to href, method: method, class: container_classes, **merged_opts, &block
     elsif variant == :link
-      link_to href, class: container_classes, **opts, &block
+      link_to href, class: container_classes, **merged_opts, &block
     else
       nil
     end
@@ -44,12 +45,16 @@ class MenuItemComponent < ViewComponent::Base
       ].join(" ")
     end
 
-    def merged_button_opts
+    def merged_opts
       merged_opts = opts.dup || {}
       data = merged_opts.delete(:data) || {}
 
       if confirm.present?
         data = data.merge(turbo_confirm: confirm.to_data_attribute)
+      end
+
+      if frame.present?
+        data = data.merge(turbo_frame: frame)
       end
 
       merged_opts.merge(data: data)

--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -2,7 +2,9 @@
 
 <%= tag.div class: "flex items-center justify-between px-4 py-3 bg-container shadow-border-xs rounded-lg" do %>
   <div class="grow">
-    <%= render "chats/chat_title", chat: chat, ctx: "list" %>
+    <%= turbo_frame_tag dom_id(chat, :title) do %>
+      <%= render "chats/chat_title", chat: chat, ctx: "list" %>
+    <% end %>
 
     <p class="text-sm text-secondary">
       <%= time_ago_in_words(chat.updated_at) %> ago
@@ -10,7 +12,13 @@
   </div>
 
   <%= render MenuComponent.new(icon_vertical: true) do |menu| %>
-    <% menu.with_item(variant: "link", text: "Edit chat", href: edit_chat_path(chat), icon: "pencil", frame: dom_id(chat, "title")) %>
+    <% menu.with_item(
+      variant: "link", 
+      text: "Edit chat title", 
+      href: edit_chat_path(chat, ctx: "list"), 
+      icon: "pencil", 
+      data: { turbo_frame: dom_id(chat, "title") }) %>
+      
     <% menu.with_item(
       variant: "button",
       text: "Delete chat",

--- a/app/views/chats/_chat.html.erb
+++ b/app/views/chats/_chat.html.erb
@@ -17,7 +17,7 @@
       text: "Edit chat title", 
       href: edit_chat_path(chat, ctx: "list"), 
       icon: "pencil", 
-      data: { turbo_frame: dom_id(chat, "title") }) %>
+      frame: dom_id(chat, "title")) %>
       
     <% menu.with_item(
       variant: "button",

--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -27,7 +27,7 @@
         text: "Edit chat title",
         href: edit_chat_path(chat, ctx: "chat"),
         icon: "pencil",
-        data: { turbo_frame: dom_id(chat, "title") }) %>
+        frame: dom_id(chat, "title")) %>
 
       <% menu.with_item(
         variant: "button",

--- a/app/views/chats/_chat_nav.html.erb
+++ b/app/views/chats/_chat_nav.html.erb
@@ -27,7 +27,7 @@
         text: "Edit chat title",
         href: edit_chat_path(chat, ctx: "chat"),
         icon: "pencil",
-        frame: dom_id(chat, "title")) %>
+        data: { turbo_frame: dom_id(chat, "title") }) %>
 
       <% menu.with_item(
         variant: "button",

--- a/app/views/chats/edit.html.erb
+++ b/app/views/chats/edit.html.erb
@@ -1,9 +1,10 @@
 <%= turbo_frame_tag dom_id(@chat, :title), class: "block" do %>
+  <% bg_class = params[:ctx] == "chat" ? "bg-container-inset" : "bg-container" %>
   <%= styled_form_with model: @chat, data: { controller: "auto-submit-form", auto_submit_form_trigger_event_value: "blur" } do |f| %>
     <%= f.text_field :title,
       data: { auto_submit_form_target: "auto" },
       autofocus: true,
       inline: true,
-      class: "w-full rounded-md px-2 py-1 text-sm font-medium bg-container-inset" %>
+      class: "w-full rounded-md px-2 py-1 text-sm font-medium #{bg_class}" %>
   <% end %>
 <% end %>

--- a/app/views/chats/edit.html.erb
+++ b/app/views/chats/edit.html.erb
@@ -1,8 +1,9 @@
 <%= turbo_frame_tag dom_id(@chat, :title), class: "block" do %>
-  <% bg_class = params[:ctx] == "chat" ? "bg-container" : "bg-container-inset" %>
-  <%= styled_form_with model: @chat,
-                       class: class_names("p-1 rounded-md font-medium text-primary w-full", bg_class),
-                       data: { controller: "auto-submit-form", auto_submit_form_trigger_event_value: "blur" } do |f| %>
-    <%= f.text_field :title, data: { auto_submit_form_target: "auto" }, inline: true %>
+  <%= styled_form_with model: @chat, data: { controller: "auto-submit-form", auto_submit_form_trigger_event_value: "blur" } do |f| %>
+    <%= f.text_field :title,
+      data: { auto_submit_form_target: "auto" },
+      autofocus: true,
+      inline: true,
+      class: "w-full rounded-md px-2 py-1 text-sm font-medium bg-container-inset" %>
   <% end %>
 <% end %>

--- a/app/views/chats/edit.html.erb
+++ b/app/views/chats/edit.html.erb
@@ -1,10 +1,9 @@
 <%= turbo_frame_tag dom_id(@chat, :title), class: "block" do %>
-  <% bg_class = params[:ctx] == "chat" ? "bg-container-inset" : "bg-container" %>
   <%= styled_form_with model: @chat, data: { controller: "auto-submit-form", auto_submit_form_trigger_event_value: "blur" } do |f| %>
     <%= f.text_field :title,
       data: { auto_submit_form_target: "auto" },
       autofocus: true,
       inline: true,
-      class: "w-full rounded-md px-2 py-1 text-sm font-medium #{bg_class}" %>
+      class: "w-full rounded-md px-2 py-1 text-sm font-medium bg-transparent" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Right now in prod, editing a chat title isn't a valid option from the chat or chat nav - they both result in a "Missing content" error. The existing edit form is also full of extra classes and has some odd behavior. 

This PR:
- Fixes the ability to edit a title from the chat and chat nav pages
- Adds autofocus to the text field so it's immediately selected. This resolves the weird UX where you select 'edit title' but then don't edit the title. Clicking around doesn't cancel the action currently - with `autofocus: true` it does
- Removes some extra classes from the form/text field and tweak a few things to improve the UI

Before (once missing content was fixed) and after:
![CleanShot-003188 2025-05-23 at 07 11 09@2x](https://github.com/user-attachments/assets/c8c36c7d-637f-4172-860c-b07b769957b3)

_(edit: the background for the box is now `bg-transparent` to blend in with the background, so this screenshot is slightly out of date)_

**Question:** Is this `data: { turbo_frame: dom_id(chat, "title") })` pattern the correct way to do this? I know the `MenuComponent` is a custom component we have, I wasn't sure if there is supposed to be something that converts the `frame: dom_id(chat, "title")` to the turbo_frame within that component or not. This seems like an easy gotcha.