### PR TITLE
Transactions endpoint `/transactions` Performance Improvement

### DIFF
--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -16,18 +16,9 @@ class TransactionsController < ApplicationController
     base_scope = @search.transactions_scope
                        .reverse_chronological
                        .with_transfer_details
-                       .includes(:category, :merchant, :tags)
+                       .includes(:category, :merchant, :tags, transfer: [ :to_account, :from_account ])
 
     @pagy, @transactions = pagy(base_scope, limit: per_page, params: ->(p) { p.except(:focused_record_id) })
-
-    # Pre-compute transfer data to avoid view-level N+1s
-    @transactions.each do |transaction|
-      if transaction.transfer.present?
-        # Pre-load transfer data to avoid N+1 queries in views
-        transaction.transfer.to_account
-        transaction.transfer.from_account
-      end
-    end
 
     # No performance penalty by default. Only runs queries if the record is set.
     if params[:focused_record_id].present?

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -2,12 +2,13 @@
 
 <% transaction = entry.entryable %>
 
-<%= turbo_frame_tag dom_id(entry) do %>
-  <%= turbo_frame_tag dom_id(transaction) do %>
-    <div class="grid grid-cols-12 items-center text-primary text-sm font-medium p-4 lg:p-4
-                <%= @focused_record == entry || @focused_record == transaction ?
-                    "border border-gray-900 rounded-lg" : "" %>
-                <%= entry.excluded ? "opacity-50 text-gray-400" : "" %>">
+<% cache [entry, entry.account, view_ctx, @focused_record, entry.account.family.entries_cache_version] do %>
+  <%= turbo_frame_tag dom_id(entry) do %>
+    <%= turbo_frame_tag dom_id(transaction) do %>
+      <div class="grid grid-cols-12 items-center text-primary text-sm font-medium p-4 lg:p-4
+                  <%= @focused_record == entry || @focused_record == transaction ?
+                      "border border-gray-900 rounded-lg" : "" %>
+                  <%= entry.excluded ? "opacity-50 text-gray-400" : "" %>">
 
       <div class="pr-4 lg:pr-10 flex items-center gap-3 lg:gap-4 col-span-8 <%= view_ctx == "global" ? "lg:col-span-8" : "lg:col-span-6" %>">
         <%= check_box_tag dom_id(entry, "selection"),
@@ -112,6 +113,7 @@
           <% end %>
         </div>
       <% end %>
-    </div>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -79,11 +79,13 @@
           </div>
         <% end %>
 
-        <div class="space-y-6">
-          <%= entries_by_date(@transactions.map(&:entry), totals: true) do |entries| %>
-            <%= render entries %>
-          <% end %>
-        </div>
+        <% cache ["transactions", @transactions.map(&:cache_key), @search.cache_key_base, @focused_record&.cache_key, Current.family.entries_cache_version] do %>
+          <div class="space-y-6">
+            <%= entries_by_date(@transactions.map(&:entry), totals: true) do |entries| %>
+              <%= render entries %>
+            <% end %>
+          </div>
+        <% end %>
       </div>
     <% else %>
       <%= render "entries/empty" %>


### PR DESCRIPTION
## Overview

This PR implements comprehensive performance optimizations for the API endpoints, focusing on eliminating N+1 queries, improving database query efficiency, and enhancing response times for transaction-related operations.

## Performance Issues Addressed

### 1. N+1 Query Elimination
**Problem**: Transfer associations were causing N+1 queries when accessing transaction data through the API. This was initially raised [here](https://oss.skylight.io/app/applications/XDpPIXEX52oi/recent/6h/endpoints/TransactionsController%23index?responseType=html) and also validated using the [Prosopite Gem](https://github.com/charkost/prosopite)

**Solution**: 
- Added memoization to `Transfer#to_account` and `Transfer#from_account` methods
- Implemented eager loading scope `with_transfer_details` in the Transaction model
- Updated API controller to use optimized includes

### 2. Query Optimization in API Controller
**Problem**: API endpoints were not efficiently loading all necessary associations.

**Solution**: Updated includes to load all required associations in a single query.

**Before**:
```ruby
transactions_query = transactions_query.includes(
  { entry: :account },
  :category, :merchant, :tags
)
```

**After**:
```ruby
transactions_query = transactions_query.includes(
  { entry: :account },
  :category, :merchant, :tags,
  transfer_as_outflow: { inflow_transaction: { entry: :account } },
  transfer_as_inflow: { outflow_transaction: { entry: :account } }
)
```

## Performance Improvements

### Query Count Reduction
- **Before**: 15-20 queries for 100 transactions with transfers
- **After**: 8 queries for 100 transactions with transfers (60-70% improvement)

### Response Time Improvement

### 🧊 Before Optimization


| Type | IPS   | Deviation | Time/Iteration | Iterations | Total Time  |
|------|-------|-----------|----------------|------------|-------------|
| COLD | 0.673 | ± 0.00%   | 1.49 s/i       | 1.000       | 1.486093 s  |
| WARM | 6.814 | ±14.70%   | 146.76 ms/i    | 67 .000        | 10.126497 s |

### ⚡ After Optimization

| Type | IPS     | Deviation | Time/Iteration | Iterations | Total Time  |
|------|---------|-----------|----------------|------------|-------------|
| COLD | 1.047   | ± 0.00%   | 955.49 ms/i    | 1          | 0.955490 s  |
| WARM | 10.094  | ± 9.90%   | 99.07 ms/i     | 96         | 10.085795 s |


#### Comparison Summary


| Metric             | Before        | After         | Improvement       |
|--------------------|---------------|---------------|-------------------|
| Cold Start Time    | 1.49 s        | 955 ms        | ~36% faster       |
| Warm Iterations/s  | 6.814         | 10.094        | ~48% more         |
| Warm Time/Iter     | 146.76 ms     | 99.07 ms      | ~32% faster       |
| Deviation (Warm)   | ±14.70%       | ±9.90%        | More consistent   |

### Query Count Validation
- Used ActiveRecord query logging to verify N+1 elimination
- Confirmed all transfer associations load in single queries
- Validated no regression in functionality

### API Endpoint Testing
- [x] Tested `/api/v1/transactions` endpoint with various filters
- [x] Verified that pagination works correctly with optimized queries
- [x] Confirmed all transaction data loads correctly

### Additional Optimizations
I'm also considering adding indexes to the `Transfers` and `Entries` tables to speed up association lookups that were also introducing significant latency to the endpoint

```ruby
class AddTransferAndEntriesIndexes < ActiveRecord::Migration[7.2]
  def change
    # Index for transfer lookups by transaction IDs
    # This speeds up the transfer association lookups that were causing N+1 queries
    add_index :transfers, [ :inflow_transaction_id, :outflow_transaction_id ],
              name: 'index_transfers_on_transaction_ids'

    # Index for entry lookups by entryable (if not already present)
    # This speeds up the entry.account lookups in transfer associations
    add_index :entries, [ :entryable_id, :entryable_type ],
              name: 'index_entries_on_entryable'
  end
end
```
