### PR TITLE
Temporary transactions page performance fix

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -28,11 +28,15 @@ class TransactionsController < ApplicationController
     items_per_page = params[:per_page].presence || default_params[:per_page]
     current_page   = params[:page].presence   || default_params[:page]
 
+    # Build a compact cache digest: sanitized filters + page info + a
+    # token that changes on updates *or* deletions.
+    entries_changed_token = [ latest_update_ts, Current.family.entries.count ].join(":")
+
     digest_source = {
-      params: request.query_parameters.to_h,
-      page:   current_page,
-      per:    items_per_page,
-      ts:     latest_update_ts
+      q:    @q,                 # processed & sanitised search params
+      page: current_page,       # requested page number
+      per:  items_per_page,     # page size
+      tok:  entries_changed_token
     }.to_json
 
     cache_key = Current.family.build_cache_key(


### PR DESCRIPTION
This PR is a temporary solution to speed up the transactions page. A longer-term fix will fully replace this very hacky solution, but will require a larger rework of the search query.

Before:

| Type | IPS | Deviation | Time/Iteration | Iterations | Total Time |
|------|-----|-----------|----------------|------------|------------|
| COLD | 0.275 | ± 0.00%     | 3.64 s/i       | 1.000      | 3.638567s  |
| WARM | 0.431 | ± 0.00%     | 2.32 s/i       | 5.000      | 11.598782s |

After:

| Type | IPS | Deviation | Time/Iteration | Iterations | Total Time |
|------|-----|-----------|----------------|------------|------------|
| COLD | 0.344 | ± 0.00%     | 2.91 s/i       | 1.000      | 2.908487s  |
| WARM | 2.767 | ± 0.00%     | 361.45 ms/i    | 28.000     | 10.126426s |