### PR TITLE
Fixes Item #2317 - typo in docker hosting documentation

### DIFF
--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -19,7 +19,7 @@ Complete the following steps:
 docker run hello-world
 ```
 
-### Step 2: Configure your Docker Compose file and environnment
+### Step 2: Configure your Docker Compose file and environment
 
 #### Create a directory for your app to run
 


### PR DESCRIPTION
Simple Typo I noticed while reviewing documentation.
There is a typo in the Docker hosting documentation - in step 2 "environnment" is incorrectly spelled.