### PR TITLE
Fix: ticker combobox background and text color

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -39,7 +39,7 @@
 .combobox {
   .hw-combobox__main__wrapper,
   .hw-combobox__input {
-    @apply bg-container w-full;
+    @apply bg-container text-primary w-full;
   }
 
   .hw-combobox__main__wrapper {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -39,7 +39,7 @@
 .combobox {
   .hw-combobox__main__wrapper,
   .hw-combobox__input {
-    @apply w-full;
+    @apply bg-container w-full;
   }
 
   .hw-combobox__main__wrapper {
@@ -52,6 +52,10 @@
 
   .hw-combobox__label {
     @apply block text-xs text-gray-500 peer-disabled:text-gray-400;
+  }
+  
+  .hw-combobox__option {
+    @apply bg-container hover:bg-container-hover;
   }
 
   .hw_combobox__pagination__wrapper {


### PR DESCRIPTION
This PR fixes the issue where the hotwire combobox input field and dropdown options have white background in dark mode, which extremely reduces visibility.

## Changes
* Fix ticker combobox input and options background color in dark mode by adding `bg-container` class.
* Fix the input text color by adding `text-primary` class.

## Before
![Screenshot 2025-06-15 at 14 00 12](https://github.com/user-attachments/assets/f6fafcf9-ff97-4258-af90-111ee4feaf74)

## After

### Dark mode
![Screenshot 2025-06-15 at 14 00 44](https://github.com/user-attachments/assets/b2cbbb02-7ef8-4a52-96fe-395a0c6acc7f)

### Light mode
![Screenshot 2025-06-15 at 14 14 01](https://github.com/user-attachments/assets/116d9ca7-d4fd-48a9-8bcc-d93eac3a22bd)

