### PR TITLE
fix: add libvips-dev to dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
   libyaml-0-2 \
   openssh-client \
   postgresql-client \
+  libvips-dev \
   vim
 
 RUN gem install bundler

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /rails
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libvips postgresql-client libyaml-0-2
+    apt-get install --no-install-recommends -y curl libvips libvips-dev postgresql-client libyaml-0-2
 
 # Set production environment
 ARG BUILD_COMMIT_SHA


### PR DESCRIPTION
When running in the `.devcontainer`, i found that the bottom left profil picture was not showing up. This issue was fixed by adding `libvips-dev` to the dependencies for the `devcontainer` and the docker image