### PR TITLE
perf(income statement): cache income statement queries

### DIFF
--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -13,6 +13,14 @@ class Account::Syncer
 
   def perform_post_sync
     account.family.auto_match_transfers!
+
+    # Warm IncomeStatement caches so subsequent requests are fast
+    # TODO: this is a temporary solution to speed up pages. Long term we'll throw a materialized view / pre-computed table
+    # in for family stats.
+    income_statement = IncomeStatement.new(account.family)
+    income_statement.family_stats
+    income_statement.category_stats
+    income_statement.totals # uses default scope internally
   end
 
   private

--- a/app/models/account/syncer.rb
+++ b/app/models/account/syncer.rb
@@ -18,9 +18,8 @@ class Account::Syncer
     # TODO: this is a temporary solution to speed up pages. Long term we'll throw a materialized view / pre-computed table
     # in for family stats.
     income_statement = IncomeStatement.new(account.family)
-    income_statement.family_stats
-    income_statement.category_stats
-    income_statement.totals # uses default scope internally
+    Rails.logger.info("Warming IncomeStatement caches")
+    income_statement.warm_caches!
   end
 
   private

--- a/app/models/income_statement.rb
+++ b/app/models/income_statement.rb
@@ -53,6 +53,13 @@ class IncomeStatement
     family_stats(interval: interval).find { |stat| stat.classification == "income" }&.median || 0
   end
 
+  def warm_caches!(interval: "month")
+    totals
+    family_stats(interval: interval)
+    category_stats(interval: interval)
+    nil
+  end
+
   private
     ScopeTotals = Data.define(:transactions_count, :income_money, :expense_money, :missing_exchange_rates?)
     PeriodTotal = Data.define(:classification, :total, :currency, :missing_exchange_rates?, :category_totals)

--- a/app/views/pages/dashboard/_balance_sheet.html.erb
+++ b/app/views/pages/dashboard/_balance_sheet.html.erb
@@ -91,7 +91,7 @@
                               # Calculate weight as percentage of classification total
                               classification_total = classification_group.total_money.amount
                               account_weight = classification_total.zero? ? 0 : account.converted_balance / classification_total * 100
-                            %>
+                          %>
                           <%= render "pages/dashboard/group_weight", weight: account_weight, color: account_group.color %>
                         </div>
 

--- a/lib/tasks/benchmarking.rake
+++ b/lib/tasks/benchmarking.rake
@@ -6,9 +6,16 @@
 # 4. Run locally, find endpoint needed
 # 5. Run an endpoint, example: `ENDPOINT=/budgets/jun-2025/budget_categories/245637cb-129f-4612-b0a8-1de57559372b RAILS_ENV=production BENCHMARKING_ENABLED=true RAILS_LOG_LEVEL=debug rake benchmarking:ips`
 namespace :benchmarking do
+  desc "Shorthand task for running warm/cold benchmark"
+  task endpoint: :environment do
+    system(
+      "RAILS_ENV=production BENCHMARKING_ENABLED=true ENDPOINT=#{ENV.fetch("ENDPOINT", "/")} rake benchmarking:warm_cold_endpoint_ips"
+    )
+  end
+
   # When to use: Track overall endpoint speed improvements over time (recommended, most practical test)
   desc "Run cold & warm performance benchmarks and append to history"
-  task ips: :environment do
+  task warm_cold_endpoint_ips: :environment do
     path = ENV.fetch("ENDPOINT", "/")
 
     # 🚫 Fail fast unless the benchmark is run in production mode

--- a/lib/tasks/benchmarking.rake
+++ b/lib/tasks/benchmarking.rake
@@ -30,7 +30,7 @@ namespace :benchmarking do
     cold_iterations = Integer(ENV.fetch("COLD_ITERATIONS", 1)) # requests to measure for the cold run
 
     warm_warmup     = Integer(ENV.fetch("WARM_WARMUP", 5))  # seconds benchmark-ips uses to stabilise JIT/caches
-    warm_time       = Integer(ENV.fetch("WARM_TIME", 30))   # seconds benchmark-ips samples for warm statistics
+    warm_time       = Integer(ENV.fetch("WARM_TIME", 10))   # seconds benchmark-ips samples for warm statistics
     # ---------------------------------------------------------------------------
 
     setup_benchmark_env(path)

--- a/perf.rake
+++ b/perf.rake
@@ -16,7 +16,7 @@ class CustomAuth < DerailedBenchmarks::AuthHelper
     # Make sure this user is created in the DB with realistic data before running benchmarks
     user = User.find_by!(email: "user@maybe.local")
 
-    puts "Found user for benchmarking: #{user.email}"
+    Rails.logger.debug "Found user for benchmarking: #{user.email}"
 
     # Mimic the way Rails handles browser cookies
     session = user.sessions.create!
@@ -27,7 +27,7 @@ class CustomAuth < DerailedBenchmarks::AuthHelper
 
     env['HTTP_COOKIE'] = "session_token=#{signed_value}"
 
-    puts "Setting up session for user: #{user.email}"
+    Rails.logger.debug "Setting up session for user: #{user.email}"
 
     app.call(env)
   end


### PR DESCRIPTION
This PR is a _temporary_ fix for the slow income statement queries that are causing huge slowdowns on the budget and transaction pages.

- Stores income statement aggregations in the cache
- "Warms" the cache after every sync to avoid a slow first page load 

This PR does not address the core issue of the inefficient query. We will push a future fix to address that.