### PR TITLE
fix: error when viewing individual holding

### DIFF
--- a/app/models/security/provided.rb
+++ b/app/models/security/provided.rb
@@ -53,7 +53,7 @@ module Security::Provided
 
     price = response.data
     Security::Price.find_or_create_by!(
-      security_id: price.security.id,
+      security_id: self.id,
       date: price.date,
       price: price.price,
       currency: price.currency


### PR DESCRIPTION
This PR fixes #2395.

## Changes
* Use `self.id` for `security_id`, since `price` does not return `security` field.
