### PR TITLE
fix: maintain chat input focus after sending message

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,10 @@ class MessagesController < ApplicationController
       ai_model: message_params[:ai_model]
     )
 
-    redirect_to chat_path(@chat, thinking: true)
+    respond_to do |format|
+      format.html { redirect_to chat_path(@chat, thinking: true) }
+      format.turbo_stream
+    end
   end
 
   private

--- a/app/javascript/controllers/chat_controller.js
+++ b/app/javascript/controllers/chat_controller.js
@@ -57,4 +57,10 @@ export default class extends Controller {
   #scrollToBottom = () => {
     this.messagesTarget.scrollTop = this.messagesTarget.scrollHeight;
   };
+
+  focusInput() {
+    if (this.hasInputTarget) {
+      this.inputTarget.focus();
+    }
+  }
 }

--- a/app/javascript/controllers/focus_chat_input_controller.js
+++ b/app/javascript/controllers/focus_chat_input_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    const chatController = this.application.getControllerForElementAndIdentifier(
+      document.querySelector('[data-controller~="chat"]'),
+      "chat"
+    );
+    
+    if (chatController) {
+      chatController.focusInput();
+    }
+    
+    this.element.remove();
+  }
+}

--- a/app/views/messages/create.turbo_stream.erb
+++ b/app/views/messages/create.turbo_stream.erb
@@ -1,0 +1,21 @@
+<%# Add thinking indicator to messages area %>
+<%= turbo_stream.append "messages" do %>
+  <%= render "chats/thinking_indicator", chat: @chat %>
+<% end %>
+
+<%# Reset the form by replacing it with a fresh version %>
+<%= turbo_stream.replace "chat-form" do %>
+  <%= render "messages/chat_form", chat: @chat %>
+<% end %>
+
+<%# Focus the input after form replacement %>
+<%= turbo_stream.after "chat-form" do %>
+  <script>
+    requestAnimationFrame(() => {
+      const textarea = document.querySelector('[data-chat-target="input"]');
+      if (textarea) {
+        textarea.focus();
+      }
+    });
+  </script>
+<% end %>

--- a/app/views/messages/create.turbo_stream.erb
+++ b/app/views/messages/create.turbo_stream.erb
@@ -8,14 +8,7 @@
   <%= render "messages/chat_form", chat: @chat %>
 <% end %>
 
-<%# Focus the input after form replacement %>
-<%= turbo_stream.after "chat-form" do %>
-  <script>
-    requestAnimationFrame(() => {
-      const textarea = document.querySelector('[data-chat-target="input"]');
-      if (textarea) {
-        textarea.focus();
-      }
-    });
-  </script>
+<%# Focus the input after form replacement using Stimulus %>
+<%= turbo_stream.append "messages" do %>
+  <div data-controller="focus-chat-input"></div>
 <% end %>


### PR DESCRIPTION
This PR fixes the issue where the chat input field loses focus after sending a message, requiring users to click back into the field to continue typing.

  ## Changes

  - Updated `MessagesController#create` to respond with Turbo Streams instead of redirecting
  - Created `create.turbo_stream.erb` to handle the async form submission
  - Replaced the chat form with a fresh version to clear the input
  - Added JavaScript to refocus the input after form replacement

  ## Testing

  1. Go to the AI chat interface
  2. Type a message and press Enter
  3. Verify that:
     - The message is sent successfully
     - The input field is cleared
     - The input field maintains focus (cursor remains in the
  field)
     - You can immediately type another message without clicking
     
 ## Demo
 https://github.com/user-attachments/assets/b8c3b418-aef7-4738-899e-468ff64af61b

 ## Related Issues
 Fixes #2335