### PR TITLE
Fix race condition causing syncing loaders to get stuck

### DIFF
--- a/app/models/sync.rb
+++ b/app/models/sync.rb
@@ -19,6 +19,8 @@ class Sync < ApplicationRecord
   scope :incomplete, -> { where("syncs.status IN (?)", %w[pending syncing]) }
   scope :visible, -> { incomplete.where("syncs.created_at > ?", VISIBLE_FOR.ago) }
 
+  after_commit :update_family_sync_timestamp
+
   validate :window_valid
 
   # Sync state machine
@@ -169,7 +171,6 @@ class Sync < ApplicationRecord
 
     def handle_transition
       log_status_change
-      family.touch(:latest_sync_activity_at)
     end
 
     def handle_completion_transition
@@ -180,6 +181,10 @@ class Sync < ApplicationRecord
       if window_start_date && window_end_date && window_start_date > window_end_date
         errors.add(:window_end_date, "must be greater than window_start_date")
       end
+    end
+
+    def update_family_sync_timestamp
+      family.touch(:latest_sync_activity_at)
     end
 
     def family


### PR DESCRIPTION
## Problem

The sync status monitor was experiencing a race condition that caused syncing loaders to appear stuck even after syncs completed. 

## Root Cause

The issue occurred because:

1. When a sync changed state, `handle_transition` would update `family.latest_sync_activity_at` 
2. This timestamp is used in the cache key for `SyncStatusMonitor`
3. However, the timestamp update happened inside the database transaction
4. Other connections could read the old timestamp value before the transaction committed
5. This caused them to use a stale cache key and retrieve outdated sync status

## Solution

Move the timestamp update to an `after_commit` callback. This ensures:
- The sync state change is fully committed and visible to all database connections
- The timestamp is updated only after the commit
- Any subsequent cache reads will see the new timestamp and invalidate properly

This eliminates the race condition while maintaining all existing functionality that depends on these timestamps for cache invalidation.

Fixes #881