### PR TITLE
fix: support comma-separated currency input for budgeted_spending  #2500

### DIFF
--- a/app/controllers/budget_categories_controller.rb
+++ b/app/controllers/budget_categories_controller.rb
@@ -37,7 +37,7 @@ class BudgetCategoriesController < ApplicationController
   private
     def budget_category_params
       params.require(:budget_category).permit(:budgeted_spending).tap do |params|
-        params[:budgeted_spending] = params[:budgeted_spending].presence || 0
+        params[:budgeted_spending] = params[:budgeted_spending].to_s.delete(',').presence || 0
       end
     end
 


### PR DESCRIPTION
### What this does  
This pull request fixes an issue where users would see a validation error (“Enter a number”) when trying to input currency values like 1,234.56 in the budget form. The problem was that Rails didn’t recognize numbers with commas as valid.

To solve this, we now sanitize the budgeted_spending input by removing commas before it's processed — so users can enter currency in a more natural way without running into errors.

### What changed  
- Updated the budget_category_params method in budget_categories_controller.rb to strip commas from the budgeted_spending value.

### Related issue  
Fixes #2500 
