### PR TITLE
perf(sync): Preload and cache exchange rate data when syncing.

### DIFF
--- a/app/models/exchange_rate/provided.rb
+++ b/app/models/exchange_rate/provided.rb
@@ -27,6 +27,23 @@ module ExchangeRate::Provided
       rate
     end
 
+    def fetch_rate(from:, to:, date: Date.current, cache: true)
+      return nil unless provider.present? # No provider configured (some self-hosted apps)
+
+      response = provider.fetch_exchange_rate(from: from, to: to, date: date)
+
+      return nil unless response.success? # Provider error
+
+      rate = response.data
+      ExchangeRate.find_or_create_by!(
+        from_currency: rate.from,
+        to_currency: rate.to,
+        date: rate.date,
+        rate: rate.rate
+      ) if cache
+      rate
+    end
+
     # @return [Integer] The number of exchange rates synced
     def import_provider_rates(from:, to:, start_date:, end_date:, clear_cache: false)
       unless provider.present?

--- a/test/models/balance/sync_cache_test.rb
+++ b/test/models/balance/sync_cache_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class Balance::SyncCacheTest < ActiveSupport::TestCase
+  include EntriesTestHelper
+  include ExchangeRateTestHelper
+
+  setup do
+    @account = families(:empty).accounts.create!(
+      name: "Test",
+      balance: 20000,
+      cash_balance: 20000,
+      currency: "USD",
+      accountable: Investment.new
+    )
+    create_transaction(account: @account, date: 1.day.ago.to_date, amount: 100, currency: "CAD")
+    @sync_cache = Balance::SyncCache.new(@account)
+  end
+
+  test "convert currency when rate available by cache" do
+    load_exchange_prices
+    money = Money.new(100, "CAD")
+    converted_money = nil
+    assert_queries_count(3) do
+      converted_money = @sync_cache.find_rate_by_cache(money, @account.currency, date: 1.day.ago.to_date)
+    end
+    expected_money = money.exchange_to(@account.currency, date: 1.day.ago.to_date)
+
+    assert_equal expected_money.amount, converted_money.amount
+    assert_equal expected_money.currency, converted_money.currency
+  end
+
+  test "convert currency after fetching rate" do
+    ExchangeRate.expects(:fetch_rate).returns(Provider::ExchangeRateConcept::Rate.new(date: 1.day.ago.to_date, from: "JPY", to: "USD", rate: 0.007))
+    money = Money.new(1000, "JPY")
+
+    assert_equal Money.new(7, "USD"), @sync_cache.find_rate_by_cache(money, @account.currency, date: 1.day.ago.to_date)
+  end
+
+  test "converts currency with a fallback rate" do
+    ExchangeRate.expects(:fetch_rate).returns(nil).twice
+    money = Money.new(1000, "CAD")
+
+    assert_queries_count(3) do
+      assert_equal Money.new(0, "USD"), @sync_cache.find_rate_by_cache(money, @account.currency, date: 1.day.ago.to_date, fallback_rate: 0)
+    end
+
+    assert_equal Money.new(1000, "USD"), @sync_cache.find_rate_by_cache(money, @account.currency, date: 1.day.ago.to_date, fallback_rate: 1)
+  end
+
+  test "raises when no conversion rate available and no fallback rate provided" do
+    money = Money.new(1000, "JPY")
+    ExchangeRate.expects(:fetch_rate).returns(nil)
+
+    assert_raises Money::ConversionError do
+      @sync_cache.find_rate_by_cache(money, @account.currency, date: 1.day.ago.to_date, fallback_rate: nil)
+    end
+  end
+
+  test "raises if input is not Money-like" do
+    assert_raises(TypeError) do
+      @sync_cache.find_rate_by_cache(12345, "USD")
+    end
+  end
+
+  test "returns original money when source and target currency are the same" do
+    money = Money.new(500, "USD")
+    result = nil
+    assert_queries_count(0) do
+      result = @sync_cache.find_rate_by_cache(money, "USD", date: Date.today)
+    end
+    assert_same money, result
+  end
+
+  test "query and cache exchange rates" do
+    load_exchange_prices
+    assert_queries_count(3) do
+      @sync_cache.find_rate_by_cache(Money.new(100, "CAD"), @account.currency, date: 1.day.ago.to_date)
+    end
+
+    assert_queries_count(0) do
+      @sync_cache.find_rate_by_cache(Money.new(100, "CAD"), @account.currency, date: 1.day.ago.to_date)
+      @sync_cache.find_rate_by_cache(Money.new(200, "CAD"), @account.currency, date: 1.day.ago.to_date)
+    end
+  end
+end

--- a/test/models/family/auto_transfer_matchable_test.rb
+++ b/test/models/family/auto_transfer_matchable_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
   include EntriesTestHelper
+  include ExchangeRateTestHelper
 
   setup do
     @family = families(:dylan_family)
@@ -116,33 +117,4 @@ class Family::AutoTransferMatchableTest < ActiveSupport::TestCase
       @family.auto_match_transfers!
     end
   end
-
-  private
-    def load_exchange_prices
-      rates = {
-        4.days.ago.to_date => 1.36,
-        3.days.ago.to_date => 1.37,
-        2.days.ago.to_date => 1.38,
-        1.day.ago.to_date  => 1.39,
-        Date.current => 1.40
-      }
-
-      rates.each do |date, rate|
-        # USD to CAD
-        ExchangeRate.create!(
-          from_currency: "USD",
-          to_currency: "CAD",
-          date: date,
-          rate: rate
-        )
-
-        # CAD to USD (inverse)
-        ExchangeRate.create!(
-          from_currency: "CAD",
-          to_currency: "USD",
-          date: date,
-          rate: (1.0 / rate).round(6)
-        )
-      end
-    end
 end

--- a/test/support/exchange_rate_test_helper.rb
+++ b/test/support/exchange_rate_test_helper.rb
@@ -1,0 +1,55 @@
+module ExchangeRateTestHelper
+  def load_exchange_prices
+    cad_rates = {
+      4.days.ago.to_date => 1.36,
+      3.days.ago.to_date => 1.37,
+      2.days.ago.to_date => 1.38,
+      1.day.ago.to_date  => 1.39,
+      Date.current => 1.40
+    }
+
+    eur_rates = {
+      4.days.ago.to_date => 1.17,
+      3.days.ago.to_date => 1.18,
+      2.days.ago.to_date => 1.19,
+      1.day.ago.to_date  => 1.2,
+      Date.current => 1.21
+    }
+
+    cad_rates.each do |date, rate|
+      # USD to CAD
+      ExchangeRate.create!(
+        from_currency: "USD",
+        to_currency: "CAD",
+        date: date,
+        rate: rate
+      )
+
+      # CAD to USD (inverse)
+      ExchangeRate.create!(
+        from_currency: "CAD",
+        to_currency: "USD",
+        date: date,
+        rate: (1.0 / rate).round(6)
+      )
+    end
+
+    eur_rates.each do |date, rate|
+      # EUR to USD
+      ExchangeRate.create!(
+        from_currency: "EUR",
+        to_currency: "USD",
+        date: date,
+        rate: rate
+      )
+
+      # USD to EUR (inverse)
+      ExchangeRate.create!(
+        from_currency: "USD",
+        to_currency: "EUR",
+        date: date,
+        rate: (1.0 / rate).round(6)
+      )
+    end
+  end
+end


### PR DESCRIPTION
When we are performing transaction syncs, we are looking up for the exchange rate of the transaction if the currency of the transaction is different from the account currency. This look up is performed on every transactions that is being synced, which results in a `N+1` query.

This change loads and caches the exchange rates when performing syncs.