### PR TITLE
Fix: chart view selector background color

### DIFF
--- a/app/views/accounts/show/_chart.html.erb
+++ b/app/views/accounts/show/_chart.html.erb
@@ -27,7 +27,7 @@
           <%= form.select :chart_view,
             [["Total value", "balance"], ["Holdings", "holdings_balance"], ["Cash", "cash_balance"]],
             { selected: chart_view },
-            class: "border border-secondary rounded-lg text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0",
+            class: "bg-container border border-secondary rounded-lg text-sm pr-7 cursor-pointer text-primary focus:outline-hidden focus:ring-0",
             data: { "auto-submit-form-target": "auto" } %>
         <% end %>
 


### PR DESCRIPTION
### Changes
* Fix chart view selector background color in dark mode by adding `bg-container` class.

### Before
<img width="316" alt="Screenshot 2025-05-25 at 10 20 54" src="https://github.com/user-attachments/assets/58872b2d-9dc4-49cf-bd1a-8de2d03fa8eb" />

### After
<img width="348" alt="Screenshot 2025-05-25 at 10 20 32" src="https://github.com/user-attachments/assets/b580ee17-1d43-44a9-aa37-30d8a717641f" />
