### PR TITLE
Fix credit card balance history

### DIFF
--- a/app/models/plaid_account/processor.rb
+++ b/app/models/plaid_account/processor.rb
@@ -84,9 +84,12 @@ class PlaidAccount::Processor
       if plaid_account.plaid_type == "investment"
         @balance_calculator ||= PlaidAccount::Investments::BalanceCalculator.new(plaid_account, security_resolver: security_resolver)
       else
+        balance = plaid_account.current_balance || plaid_account.available_balance || 0
+
+        # We don't currently distinguish "cash" vs. "non-cash" balances for non-investment accounts.
         OpenStruct.new(
-          balance: plaid_account.current_balance || plaid_account.available_balance,
-          cash_balance: plaid_account.available_balance || 0
+          balance: balance,
+          cash_balance: balance
         )
       end
     end


### PR DESCRIPTION
When syncing Plaid credit card accounts, we were getting very overstated histories due to the `account.cash_balance` value. In `Balance::ReverseCalculator`, we use "cash balance" as our starting point and work backwards, applying entry changes to generate historicals. For credit card accounts, Plaid considers `available_balance` as "the limit less the current balance, less any pending outflows plus any pending inflows". We were previously setting `cash_balance` equal to Plaid's `available_balance`, which was giving us a starting point closer to the "credit limit" (which is often much higher than the user's utilization). This made it so we had today's balance correct, but historicals were then extremely inflated.

This PR moves us to a more standard way of handling Plaid balances:

- If it's an investment account, we apply custom logic to find cash balance
- All other accounts do NOT distinguish `current` vs. `available` anymore. We simply use `current` always, which means, "total account value"