### PR TITLE
Fix: Use PATCH method for onboarding preferences form

### DIFF
--- a/app/views/onboardings/preferences.html.erb
+++ b/app/views/onboardings/preferences.html.erb
@@ -63,7 +63,7 @@
 
     <p class="text-secondary text-xs mb-4"><%= t(".preview") %></p>
 
-    <%= styled_form_with model: @user, data: { turbo: false } do |form| %>
+    <%= styled_form_with model: @user, method: :patch, data: { turbo: false } do |form| %>
       <%= form.hidden_field :set_onboarding_preferences_at, value: Time.current %>
       <%= form.hidden_field :redirect_to, value: "goals" %>
 


### PR DESCRIPTION
The form on the user onboarding preferences page was submitting with the POST HTTP method, which caused an ActionController::RoutingError because the /users/:id route only accepts PATCH/PUT for updates.

This appeared to be a state-related bug where form_with was not correctly inferring the method from the persisted @user object during the initial onboarding flow.

This change explicitly sets `method: :patch` on the form_with helper to ensure the correct verb is always used, resolving the routing error for all new users.

Fixes #2398