### PR TITLE
fix: user deletion foreign key constraint with invitations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
   belongs_to :last_viewed_chat, class_name: "Chat", optional: true
   has_many :sessions, dependent: :destroy
   has_many :chats, dependent: :destroy
+  has_many :invitations, foreign_key: :inviter_id, dependent: :destroy
   has_many :impersonator_support_sessions, class_name: "ImpersonationSession", foreign_key: :impersonator_id, dependent: :destroy
   has_many :impersonated_support_sessions, class_name: "ImpersonationSession", foreign_key: :impersonated_id, dependent: :destroy
   accepts_nested_attributes_for :family, update_only: true


### PR DESCRIPTION
## Summary
  • Fix foreign key constraint violation when deleting users
  with invitations
  • Add missing `has_many :invitations` association with
  `dependent: :destroy` to User model
  • Resolves #2341

  ## Test plan
  - [x] Verify User model has correct association
  - [x] Confirm database foreign key constraint exists
  - [x] Test deletion flow works without constraint violation