### PR TITLE
chart: Do not initalize Series class with `trend`.

### DIFF
--- a/app/models/series.rb
+++ b/app/models/series.rb
@@ -10,7 +10,7 @@ class Series
     values.each(&block)
   end
 
-  attr_reader :start_date, :end_date, :interval, :trend, :values, :favorable_direction
+  attr_reader :start_date, :end_date, :interval, :values, :favorable_direction
 
   Value = Struct.new(
     :date,


### PR DESCRIPTION
Following up to #2306, we are getting `trend` via instance method. However we are still initializing it as an instance variable. This PR removes the initialization of `trend` as a instance variable.

Fixes: #2311.